### PR TITLE
'SectorJ04 Group' as alias introduced by NSHC for TA505

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6914,7 +6914,11 @@
           "https://www.cybereason.com/blog/threat-actor-ta505-targets-financial-enterprises-using-lolbins-and-a-new-backdoor-malware",
           "https://e.cyberint.com/hubfs/Report%20Legit%20Remote%20Access%20Tools%20Turn%20Into%20Threat%20Actors%20Tools/CyberInt_Legit%20Remote%20Access%20Tools%20Turn%20Into%20Threat%20Actors'%20Tools_Report.pdf",
           "https://threatpost.com/ta505-servhelper-malware/140792/",
-          "https://blog.yoroi.company/research/the-stealthy-email-stealer-in-the-ta505-arsenal/"
+          "https://blog.yoroi.company/research/the-stealthy-email-stealer-in-the-ta505-arsenal/",
+          "https://threatrecon.nshc.net/2019/08/29/sectorj04-groups-increased-activity-in-2019/"
+        ],
+        "synonyms": [
+          "SectorJ04 Group"
         ]
       },
       "uuid": "03c80674-35f8-4fe0-be2b-226ed0fcd69f",
@@ -7701,5 +7705,5 @@
       "value": "APT41"
     }
   ],
-  "version": 129
+  "version": 130
 }


### PR DESCRIPTION
Not explicitly mentioned in the blog post but it looks like we just got an alias for TA505... https://threatrecon.nshc.net/2019/08/29/sectorj04-groups-increased-activity-in-2019/