### PR TITLE
New name SNAKEMACKEREL for APT28 by Accenture

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -2175,7 +2175,8 @@
           "https://www.us-cert.gov/sites/default/files/publications/AR-17-20045_Enhanced_Analysis_of_GRIZZLY_STEPPE_Activity.pdf",
           "https://www.fireeye.com/blog/threat-research/2017/03/dissecting_one_ofap.html",
           "https://www.cfr.org/interactive/cyber-operations/dukes",
-          "https://pylos.co/2018/11/18/cozybear-in-from-the-cold/"
+          "https://pylos.co/2018/11/18/cozybear-in-from-the-cold/",
+          "https://cloudblogs.microsoft.com/microsoftsecure/2018/12/03/analysis-of-cyberattack-on-u-s-think-tanks-non-profits-public-sector-by-unidentified-attackers/"
         ],
         "synonyms": [
           "Dukes",
@@ -2193,7 +2194,8 @@
           "The Dukes",
           "Minidionis",
           "SeaDuke",
-          "Hammer Toss"
+          "Hammer Toss",
+          "YTTRIUM"
         ]
       },
       "related": [

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -2101,7 +2101,8 @@
           "https://www.cfr.org/interactive/cyber-operations/apt-28",
           "https://blogs.microsoft.com/on-the-issues/2018/08/20/we-are-taking-new-steps-against-broadening-threats-to-democracy/",
           "https://www.bleepingcomputer.com/news/security/microsoft-disrupts-apt28-hacking-campaign-aimed-at-us-midterm-elections/",
-          "https://www.bleepingcomputer.com/news/security/apt28-uses-lojax-first-uefi-rootkit-seen-in-the-wild/"
+          "https://www.bleepingcomputer.com/news/security/apt28-uses-lojax-first-uefi-rootkit-seen-in-the-wild/",
+          "https://www.accenture.com/us-en/blogs/blogs-snakemackerel-delivers-zekapab-malware"
         ],
         "synonyms": [
           "APT 28",
@@ -2110,6 +2111,7 @@
           "PawnStorm",
           "Fancy Bear",
           "Sednit",
+          "SNAKEMACKEREL",
           "TsarTeam",
           "Tsar Team",
           "TG-4127",


### PR DESCRIPTION
Accenture introduced another name for APT28 - Adding the MS alias YTTRIUM for APT29 while I'm at it. :)