### PR TITLE
added Hidden Cobra as alias for Lazarus Group

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -952,13 +952,16 @@
       "meta": {
         "country": "KP",
         "synonyms": [
-          "Operation DarkSeoul"
+          "Operation DarkSeoul",
+          "Hidden Cobra"
         ],
         "refs": [
-          "https://threatpost.com/operation-blockbuster-coalition-ties-destructive-attacks-to-lazarus-group/116422/"
+          "https://threatpost.com/operation-blockbuster-coalition-ties-destructive-attacks-to-lazarus-group/116422/",
+          "https://www.us-cert.gov/ncas/alerts/TA17-164A"
         ]
       },
-      "value": "Lazarus Group"
+      "value": "Lazarus Group",
+      "description": "Since 2009, HIDDEN COBRA actors have leveraged their capabilities to target and compromise a range of victims; some intrusions have resulted in the exfiltration of data while others have been disruptive in nature. Commercial reporting has referred to this activity as Lazarus Group and Guardians of Peace. Tools and capabilities used by HIDDEN COBRA actors include DDoS botnets, keyloggers, remote access tools (RATs), and wiper malware. Variants of malware and tools used by HIDDEN COBRA actors include Destover, Duuzer, and Hangman."
     },
     {
       "meta": {
@@ -1569,5 +1572,5 @@
   ],
   "description": "Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.",
   "uuid": "7cdff317-a673-4474-84ec-4f1754947823",
-  "version": 22
+  "version": 23
 }


### PR DESCRIPTION
Hey, 

US CERT introduced a new alias for Lazarus Group (Hidden Cobra) [1], which imho can be added right away. 
I'll spend some more time in the next days making inquiries if the listed KP actors can be reorganized because OP Blockbuster / GOP has been linked to Lazarus as well.

[1] https://www.us-cert.gov/ncas/alerts/TA17-164A