### PR TITLE
Threat actor electrum

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1555,6 +1555,16 @@
           "Sphinx Moth"
         ]
       }
+    },
+    {
+      "value": "PLATINUM",
+      "description": "PLATINUM has been targeting its victims since at least as early as 2009, and may have been active for several years prior. Its activities are distinctly different not only from those typically seen in untargeted attacks, but from many targeted attacks as well. A large share of targeted attacks can be characterized as opportunistic: the activity group changes its target profiles and attack geographies based on geopolitical seasons, and may attack institutions all over the world. Like many such groups, PLATINUM seeks to steal sensitive intellectual property related to government interests, but its range of preferred targets is consistently limited to specific governmental organizations, defense institutes, intelligence agencies, diplomatic institutions, and telecommunication providers in South and Southeast Asia. The group’s persistent use of spear phishing tactics (phishing attempts aimed at specific individuals) and access to previously undiscovered zero-day exploits have made it a highly resilient threat.",
+      "meta": {
+        "refs": [
+          "http://download.microsoft.com/download/2/2/5/225BFE3E-E1DE-4F5B-A77B-71200928D209/Platinum%20feature%20article%20-%20Targeted%20attacks%20in%20South%20and%20Southeast%20Asia%20April%202016.pdf",
+          "https://blogs.technet.microsoft.com/mmpc/2016/04/26/digging-deep-for-platinum/"
+        ]
+      }
     }
   ],
   "name": "Threat actor",
@@ -1569,5 +1579,5 @@
   ],
   "description": "Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.",
   "uuid": "7cdff317-a673-4474-84ec-4f1754947823",
-  "version": 22
+  "version": 23
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1565,6 +1565,16 @@
           "https://blogs.technet.microsoft.com/mmpc/2016/04/26/digging-deep-for-platinum/"
         ]
       }
+    },
+    {
+      "value": "ELECTRUM",
+      "description": "Dragos, Inc. tracks the adversary group behind CRASHOVERRIDE as ELECTRUM and assesses with high confidence through confidential sources that ELECTRUM has direct ties to the Sandworm team. Our intelligence ICS WorldView customers have received a comprehensive report and this industry report will not get into sensitive technical details but instead focus on information needed for defense and impact awareness.",
+      "meta": {
+        "refs": [
+          "https://dragos.com/blog/crashoverride/CrashOverride-01.pdf",
+          "https://www.welivesecurity.com/wp-content/uploads/2017/06/Win32_Industroyer.pdf"
+        ]
+      }
     }
   ],
   "name": "Threat actor",
@@ -1579,5 +1589,5 @@
   ],
   "description": "Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.",
   "uuid": "7cdff317-a673-4474-84ec-4f1754947823",
-  "version": 23
+  "version": 24
 }


### PR DESCRIPTION
Hey, 
I'm not 100% sure how to handle this one. ;)
Dragos states "high-confidence in direct ties" to Sandworm (https://dragos.com/blog/crashoverride/CrashOverride-01.pdf p4) but ESET does attribute in their document. 
Should this be handled similar to TeleBots, which also has apparent ties to Sandworm but is treated as its own actor?