### PR TITLE
fixes an important bug in the gen_relations

### DIFF
--- a/clusters/android.json
+++ b/clusters/android.json
@@ -139,13 +139,6 @@
       },
       "related": [
         {
-          "dest-uuid": "a6f481fe-b6db-4507-bb3c-28f10d800e2f",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "b8fa5036-813f-4887-b4d4-bb17b4a7eba0",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -3802,7 +3795,7 @@
       },
       "related": [
         {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
+          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -3817,41 +3810,6 @@
         },
         {
           "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "8ae43c46-57ef-47d5-a77a-eebb35628db2",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "6bd20349-1231-4aaa-ba2a-f4b09d3b344c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -4605,15 +4563,6 @@
           "https://researchcenter.paloaltonetworks.com/2018/04/unit42-henbox-inside-coop/"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "36ee04f4-a9df-11e8-b92b-d7ddfd3a8896",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "72c37e24-4ead-11e8-8f08-db3ec8f8db86§",
       "value": "HenBox"
     },
@@ -4676,5 +4625,5 @@
       "value": "Triout"
     }
   ],
-  "version": 15
+  "version": 16
 }

--- a/clusters/banker.json
+++ b/clusters/banker.json
@@ -100,21 +100,7 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "7ca93488-c357-44c3-b246-3f88391aca5a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "b4216929-1626-4444-bdd7-bfd4b68a766e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "66781866-f064-467d-925d-5e5f290352f0",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -200,13 +186,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "0f96a666-bf26-44e0-8ad6-f2136208c924",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "uuid": "ffbbbc14-1cdb-4be9-a631-ed53c5407369",
@@ -237,13 +216,6 @@
       "related": [
         {
           "dest-uuid": "a171321e-4968-4ac0-8497-3250c1f0d77d",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "ffbbbc14-1cdb-4be9-a631-ed53c5407369",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -481,13 +453,6 @@
       },
       "related": [
         {
-          "dest-uuid": "96b2b31e-b191-43c4-9929-48ba1cbee62c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "75f53ead-1aee-4f91-8cb9-b4170d747cfc",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -560,20 +525,6 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "44754726-e1d5-4e5f-a113-234c4a8ca65e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "b4216929-1626-4444-bdd7-bfd4b68a766e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "66781866-f064-467d-925d-5e5f290352f0",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -638,13 +589,6 @@
       "related": [
         {
           "dest-uuid": "ac2ff27d-a7cb-46fe-ae32-cfe571dc614d",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "6e1168e6-7768-4fa2-951f-6d6934531633",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -753,13 +697,6 @@
         },
         {
           "dest-uuid": "80acc956-d418-42e3-bddf-078695a01289",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "e159c4f8-3c22-49f9-a60a-16588a9c22b0",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -996,13 +933,6 @@
         },
         {
           "dest-uuid": "80acc956-d418-42e3-bddf-078695a01289",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "87b69cb4-8b65-47ee-91b0-9b1decdd5c5c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1244,5 +1174,5 @@
       "value": "CamuBot"
     }
   ],
-  "version": 14
+  "version": 15
 }

--- a/clusters/botnet.json
+++ b/clusters/botnet.json
@@ -713,6 +713,20 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        },
+        {
+          "dest-uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
         }
       ],
       "uuid": "fcdfd4af-da35-49a8-9610-19be8a487185",
@@ -855,6 +869,27 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "fcdfd4af-da35-49a8-9610-19be8a487185",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        },
+        {
+          "dest-uuid": "dcbf1aaa-1fdd-4bfc-a35e-145ffdfb5ac5",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        },
+        {
+          "dest-uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
         }
       ],
       "uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
@@ -1036,6 +1071,29 @@
           "Mirai Sora"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "fcdfd4af-da35-49a8-9610-19be8a487185",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        },
+        {
+          "dest-uuid": "dcbf1aaa-1fdd-4bfc-a35e-145ffdfb5ac5",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        },
+        {
+          "dest-uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        }
+      ],
       "uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
       "value": "Sora"
     },

--- a/clusters/botnet.json
+++ b/clusters/botnet.json
@@ -195,20 +195,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "b2ec1f16-2a76-4910-adc5-ecb3570e7c1a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "2ccaccd0-8362-4224-8497-2012e7cc7549",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "uuid": "6e1168e6-7768-4fa2-951f-6d6934531633",
@@ -722,20 +708,6 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
-          "dest-uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
           "dest-uuid": "17e12216-a303-4a00-8283-d3fe92d0934c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -877,27 +849,6 @@
         ]
       },
       "related": [
-        {
-          "dest-uuid": "fcdfd4af-da35-49a8-9610-19be8a487185",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
-          "dest-uuid": "dcbf1aaa-1fdd-4bfc-a35e-145ffdfb5ac5",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
-          "dest-uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
         {
           "dest-uuid": "ec67f206-6464-48cf-a012-3cdfc1278488",
           "tags": [
@@ -1085,29 +1036,6 @@
           "Mirai Sora"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "fcdfd4af-da35-49a8-9610-19be8a487185",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
-          "dest-uuid": "dcbf1aaa-1fdd-4bfc-a35e-145ffdfb5ac5",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
-          "dest-uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        }
-      ],
       "uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
       "value": "Sora"
     },
@@ -1151,5 +1079,5 @@
       "value": "Persirai"
     }
   ],
-  "version": 16
+  "version": 17
 }

--- a/clusters/exploit-kit.json
+++ b/clusters/exploit-kit.json
@@ -53,6 +53,15 @@
           "Fallout"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "5920464b-e093-4fa0-a275-438dffef228f",
+          "tags": [
+            "estimative-language:likelihood-probability=\"almost-certain\""
+          ],
+          "type": "dropped"
+        }
+      ],
       "uuid": "1f05f646-5af6-4a95-825b-164f49616aa4",
       "value": "Fallout"
     },

--- a/clusters/exploit-kit.json
+++ b/clusters/exploit-kit.json
@@ -53,15 +53,6 @@
           "Fallout"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "5920464b-e093-4fa0-a275-438dffef228f",
-          "tags": [
-            "estimative-language:likelihood-probability=\"almost-certain\""
-          ],
-          "type": "dropped"
-        }
-      ],
       "uuid": "1f05f646-5af6-4a95-825b-164f49616aa4",
       "value": "Fallout"
     },
@@ -276,20 +267,6 @@
       "related": [
         {
           "dest-uuid": "75f53ead-1aee-4f91-8cb9-b4170d747cfc",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "5594b171-32ec-4145-b712-e7701effffdd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "5eee35b6-bd21-4b67-b198-e9320fcf2c88",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -761,5 +738,5 @@
       "value": "Unknown"
     }
   ],
-  "version": 11
+  "version": 12
 }

--- a/clusters/malpedia.json
+++ b/clusters/malpedia.json
@@ -495,13 +495,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "fbda9705-677b-4c5b-9b0b-13b52eff587c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "uuid": "a6f481fe-b6db-4507-bb3c-28f10d800e2f",
@@ -2813,13 +2806,6 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -2841,21 +2827,7 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "6bd20349-1231-4aaa-ba2a-f4b09d3b344c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -5280,6 +5252,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "276c2c2e-09da-44cf-a3f7-806b3feb41da",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "16794655-c0e2-4510-9169-f862df104045",
@@ -7482,20 +7461,6 @@
       },
       "related": [
         {
-          "dest-uuid": "276c2c2e-09da-44cf-a3f7-806b3feb41da",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "66781866-f064-467d-925d-5e5f290352f0",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "44754726-e1d5-4e5f-a113-234c4a8ca65e",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -7503,7 +7468,7 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "7ca93488-c357-44c3-b246-3f88391aca5a",
+          "dest-uuid": "276c2c2e-09da-44cf-a3f7-806b3feb41da",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -8289,20 +8254,6 @@
       "related": [
         {
           "dest-uuid": "276c2c2e-09da-44cf-a3f7-806b3feb41da",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "b4216929-1626-4444-bdd7-bfd4b68a766e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "44754726-e1d5-4e5f-a113-234c4a8ca65e",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -9558,13 +9509,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "cd201689-4bf1-4c5b-ac4d-21c4dcc39e7d",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "uuid": "4166ab63-24b0-4448-92ea-21c8deef978d",
@@ -9609,13 +9553,6 @@
         "type": []
       },
       "related": [
-        {
-          "dest-uuid": "083bb47b-02c8-4423-81a2-f9ef58572974",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
         {
           "dest-uuid": "d7183f66-59ec-4803-be20-237b442259fc",
           "tags": [
@@ -10716,6 +10653,13 @@
         "type": []
       },
       "related": [
+        {
+          "dest-uuid": "2a16a1d4-a098-4f17-80f3-3cfc6c60b539",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
         {
           "dest-uuid": "74167065-90b3-4c29-807a-79b6f098e45b",
           "tags": [
@@ -14001,13 +13945,6 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "4166ab63-24b0-4448-92ea-21c8deef978d",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "652b5242-b790-4695-ad0e-b79bbf78f351",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -14471,13 +14408,6 @@
         },
         {
           "dest-uuid": "b2ec1f16-2a76-4910-adc5-ecb3570e7c1a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "6e1168e6-7768-4fa2-951f-6d6934531633",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -16075,7 +16005,7 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
+          "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -16097,27 +16027,6 @@
         },
         {
           "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -17669,13 +17578,6 @@
         "type": []
       },
       "related": [
-        {
-          "dest-uuid": "96b2b31e-b191-43c4-9929-48ba1cbee62c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
         {
           "dest-uuid": "75f53ead-1aee-4f91-8cb9-b4170d747cfc",
           "tags": [
@@ -19976,5 +19878,5 @@
       "value": "Zyklon"
     }
   ],
-  "version": 1650
+  "version": 1651
 }

--- a/clusters/mitre-enterprise-attack-intrusion-set.json
+++ b/clusters/mitre-enterprise-attack-intrusion-set.json
@@ -291,7 +291,21 @@
       },
       "related": [
         {
+          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "a0cb9370-e39b-44d5-9f50-ef78e412b973",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -345,6 +359,13 @@
         },
         {
           "dest-uuid": "0286e80e-b0ed-464f-ad62-beec8536d0cb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "103ebfd8-4280-4027-b61a-69bd9967ad6c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -660,6 +681,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "f9d6633a-55e6-4adc-9263-6ae080421a13",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -811,6 +839,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "f3bdec95-3d62-42d9-a840-29630f6cdc1a",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "519630c5-f03f-4882-825c-3af924935817",
           "tags": [
             "estimative-language:likelihood-probability=\"almost-certain\""
@@ -884,6 +919,13 @@
         ]
       },
       "related": [
+        {
+          "dest-uuid": "2e5d3a83-fe00-41a5-9b60-237efc84832f",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
         {
           "dest-uuid": "a9b44750-992c-4743-8922-129880d277ea",
           "tags": [
@@ -1180,6 +1222,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "f047ee18-7985-4946-8bfb-4ed754d3a0dd",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "5a63f900-5e7e-4928-a746-dd4558e1df71",
           "tags": [
             "estimative-language:likelihood-probability=\"almost-certain\""
@@ -1344,6 +1393,13 @@
       },
       "related": [
         {
+          "dest-uuid": "2a158b0a-7ef8-43cb-9985-bf34d1e12050",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "2f1fd017-9df6-4759-91fb-e7039609b5ff",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -1463,6 +1519,13 @@
       "related": [
         {
           "dest-uuid": "00220228-a5a4-4032-a30d-826bb55aa3fb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "55033a4d-3ffe-46b2-99b4-2c1541e9ce1c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2060,6 +2123,20 @@
       },
       "related": [
         {
+          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -2154,6 +2231,13 @@
         },
         {
           "dest-uuid": "8f5e8dc7-739d-4f5e-a8a1-a66e004d7063",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2257,6 +2341,13 @@
         ]
       },
       "related": [
+        {
+          "dest-uuid": "3753cc21-2dae-4dfb-8481-d004e74502cc",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
         {
           "dest-uuid": "00220228-a5a4-4032-a30d-826bb55aa3fb",
           "tags": [
@@ -2460,5 +2551,5 @@
       "value": "Gamaredon Group - G0047"
     }
   ],
-  "version": 6
+  "version": 7
 }

--- a/clusters/mitre-enterprise-attack-malware.json
+++ b/clusters/mitre-enterprise-attack-malware.json
@@ -371,13 +371,6 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "c04fc02e-f35a-44b6-a9b0-732bf2fc551a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "8f4a33ec-8b1f-4b80-a2f6-642b2e479580",
           "tags": [
             "estimative-language:likelihood-probability=\"almost-certain\""
@@ -1561,6 +1554,27 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "1de47f51-1f20-403b-a2e1-5eaabe275faa",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "355be19c-ffc9-46d5-8d50-d6a036c675b6",
           "tags": [
             "estimative-language:likelihood-probability=\"almost-certain\""
@@ -1864,6 +1878,13 @@
         },
         {
           "dest-uuid": "2abe89de-46dd-4dae-ae22-b49a593aff54",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "e336aeba-b61a-44e0-a0df-cd52a5839db5",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -3621,6 +3642,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "0a52e73b-d7e9-45ae-9bda-46568f753931",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
           "tags": [
             "estimative-language:likelihood-probability=\"almost-certain\""
@@ -4002,48 +4030,6 @@
         },
         {
           "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "8ae43c46-57ef-47d5-a77a-eebb35628db2",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "6bd20349-1231-4aaa-ba2a-f4b09d3b344c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -4625,6 +4611,13 @@
         },
         {
           "dest-uuid": "d9cc15f7-0880-4ae4-8df4-87c58338d6b8",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "da079741-05e6-458c-b434-011263dc691c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -5822,13 +5815,6 @@
       },
       "related": [
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -5844,20 +5830,6 @@
         },
         {
           "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -5913,5 +5885,5 @@
       "value": "ELMER - S0064"
     }
   ],
-  "version": 7
+  "version": 8
 }

--- a/clusters/mitre-intrusion-set.json
+++ b/clusters/mitre-intrusion-set.json
@@ -178,7 +178,21 @@
       },
       "related": [
         {
+          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "a0cb9370-e39b-44d5-9f50-ef78e412b973",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -224,6 +238,13 @@
         },
         {
           "dest-uuid": "0286e80e-b0ed-464f-ad62-beec8536d0cb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "103ebfd8-4280-4027-b61a-69bd9967ad6c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -419,6 +440,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "f9d6633a-55e6-4adc-9263-6ae080421a13",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -495,6 +523,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "f3bdec95-3d62-42d9-a840-29630f6cdc1a",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "value": "Moafee"
@@ -555,6 +590,13 @@
         "uuid": "f3bdec95-3d62-42d9-a840-29630f6cdc1a"
       },
       "related": [
+        {
+          "dest-uuid": "2e5d3a83-fe00-41a5-9b60-237efc84832f",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
         {
           "dest-uuid": "a9b44750-992c-4743-8922-129880d277ea",
           "tags": [
@@ -663,6 +705,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "f047ee18-7985-4946-8bfb-4ed754d3a0dd",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "value": "Naikon"
@@ -728,6 +777,13 @@
         "uuid": "f047ee18-7985-4946-8bfb-4ed754d3a0dd"
       },
       "related": [
+        {
+          "dest-uuid": "2a158b0a-7ef8-43cb-9985-bf34d1e12050",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
         {
           "dest-uuid": "2f1fd017-9df6-4759-91fb-e7039609b5ff",
           "tags": [
@@ -845,6 +901,13 @@
       "related": [
         {
           "dest-uuid": "00220228-a5a4-4032-a30d-826bb55aa3fb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "55033a4d-3ffe-46b2-99b4-2c1541e9ce1c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1018,6 +1081,27 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "8f5e8dc7-739d-4f5e-a8a1-a66e004d7063",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "11e17436-6ede-4733-8547-4ce0254ea19e",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "86724806-7ec9-4a48-a0a7-ecbde3bf4810",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "42be2a84-5a5c-4c6d-9864-3f09d75bb0ba",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -1025,7 +1109,49 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "d56c99fa-4710-472c-81a6-41b7a84ea4be",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "a0082cfa-32e2-42b8-92d8-5c7a7409dcf1",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "f9d6633a-55e6-4adc-9263-6ae080421a13",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "ba724df5-9aa0-45ca-8e0e-7101c208ae48",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "f98bac6b-12fd-4cad-be84-c84666932232",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "f873db71-3d53-41d5-b141-530675ade27a",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "47204403-34c9-4d25-a006-296a0939d1a2",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1296,7 +1422,21 @@
       },
       "related": [
         {
+          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1326,6 +1466,13 @@
         "uuid": "55033a4d-3ffe-46b2-99b4-2c1541e9ce1c"
       },
       "related": [
+        {
+          "dest-uuid": "3753cc21-2dae-4dfb-8481-d004e74502cc",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
         {
           "dest-uuid": "00220228-a5a4-4032-a30d-826bb55aa3fb",
           "tags": [
@@ -1431,5 +1578,5 @@
       "value": "Gamaredon Group"
     }
   ],
-  "version": 7
+  "version": 8
 }

--- a/clusters/mitre-malware.json
+++ b/clusters/mitre-malware.json
@@ -263,13 +263,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "c04fc02e-f35a-44b6-a9b0-732bf2fc551a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "value": "Backdoor.Oldrea"
@@ -454,6 +447,27 @@
         },
         {
           "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "1de47f51-1f20-403b-a2e1-5eaabe275faa",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1021,6 +1035,13 @@
         },
         {
           "dest-uuid": "7789fc1b-3cbc-4a1c-8ef0-8b06760f93e7",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "e336aeba-b61a-44e0-a0df-cd52a5839db5",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1887,48 +1908,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "8ae43c46-57ef-47d5-a77a-eebb35628db2",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "6bd20349-1231-4aaa-ba2a-f4b09d3b344c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "value": "CORESHELL"
@@ -2168,6 +2147,13 @@
         },
         {
           "dest-uuid": "d9cc15f7-0880-4ae4-8df4-87c58338d6b8",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "da079741-05e6-458c-b434-011263dc691c",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2782,13 +2768,6 @@
       },
       "related": [
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -2804,20 +2783,6 @@
         },
         {
           "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2852,5 +2817,5 @@
       "value": "ELMER"
     }
   ],
-  "version": 6
+  "version": 7
 }

--- a/clusters/mitre-mobile-attack-intrusion-set.json
+++ b/clusters/mitre-mobile-attack-intrusion-set.json
@@ -32,56 +32,14 @@
       },
       "related": [
         {
-          "dest-uuid": "8ae43c46-57ef-47d5-a77a-eebb35628db2",
+          "dest-uuid": "5b4ee3ea-eee3-4c8e-8323-85ae32658754",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         },
         {
-          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "1de47f51-1f20-403b-a2e1-5eaabe275faa",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "3948ce95-468e-4ce1-82b1-57439c6d6afd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "d26b5518-8d7f-41a6-b539-231e4962853e",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "6bd20349-1231-4aaa-ba2a-f4b09d3b344c",
+          "dest-uuid": "213cdde9-c11a-4ea9-8ce0-c868e9826fec",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -92,5 +50,5 @@
       "value": "APT28 - G0007"
     }
   ],
-  "version": 5
+  "version": 6
 }

--- a/clusters/mitre-pre-attack-intrusion-set.json
+++ b/clusters/mitre-pre-attack-intrusion-set.json
@@ -132,6 +132,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "f9d6633a-55e6-4adc-9263-6ae080421a13",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -326,5 +333,5 @@
       "value": "APT17 - G0025"
     }
   ],
-  "version": 5
+  "version": 6
 }

--- a/clusters/ransomware.json
+++ b/clusters/ransomware.json
@@ -10083,6 +10083,15 @@
           "https://www.bleepingcomputer.com/news/security/gandcrab-v5-ransomware-utilizing-the-alpc-task-scheduler-exploit/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "1f05f646-5af6-4a95-825b-164f49616aa4",
+          "tags": [
+            "estimative-language:likelihood-probability=\"almost-certain\""
+          ],
+          "type": "dropped-by"
+        }
+      ],
       "uuid": "5920464b-e093-4fa0-a275-438dffef228f",
       "value": "GandCrab"
     },

--- a/clusters/ransomware.json
+++ b/clusters/ransomware.json
@@ -5534,6 +5534,15 @@
           "crjoker.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "10f92054-b028-11e8-a51f-2f82236ac72d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        }
+      ],
       "uuid": "2fb307a2-8752-4521-8973-75b68703030d",
       "value": "CryptoJoker"
     },
@@ -10918,6 +10927,15 @@
           "https://twitter.com/malwrhunterteam/status/1034492151541977088"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2fb307a2-8752-4521-8973-75b68703030d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        }
+      ],
       "uuid": "10f92054-b028-11e8-a51f-2f82236ac72d",
       "value": "CryptoNar"
     },

--- a/clusters/ransomware.json
+++ b/clusters/ransomware.json
@@ -3290,15 +3290,6 @@
           "https://www.bleepingcomputer.com/news/security/new-bip-dharma-ransomware-variant-released/"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "15a30d84-4f5f-4b75-a162-e36107d30215",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "2b365b2c-4a9a-4b66-804d-3b2d2814fe7b",
       "value": "Dharma Ransomware"
     },
@@ -5543,15 +5534,6 @@
           "crjoker.html"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "10f92054-b028-11e8-a51f-2f82236ac72d",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "2fb307a2-8752-4521-8973-75b68703030d",
       "value": "CryptoJoker"
     },
@@ -9483,15 +9465,6 @@
           "CrySiS"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "2b365b2c-4a9a-4b66-804d-3b2d2814fe7b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "15a30d84-4f5f-4b75-a162-e36107d30215",
       "value": "Virus-Encoder"
     },
@@ -9891,6 +9864,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "00c31914-bc0e-11e8-8241-3ff3b5e4671d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "e8af6388-6575-4812-94a8-9df1567294c5",
@@ -10094,15 +10074,6 @@
           "https://www.bleepingcomputer.com/news/security/gandcrab-v5-ransomware-utilizing-the-alpc-task-scheduler-exploit/"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "1f05f646-5af6-4a95-825b-164f49616aa4",
-          "tags": [
-            "estimative-language:likelihood-probability=\"almost-certain\""
-          ],
-          "type": "dropped-by"
-        }
-      ],
       "uuid": "5920464b-e093-4fa0-a275-438dffef228f",
       "value": "GandCrab"
     },
@@ -10947,15 +10918,6 @@
           "https://twitter.com/malwrhunterteam/status/1034492151541977088"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "2fb307a2-8752-4521-8973-75b68703030d",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "10f92054-b028-11e8-a51f-2f82236ac72d",
       "value": "CryptoNar"
     },
@@ -11119,5 +11081,5 @@
       "value": "SAVEfiles"
     }
   ],
-  "version": 38
+  "version": 39
 }

--- a/clusters/rat.json
+++ b/clusters/rat.json
@@ -106,6 +106,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "e336aeba-b61a-44e0-a0df-cd52a5839db5",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "7789fc1b-3cbc-4a1c-8ef0-8b06760f93e7",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -1827,6 +1834,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "da079741-05e6-458c-b434-011263dc691c",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "9223bf17-7e32-4833-9574-9ffd8c929765",
@@ -3034,6 +3048,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "0a52e73b-d7e9-45ae-9bda-46568f753931",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "e0bea149-2def-484f-b658-f782a4f94815",
@@ -3255,5 +3276,5 @@
       "value": "NukeSped"
     }
   ],
-  "version": 19
+  "version": 20
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -127,6 +127,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "a653431d-6a5e-4600-8ad3-609b5af57064",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "103ebfd8-4280-4027-b61a-69bd9967ad6c",
@@ -476,7 +483,14 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "9cebfaa8-a797-11e8-99e0-3ffa312b9a10",
+          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "a0cb9370-e39b-44d5-9f50-ef78e412b973",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -624,13 +638,6 @@
         },
         {
           "dest-uuid": "a0cb9370-e39b-44d5-9f50-ef78e412b973",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "9cebfaa8-a797-11e8-99e0-3ffa312b9a10",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1111,15 +1118,6 @@
           "Royal APT"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "9cebfaa8-a797-11e8-99e0-3ffa312b9a10",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "3501fbf2-098f-47e7-be6a-6b0ff5742ce8",
       "value": "Mirage"
     },
@@ -1542,6 +1540,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "ba724df5-9aa0-45ca-8e0e-7101c208ae48",
@@ -1609,6 +1614,13 @@
         },
         {
           "dest-uuid": "a0082cfa-32e2-42b8-92d8-5c7a7409dcf1",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1718,6 +1730,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "f98bac6b-12fd-4cad-be84-c84666932232",
@@ -1815,7 +1834,7 @@
         {
           "dest-uuid": "ba724df5-9aa0-45ca-8e0e-7101c208ae48",
           "tags": [
-            "estimative-language:likelihood-probability=\"very-likely\""
+            "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         },
@@ -1863,6 +1882,13 @@
         },
         {
           "dest-uuid": "8f5e8dc7-739d-4f5e-a8a1-a66e004d7063",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1950,6 +1976,13 @@
         },
         {
           "dest-uuid": "a0082cfa-32e2-42b8-92d8-5c7a7409dcf1",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -3634,6 +3667,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "47204403-34c9-4d25-a006-296a0939d1a2",
@@ -4575,6 +4615,13 @@
         },
         {
           "dest-uuid": "a0082cfa-32e2-42b8-92d8-5c7a7409dcf1",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "b96e02f1-4037-463f-b158-5a964352f8d9",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -5603,29 +5650,6 @@
           "https://www.cfr.org/interactive/cyber-operations/winnti-umbrella"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "3501fbf2-098f-47e7-be6a-6b0ff5742ce8",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "9cebfaa8-a797-11e8-99e0-3ffa312b9a10",
       "value": "Winnti Umbrella"
     },
@@ -5645,15 +5669,6 @@
           "https://www.cfr.org/interactive/cyber-operations/henbox"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "72c37e24-4ead-11e8-8f08-db3ec8f8db86§",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "36ee04f4-a9df-11e8-b92b-d7ddfd3a8896",
       "value": "HenBox"
     },
@@ -5812,15 +5827,6 @@
           "the Rocra"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "1572f618-bcb3-11e8-841b-1fd7f9cfe126",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "same-as"
-        }
-      ],
       "uuid": "358b8982-bcaa-11e8-8a5b-4b618197c5b0",
       "value": "Red October"
     },
@@ -5844,15 +5850,6 @@
           "https://www.cfr.org/interactive/cyber-operations/cloud-atlas"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "358b8982-bcaa-11e8-8a5b-4b618197c5b0",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "same-as"
-        }
-      ],
       "uuid": "1572f618-bcb3-11e8-841b-1fd7f9cfe126",
       "value": "Cloud Atlas"
     },
@@ -5916,18 +5913,9 @@
     },
     {
       "description": "Treasury has identified a sophisticated cyber-enabled ATM cash out campaign we are calling FASTCash. FASTCash has been active since late 2016 targeting banks in Africa and Asia to remotely compromise payment switch application servers within banks to facilitate fraudulent transactions, primarily involving ATMs, to steal cash equivalent to tens of millions of dollars. FBI has attributed malware used in this campaign to the North Korean government. We expect FASTCash to continue targeting retail payment systems vulnerable to remote exploitation.",
-      "related": [
-        {
-          "dest-uuid": "e306fe62-c708-11e8-89f2-073e396e5403",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "e38d32a2-c708-11e8-8785-472c4cfccd85",
       "value": "FASTCash"
     }
   ],
-  "version": 70
+  "version": 71
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1834,7 +1834,7 @@
         {
           "dest-uuid": "ba724df5-9aa0-45ca-8e0e-7101c208ae48",
           "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
+            "estimative-language:likelihood-probability=\"very-likely\""
           ],
           "type": "similar"
         },

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -160,6 +160,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "e336aeba-b61a-44e0-a0df-cd52a5839db5",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "2abe89de-46dd-4dae-ae22-b49a593aff54",
@@ -834,6 +841,20 @@
       },
       "related": [
         {
+          "dest-uuid": "9223bf17-7e32-4833-9574-9ffd8c929765",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "da5880b4-f7da-4869-85f2-e0aba84b8565",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "d9cc15f7-0880-4ae4-8df4-87c58338d6b8",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -1167,7 +1188,7 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
+          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1188,14 +1209,14 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "60c18d06-7b91-4742-bae3-647845cd9d81",
+          "dest-uuid": "75c79f95-4c84-4650-9158-510f0ce4831d",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         },
         {
-          "dest-uuid": "df36267b-7267-4c23-a7a1-cf94ef1b3729",
+          "dest-uuid": "f108215f-3487-489d-be8b-80e346d32518",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1259,14 +1280,21 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
+          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         },
         {
-          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
+          "dest-uuid": "75c79f95-4c84-4650-9158-510f0ce4831d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "f108215f-3487-489d-be8b-80e346d32518",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -1358,14 +1386,21 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "bef4c620-0787-42a8-a96d-b7eb6e85917c",
+          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         },
         {
-          "dest-uuid": "43cd8a09-9c80-48c8-9568-1992433af60a",
+          "dest-uuid": "75c79f95-4c84-4650-9158-510f0ce4831d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "f108215f-3487-489d-be8b-80e346d32518",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2231,6 +2266,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "652b5242-b790-4695-ad0e-b79bbf78f351",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "ff0404a1-465f-4dd5-8b66-ee773628ca64",
@@ -2660,6 +2702,13 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "b4216929-1626-4444-bdd7-bfd4b68a766e",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "7ca93488-c357-44c3-b246-3f88391aca5a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -2667,7 +2716,7 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "b4216929-1626-4444-bdd7-bfd4b68a766e",
+          "dest-uuid": "16794655-c0e2-4510-9169-f862df104045",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2688,6 +2737,13 @@
       "related": [
         {
           "dest-uuid": "cd201689-4bf1-4c5b-ac4d-21c4dcc39e7d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "ff0404a1-465f-4dd5-8b66-ee773628ca64",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2890,6 +2946,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "2a16a1d4-a098-4f17-80f3-3cfc6c60b539",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "74167065-90b3-4c29-807a-79b6f098e45b",
@@ -2907,7 +2970,21 @@
       },
       "related": [
         {
+          "dest-uuid": "28c13455-7f95-40a5-9568-1e8732503507",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "a673b4fb-a864-4a5b-94ab-3fc4f5606cc8",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "74167065-90b3-4c29-807a-79b6f098e45b",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -2939,20 +3016,6 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
-        },
-        {
-          "dest-uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "variant-of"
         },
         {
           "dest-uuid": "17e12216-a303-4a00-8283-d3fe92d0934c",
@@ -3108,13 +3171,6 @@
       },
       "related": [
         {
-          "dest-uuid": "e6085ce0-af6d-41f7-8bcb-7f2eed246941",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "6e668c0c-7085-4951-87d4-0334b6a5cdb3",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -3132,15 +3188,6 @@
           "https://securityintelligence.com/tag/shiz-trojan-malware/"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "67d712c8-d254-4820-83fa-9a892b87923b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "e6085ce0-af6d-41f7-8bcb-7f2eed246941",
       "value": "Shiz"
     },
@@ -3531,7 +3578,28 @@
       },
       "related": [
         {
+          "dest-uuid": "4e104fef-8a2c-4679-b497-6e86d7d47db0",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "b42378e0-f147-496f-992a-26a49705395b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "7789fc1b-3cbc-4a1c-8ef0-8b06760f93e7",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "2abe89de-46dd-4dae-ae22-b49a593aff54",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -5164,6 +5232,20 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "e0bea149-2def-484f-b658-f782a4f94815",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "fece06b7-d4b1-42cf-b81a-5323c917546e",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "bbfd4fb4-3e5a-43bf-b4bb-eaf5ef4fb25f",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -5689,6 +5771,13 @@
       "related": [
         {
           "dest-uuid": "43a56ed7-8092-4b36-998c-349b02b3bd0d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "d1482c9e-6af3-11e8-aa8e-279274bd10c7",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -6434,6 +6523,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "a71ed71f-b8f4-416d-9c57-910a42e59430",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "d1482c9e-6af3-11e8-aa8e-279274bd10c7",
@@ -6911,6 +7007,13 @@
       },
       "related": [
         {
+          "dest-uuid": "e8af6388-6575-4812-94a8-9df1567294c5",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
           "dest-uuid": "6f736038-4f74-435b-8904-6870ee0e23ba",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -6963,15 +7066,6 @@
     },
     {
       "description": "Treasury has identified a sophisticated cyber-enabled ATM cash out campaign we are calling FASTCash. FASTCash has been active since late 2016 targeting banks in Africa and Asia to remotely compromise payment switch application servers within banks to facilitate fraudulent transactions, primarily involving ATMs, to steal cash equivalent to tens of millions of dollars. FBI has attributed malware used in this campaign to the North Korean government. We expect FASTCash to continue targeting retail payment systems vulnerable to remote exploitation.",
-      "related": [
-        {
-          "dest-uuid": "e38d32a2-c708-11e8-8785-472c4cfccd85",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "e306fe62-c708-11e8-89f2-073e396e5403",
       "value": "FASTCash"
     },
@@ -6995,5 +7089,5 @@
       "value": "CoalaBot"
     }
   ],
-  "version": 94
+  "version": 95
 }

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -3190,6 +3190,13 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "e6085ce0-af6d-41f7-8bcb-7f2eed246941",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "67d712c8-d254-4820-83fa-9a892b87923b",
@@ -3202,6 +3209,15 @@
           "https://securityintelligence.com/tag/shiz-trojan-malware/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "67d712c8-d254-4820-83fa-9a892b87923b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        }
+      ],
       "uuid": "e6085ce0-af6d-41f7-8bcb-7f2eed246941",
       "value": "Shiz"
     },

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -3023,6 +3023,20 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "f24ad5ca-04c5-4cd0-bd72-209ebce4fdbc",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
+        },
+        {
+          "dest-uuid": "025ab0ce-bffc-11e8-be19-d70ec22c5d56",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "variant-of"
         }
       ],
       "uuid": "dcbf1aaa-1fdd-4bfc-a35e-145ffdfb5ac5",

--- a/tools/gen_mapping.py
+++ b/tools/gen_mapping.py
@@ -36,7 +36,7 @@ type_mapping = {
     'mitre-mobile-attack-tool': 'tool',
     'backdoor': 'tool',
     # 'mitre-pre-attack-attack-pattern': '',
-    'mitre-mobile-attack-intrusion-set': 'tool',
+    'mitre-mobile-attack-intrusion-set': 'actor',
     'mitre-tool': 'tool',
     # 'mitre-mobile-attack-attack-pattern': '',
     'mitre-mobile-attack-malware': 'tool',


### PR DESCRIPTION
A severe bug was present in the gen_relations script causing a considerable amount of incorrect relations to be build.

I've fixed the bug in the script and had to re-generate all relationships in the clusters (dropping existing relations, including manually created ones)

This pull request tries to fix this issue and also includes some manually added relations. (the "add missing relations from commit" commits). I hope I didn't miss too many of them.
