### PR TITLE
Remove some empty strings

### DIFF
--- a/clusters/exploit-kit.json
+++ b/clusters/exploit-kit.json
@@ -218,9 +218,6 @@
     {
       "description": "Taurus Builder is a tool used to generate malicious MS Word documents that contain macros. The kit is advertised on forums by the user \"badbullzvenom\". ",
       "meta": {
-        "refs": [
-          ""
-        ],
         "status": "Active"
       },
       "uuid": "63988ca2-46c8-4bda-be46-96a8670af357",

--- a/clusters/ransomware.json
+++ b/clusters/ransomware.json
@@ -12889,8 +12889,7 @@
           "read_me_for_recover_your_files.txt"
         ],
         "refs": [
-          "https://www.bleepingcomputer.com/news/security/the-week-in-ransomware-september-14th-2018-kraken-dharma-and-matrix/",
-          ""
+          "https://www.bleepingcomputer.com/news/security/the-week-in-ransomware-september-14th-2018-kraken-dharma-and-matrix/"
         ]
       },
       "uuid": "3675e50d-3f76-45f8-b3f3-4a645779e14d",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -7423,8 +7423,7 @@
       "meta": {
         "refs": [
           "https://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/the_luckycat_hackers.pdf",
-          "https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp_luckycat_redux.pdf",
-          ""
+          "https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp_luckycat_redux.pdf"
         ]
       },
       "uuid": "e502802e-8d0a-11e9-bd72-9f046529b3fd",
@@ -7683,9 +7682,6 @@
         "country": "CN",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2019/08/apt41-dual-espionage-and-cyber-crime-operation.html"
-        ],
-        "synonyms": [
-          ""
         ]
       },
       "uuid": "9c124874-042d-48cd-b72b-ccdc51ecbbd6",


### PR DESCRIPTION
I'm not sure if empty sections should also be removed, but the empty strings are an error quite sure. 

I came across them when using the threat actor data for [matching malware names](https://github.com/certtools/intelmq/blob/develop/contrib/malware_name_mapping/download_mapping.py#L89). And empty strings lead to regular expressing matching empty strings...