### PR TITLE
Add more info on Lotus Blossom

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -801,12 +801,15 @@
         "refs": [
           "https://securelist.com/blog/research/70726/the-spring-dragon-apt/",
           "https://securelist.com/spring-dragon-updated-activity/79067/",
-          "https://www.cfr.org/interactive/cyber-operations/lotus-blossom"
+          "https://www.cfr.org/interactive/cyber-operations/lotus-blossom",
+          "https://unit42.paloaltonetworks.com/operation-lotus-blossom/",
+          "https://www.accenture.com/t00010101T000000Z__w__/gb-en/_acnmedia/PDF-46/Accenture-Security-Elise-Threat-Analysis.pdf"
         ],
         "synonyms": [
           "Spring Dragon",
           "ST Group",
-          "Eslie"
+          "Esile",
+          "DRAGONFISH"
         ]
       },
       "related": [


### PR DESCRIPTION
Add 2 more references, fix typo - Trend calls it "Esile", not "Eslie" as mistakenly stated by CFR. The backdoor itself is commonly referred to as Elise.