### PR TITLE
Fixed mixed up description/value for MuddyWater

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -2228,8 +2228,8 @@
           "https://researchcenter.paloaltonetworks.com/2017/11/unit42-muddying-the-water-targeted-attacks-in-the-middle-east/"
         ]
       },
-      "description": "MuddyWater",
-      "value": "The MuddyWater attacks are primarily against Middle Eastern nations. However, we have also observed attacks against surrounding nations and beyond, including targets in India and the USA. MuddyWater attacks are characterized by the use of a slowly evolving PowerShell-based first stage backdoor we call “POWERSTATS”. Despite broad scrutiny and reports on MuddyWater attacks, the activity continues with only incremental changes to the tools and techniques."
+      "description": "The MuddyWater attacks are primarily against Middle Eastern nations. However, we have also observed attacks against surrounding nations and beyond, including targets in India and the USA. MuddyWater attacks are characterized by the use of a slowly evolving PowerShell-based first stage backdoor we call “POWERSTATS”. Despite broad scrutiny and reports on MuddyWater attacks, the activity continues with only incremental changes to the tools and techniques.",
+      "value": "MuddyWater"
     }
   ],
   "name": "Threat actor",


### PR DESCRIPTION
On the current master, the values for ActorName ("value") and the description are switched.