### PR TITLE
Two small typos

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -533,7 +533,7 @@
           "Malaysia",
           "Cambodia",
           "China",
-          "Phillipines",
+          "Philippines",
           "South Korea",
           "United States",
           "Indonesia",
@@ -825,7 +825,7 @@
         "cfr-suspected-victims": [
           "Mongolia",
           "Kazakhstan",
-          "Tajikstan",
+          "Tajikistan",
           "Germany",
           "United Kingdom",
           "India",


### PR DESCRIPTION
Found two small typos while automating iso3166 conversion.