### PR TITLE
Added Bahamut to threat actors list

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -5724,6 +5724,17 @@
         ]
       },
       "uuid": "abd89986-b1b0-11e8-b857-efe290264006"
+    },
+    {
+      "value": "Bahamut",
+      "description": "Bahamut is a threat actor primarily operating in Middle East and Central Asia, suspected to be a private contractor to several state sponsored actors. They were observed conduct phishing as well as desktop and mobile malware campaigns.",
+      "meta": {
+        "refs": [
+          "https://www.bellingcat.com/news/mena/2017/06/12/bahamut-pursuing-cyber-espionage-actor-middle-east/",
+          "https://www.bellingcat.com/resources/case-studies/2017/10/27/bahamut-revisited-cyber-espionage-middle-east-south-asia/"
+        ]
+      },
+      "uuid": "dc3edacc-bb24-11e8-81fb-8c16458922a7"
     }
   ],
   "version": 57


### PR DESCRIPTION
Added Bahamut, which was missing from the list.
On a sort of related note: there is other information (such as suspected state sponsor, target categories, etc.) which is currently only present from the CFR data, while it would be useful (for example in this case) to have it included also. Any suggestions on how to do that properly?