### PR TITLE
Corrected DarkHotel threat actor entry

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -346,7 +346,7 @@
           "Private sector"
         ],
         "cfr-type-of-incident": "Espionage",
-        "country": "KP",
+        "country": "KR",
         "refs": [
           "https://securelist.com/blog/research/71713/darkhotels-attacks-in-2015/",
           "https://blogs.technet.microsoft.com/mmpc/2016/06/09/reverse-engineering-dubnium-2",


### PR DESCRIPTION
Waiting for answer on #259. As the PR was about syncing CFR information, the country code for DarkHotel should be KR instead of KP, I think. :thinking: 