### PR TITLE
added APT38 as (FireEye) alias for Lazarus

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -2637,7 +2637,8 @@
           "https://www.cfr.org/interactive/cyber-operations/operation-ghostsecret",
           "https://securelist.com/operation-applejeus/87553/",
           "https://www.cfr.org/interactive/cyber-operations/compromise-cryptocurrency-exchanges-south-korea",
-          "https://www.bleepingcomputer.com/news/security/lazarus-group-deploys-its-first-mac-malware-in-cryptocurrency-exchange-hack/"
+          "https://www.bleepingcomputer.com/news/security/lazarus-group-deploys-its-first-mac-malware-in-cryptocurrency-exchange-hack/",
+          "https://content.fireeye.com/apt/rpt-apt38"
         ],
         "synonyms": [
           "Operation DarkSeoul",
@@ -2653,7 +2654,8 @@
           "Labyrinth Chollima",
           "Operation Troy",
           "Operation GhostSecret",
-          "Operation AppleJeus"
+          "Operation AppleJeus",
+          "APT38"
         ]
       },
       "related": [
@@ -5999,5 +6001,5 @@
       "value": "EvilTraffic"
     }
   ],
-  "version": 76
+  "version": 77
 }


### PR DESCRIPTION
cross-references in https://content.fireeye.com/apt/rpt-apt38 suggest the link to Lazarus.