### PR TITLE
Use standard (2 digits) ISO codes for all countries

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1632,5 +1632,5 @@
   ],
   "description": "Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.",
   "uuid": "7cdff317-a673-4474-84ec-4f1754947823",
-  "version": 25
+  "version": 26
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1059,7 +1059,7 @@
         "synonyms": [
           "FruityArmor"
         ],
-        "country": "UAE"
+        "country": "AE"
       },
       "value": "Stealth Falcon",
       "description": "Group targeting Emirati journalists, activists, and dissidents."
@@ -1242,7 +1242,7 @@
     },
     {
       "meta": {
-        "country": "LBY"
+        "country": "LY"
       },
       "description": "Libyan Scorpions is a malware operation in use since September 2015 and operated by a politically motivated group whose main objective is intelligence gathering, spying on influentials and political figures and operate an espionage campaign within Libya.",
       "value": "Libyan Scorpions"
@@ -1324,7 +1324,7 @@
         "synonyms": [
           "StrongPity"
         ],
-        "country": "TU"
+        "country": "TR"
       }
     },
     {
@@ -1379,7 +1379,7 @@
       "value": "Sath-ı Müdafaa",
       "description": "A Turkish hacking group, Sath-ı Müdafaa, is encouraging individuals to join its DDoS-for-Points platform that features points and prizes for carrying out distributed denial-of-service (DDoS) attacks against a list of predetermined targets. Their DDoS tool also contains a backdoor to hack the hackers. So the overarching motivation and allegiance of the group is not entirely clear.",
       "meta": {
-        "country": "TU",
+        "country": "TR",
         "motive": "Hacktivists-Nationalists"
       }
     },
@@ -1387,7 +1387,7 @@
       "value": "Aslan Neferler Tim",
       "description": "Turkish nationalist hacktivist group that has been active for roughly one year. According to Domaintools, the group’s site has been registered since December 2015, with an active Twitter account since January 2016. The group carries out distributed denial-of-service (DDoS) attacks and defacements against the sites of news organizations and governments perceived to be critical of Turkey’s policies or leadership, and purports to act in defense of Islam",
       "meta": {
-        "country": "TU",
+        "country": "TR",
         "synonyms": [
           "Lion Soldiers Team",
           "Phantom Turk"
@@ -1399,7 +1399,7 @@
       "value": "Ayyıldız Tim",
       "description": "Ayyıldız (Crescent and Star) Tim is a nationalist hacking group founded in 2002. It performs defacements and DDoS attacks against the websites of governments that it considers to be repressing Muslim minorities or engaged in Islamophobic policies.",
       "meta": {
-        "country": "TU",
+        "country": "TR",
         "synonyms": [
           "Crescent and Star"
         ],
@@ -1410,7 +1410,7 @@
       "value": "TurkHackTeam",
       "description": "Founded in 2004, Turkhackteam is one of Turkey’s oldest and most high-profile hacking collectives. According to a list compiled on Turkhackteam’s forum, the group has carried out almost 30 highly publicized hacking campaigns targeting foreign government and commercial websites, including websites of international corporations. ",
       "meta": {
-        "country": "TU",
+        "country": "TR",
         "synonyms": [
           "Turk Hack Team"
         ],
@@ -1447,7 +1447,7 @@
     },
     {
       "meta": {
-        "country": "CHN",
+        "country": "CN",
         "synonyms": [
           "Zhenbao"
         ],
@@ -1460,7 +1460,7 @@
     },
     {
       "meta": {
-        "country": "IRN",
+        "country": "IR",
         "synonyms": [
           "Operation Mermaid"
         ],
@@ -1473,7 +1473,7 @@
     },
     {
       "meta": {
-        "country": "IRN",
+        "country": "IR",
         "refs": [
           "https://www.blackhat.com/docs/us-16/materials/us-16-Guarnieri-Iran-And-The-Soft-War-For-Internet-Dominance-wp.pdf"
         ]
@@ -1483,7 +1483,7 @@
     },
     {
       "meta": {
-        "country": "CHN",
+        "country": "CN",
         "synonyms": [
           "Cloudy Omega"
         ],
@@ -1496,7 +1496,7 @@
     },
     {
       "meta": {
-        "country": "UKR",
+        "country": "UA",
         "refs": [
           "http://www.welivesecurity.com/2016/05/18/groundbait"
         ]


### PR DESCRIPTION
In the threat actor cluster I have found a mix of two digits ISO codes, three digit ISO codes, FIPS and one country code (UAE) which is neither ISO, ISO3 or fips, according to this list:

http://download.geonames.org/export/dump/countryInfo.txt

This PR changes all of them to legal ISO (two digits) codes, which is already used in most of the entries.

- UAE -> AE (United Arab Emirates)
- CHN -> CN (China)
- TU -> TR (Turkey)
- IRN -> IR (Iran)
- UKR -> UA (Ukraine)