### PR TITLE
merged barium into axiom (only one redundant reference given)

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -268,7 +268,8 @@
           "Ragebeast",
           "Blackfly",
           "Lead",
-          "Wicked Spider"
+          "Wicked Spider",
+          "Barium"
         ],
         "country": "CN",
         "refs": [
@@ -1443,16 +1444,6 @@
       },
       "value": "Hammer Panda",
       "description": "Hammer Panda is a group of suspected Chinese origin targeting organisations in Russia."
-    },
-    {
-      "meta": {
-        "country": "CHN",
-        "refs": [
-          "https://blogs.technet.microsoft.com/mmpc/2017/01/25/detecting-threat-actors-in-recent-german-industrial-attacks-with-windows-defender-atp"
-        ]
-      },
-      "value": "Barium",
-      "description": "Barium is one of the groups using Winnti."
     },
     {
       "meta": {


### PR DESCRIPTION
Microsoft refers to Axiom as "Barium", at least the same URL (https://blogs.technet.microsoft.com/mmpc/2017/01/25/detecting-threat-actors-in-recent-german-industrial-attacks-with-windows-defender-atp) is listed already with Axiom. The entry for Barium is therefore redundant and can be merged into Axiom (making Barium a synonym).