### PR TITLE
Adding Amavaldo Banking Trojan

### DIFF
--- a/clusters/rat.json
+++ b/clusters/rat.json
@@ -3382,6 +3382,17 @@
       },
       "uuid": "0f117f50-9657-11e9-8e2b-83e391e0ce57",
       "value": "Felipe"
+    },
+    {
+      "description": "Amavaldo is banking trojan writen in Delphi and known to targeting Spanish or Portuguese speaking countries. It contains backdoor functionality and can work as multi stage. Amavaldo also abuses legitimate tools and softwares",
+      "meta": {
+        "date": "2019",
+        "refs": [
+          "https://www.welivesecurity.com/2019/08/01/banking-trojans-amavaldo/"
+        ]
+      },
+      "uuid": "39c65b1d-7799-43d6-a963-4a058b1c756e",
+      "value": "Amavaldo Banking Trojan"
     }
   ],
   "version": 30


### PR DESCRIPTION
Adding Amavaldo Banking Trojan to RAT Clusters.
External Reference Link: https://www.welivesecurity.com/2019/08/01/banking-trojans-amavaldo/