### PR TITLE
Added missing actors from CrowdStrike GTR2019

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6251,7 +6251,107 @@
       },
       "uuid": "c79dab01-3f9f-491e-8a5f-6423339c9f76",
       "value": "Gallmaker"
+    },
+    {
+      "description": "Throughout 2018, CrowdStrike Intelligence tracked BOSS SPIDER as it regularly updated Samas ransomware and received payments to known Bitcoin (BTC) addresses. This consistent pace of activity came to an abrupt halt at the end of November 2018 when the U.S. DoJ released an indictment for Iran-based individuals Faramarz Shahi Savandi and Mohammad Mehdi Shah Mansouri, alleged members of the group.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "d6a13387-4c98-4a0c-a516-6c36c081b64c",
+      "value": "Boss Spider"
+    },
+    {
+      "description": "First observed in January 2018, GandCrab ransomware quickly began to proliferate and receive regular updates from its developer, PINCHY SPIDER, which over the course of the year established a RaaS operation with a dedicated set of affiliates.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "80f07c15-cad3-44a2-a8a4-dd14490b5117",
+      "value": "Pinchy Spider"
+    },
+    {
+      "description": "Early in 2018, CrowdStrike Intelligence observed GURU SPIDER supporting the distribution of multiple crimeware families through its flagship malware loader, Quant Loader.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "0a667713-bc31-4a72-9ea3-34fc094a9dde",
+      "value": "Guru Spider"
+    },
+    {
+      "description": "Beginning in January 2018 and persisting through the first half of the year, CrowdStrike Intelligence observed SALTY SPIDER, developer and operator of the long-running Sality botnet, distribute malware designed to target cryptocurrency users.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "7e37be6b-5a94-45f3-bdeb-f494c520eee3",
+      "value": "Salty Spider"
+    },
+    {
+      "description": "This adversary is suspected of continuing to target upstream providers (e.g., law firms and managed service providers) to support additional intrusions against high-profile assets. In 2018, CrowdStrike observed this adversary using spear-phishing, URL 'web bugs' and scheduled tasks to automate credential harvesting.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "d7a41ada-6687-4a6b-8b5c-396808cdd758",
+      "value": "Judgment Panda"
+    },
+    {
+      "description": "One of the first observed adopters of the 8.t exploit document builder in late 2017, further KRYPTONITE PANDA activity was limited in 2018. Last known activity for this adversary occurred in June 2018 and involved suspected targeting of Cambodia.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "393ebaad-4f05-4b35-bd31-45ac4ae7472d",
+      "value": "Kryptonite Panda"
+    },
+    {
+      "description": "In the first quarter of 2018, CrowdStrike Intelligence identified NOMAD PANDA activity targeting Central Asian nations with exploit documents built with the 8.t tool.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "4b7df353-fbcc-4f00-a54f-5121c5edb9be",
+      "value": "Nomad Panda"
+    },
+    {
+      "description": "This suspected Iran-based adversary conducted long-running SWC campaigns from December 2016 until public disclosure in July 2018. Like other Iran-based actors, the target scope for FLASH KITTEN appears to be focused on the MENA region.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "6e899dd4-f95e-42a0-a5a3-e57249f017cf",
+      "value": "Flash Kitten"
+    },
+    {
+      "description": "According to CrowdStrike, this actor is using FrameworkPOS, potentially buying access through Dridex infections.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "998b0a78-ff3e-4928-802f-b42e3f5cf491",
+      "value": "Skeleton Spider"
+    },
+    {
+      "description": "According to CrowdStrike, this actor is using TinyLoader and TinyPOS, potentially buying access through Dridex infections.",
+      "meta": {
+        "refs": [
+          "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
+        ]
+      },
+      "uuid": "89a05f9f-a6dc-4426-8c15-a8d5ef6d8524",
+      "value": "Tiny Spider"
     }
   ],
-  "version": 90
+  "version": 91
 }


### PR DESCRIPTION
I checked CrowdStrike's 2019 Global Threat Report for actor names currently not present in the actor directory and added them with the respective short descriptions from the report.