### PR TITLE
added FIN7 as alias for anunak

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -863,11 +863,13 @@
       "meta": {
         "synonyms": [
           "Carbanak",
-          "Carbon Spider"
+          "Carbon Spider",
+          "FIN7"
         ],
         "country": "RU",
         "refs": [
-          "https://en.wikipedia.org/wiki/Carbanak"
+          "https://en.wikipedia.org/wiki/Carbanak",
+          "https://www.proofpoint.com/us/threat-insight/post/fin7carbanak-threat-actor-unleashes-bateleur-jscript-backdoor"
         ],
         "motive": "Cybercrime"
       },


### PR DESCRIPTION
FIN7 is seemingly the FireEye alias for carbanak/anunak (added a reference for context).