### PR TITLE
fix: [misinfosec] fixed kill_chain fields

### DIFF
--- a/clusters/misinfosec-amitt-misinformation-technique.json
+++ b/clusters/misinfosec-amitt-misinformation-technique.json
@@ -14,7 +14,7 @@
       "meta": {
         "external_id": "T0001",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:strategic-planning"
+          "misinformation-tactics:Strategic Planning"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0001.md"
@@ -28,7 +28,7 @@
       "meta": {
         "external_id": "T0002",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:strategic-planning"
+          "misinformation-tactics:Strategic Planning"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0002.md"
@@ -42,7 +42,7 @@
       "meta": {
         "external_id": "T0003",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:strategic-planning"
+          "misinformation-tactics:Strategic Planning"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0003.md"
@@ -56,7 +56,7 @@
       "meta": {
         "external_id": "T0004",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:strategic-planning"
+          "misinformation-tactics:Strategic Planning"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0004.md"
@@ -70,7 +70,7 @@
       "meta": {
         "external_id": "T0005",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:objective-planning"
+          "misinformation-tactics:Objective Planning"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0005.md"
@@ -84,7 +84,7 @@
       "meta": {
         "external_id": "T0006",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:objective-planning"
+          "misinformation-tactics:Objective Planning"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0006.md"
@@ -98,7 +98,7 @@
       "meta": {
         "external_id": "T0007",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-people"
+          "misinformation-tactics:Develop People"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0007.md"
@@ -112,7 +112,7 @@
       "meta": {
         "external_id": "T0008",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-people"
+          "misinformation-tactics:Develop People"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0008.md"
@@ -126,7 +126,7 @@
       "meta": {
         "external_id": "T0009",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-people"
+          "misinformation-tactics:Develop People"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0009.md"
@@ -140,7 +140,7 @@
       "meta": {
         "external_id": "T0010",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-networks"
+          "misinformation-tactics:Develop Networks"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0010.md"
@@ -154,7 +154,7 @@
       "meta": {
         "external_id": "T0011",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-networks"
+          "misinformation-tactics:Develop Networks"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0011.md"
@@ -168,7 +168,7 @@
       "meta": {
         "external_id": "T0012",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-networks"
+          "misinformation-tactics:Develop Networks"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0012.md"
@@ -182,7 +182,7 @@
       "meta": {
         "external_id": "T0013",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-networks"
+          "misinformation-tactics:Develop Networks"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0013.md"
@@ -196,7 +196,7 @@
       "meta": {
         "external_id": "T0014",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-networks"
+          "misinformation-tactics:Develop Networks"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0014.md"
@@ -210,7 +210,7 @@
       "meta": {
         "external_id": "T0015",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-networks"
+          "misinformation-tactics:Develop Networks"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0015.md"
@@ -224,7 +224,7 @@
       "meta": {
         "external_id": "T0016",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:microtargeting"
+          "misinformation-tactics:Microtargeting"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0016.md"
@@ -238,7 +238,7 @@
       "meta": {
         "external_id": "T0017",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:microtargeting"
+          "misinformation-tactics:Microtargeting"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0017.md"
@@ -252,7 +252,7 @@
       "meta": {
         "external_id": "T0018",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:microtargeting"
+          "misinformation-tactics:Microtargeting"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0018.md"
@@ -266,7 +266,7 @@
       "meta": {
         "external_id": "T0019",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0019.md"
@@ -280,7 +280,7 @@
       "meta": {
         "external_id": "T0020",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0020.md"
@@ -294,7 +294,7 @@
       "meta": {
         "external_id": "T0021",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0021.md"
@@ -308,7 +308,7 @@
       "meta": {
         "external_id": "T0022",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0022.md"
@@ -322,7 +322,7 @@
       "meta": {
         "external_id": "T0023",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0023.md"
@@ -336,7 +336,7 @@
       "meta": {
         "external_id": "T0024",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0024.md"
@@ -350,7 +350,7 @@
       "meta": {
         "external_id": "T0025",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0025.md"
@@ -364,7 +364,7 @@
       "meta": {
         "external_id": "T0026",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0026.md"
@@ -378,7 +378,7 @@
       "meta": {
         "external_id": "T0027",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0027.md"
@@ -392,7 +392,7 @@
       "meta": {
         "external_id": "T0028",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:develop-content"
+          "misinformation-tactics:Develop Content"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0028.md"
@@ -406,7 +406,7 @@
       "meta": {
         "external_id": "T0029",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0029.md"
@@ -420,7 +420,7 @@
       "meta": {
         "external_id": "T0030",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0030.md"
@@ -434,7 +434,7 @@
       "meta": {
         "external_id": "T0031",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0031.md"
@@ -448,7 +448,7 @@
       "meta": {
         "external_id": "T0032",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0032.md"
@@ -462,7 +462,7 @@
       "meta": {
         "external_id": "T0033",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0033.md"
@@ -476,7 +476,7 @@
       "meta": {
         "external_id": "T0034",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0034.md"
@@ -490,7 +490,7 @@
       "meta": {
         "external_id": "T0035",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0035.md"
@@ -504,7 +504,7 @@
       "meta": {
         "external_id": "T0036",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0036.md"
@@ -518,7 +518,7 @@
       "meta": {
         "external_id": "T0037",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0037.md"
@@ -532,7 +532,7 @@
       "meta": {
         "external_id": "T0038",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:channel-selection"
+          "misinformation-tactics:Channel Selection"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0038.md"
@@ -546,7 +546,7 @@
       "meta": {
         "external_id": "T0039",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0039.md"
@@ -560,7 +560,7 @@
       "meta": {
         "external_id": "T0040",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0040.md"
@@ -574,7 +574,7 @@
       "meta": {
         "external_id": "T0041",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0041.md"
@@ -588,7 +588,7 @@
       "meta": {
         "external_id": "T0042",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0042.md"
@@ -602,7 +602,7 @@
       "meta": {
         "external_id": "T0043",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0043.md"
@@ -616,7 +616,7 @@
       "meta": {
         "external_id": "T0044",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0044.md"
@@ -630,7 +630,7 @@
       "meta": {
         "external_id": "T0045",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0045.md"
@@ -644,7 +644,7 @@
       "meta": {
         "external_id": "T0046",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:pump-priming"
+          "misinformation-tactics:Pump Priming"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0046.md"
@@ -658,7 +658,7 @@
       "meta": {
         "external_id": "T0047",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0047.md"
@@ -672,7 +672,7 @@
       "meta": {
         "external_id": "T0048",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0048.md"
@@ -686,7 +686,7 @@
       "meta": {
         "external_id": "T0049",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0049.md"
@@ -700,7 +700,7 @@
       "meta": {
         "external_id": "T0050",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0050.md"
@@ -714,7 +714,7 @@
       "meta": {
         "external_id": "T0051",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0051.md"
@@ -728,7 +728,7 @@
       "meta": {
         "external_id": "T0052",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0052.md"
@@ -742,7 +742,7 @@
       "meta": {
         "external_id": "T0053",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0053.md"
@@ -756,7 +756,7 @@
       "meta": {
         "external_id": "T0054",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0054.md"
@@ -770,7 +770,7 @@
       "meta": {
         "external_id": "T0055",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0055.md"
@@ -784,7 +784,7 @@
       "meta": {
         "external_id": "T0056",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:exposure"
+          "misinformation-tactics:Exposure"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0056.md"
@@ -798,7 +798,7 @@
       "meta": {
         "external_id": "T0057",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:go-physical"
+          "misinformation-tactics:Go Physical"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0057.md"
@@ -812,7 +812,7 @@
       "meta": {
         "external_id": "T0058",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:persistence"
+          "misinformation-tactics:Persistence"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0058.md"
@@ -826,7 +826,7 @@
       "meta": {
         "external_id": "T0059",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:persistence"
+          "misinformation-tactics:Persistence"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0059.md"
@@ -840,7 +840,7 @@
       "meta": {
         "external_id": "T0060",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:persistence"
+          "misinformation-tactics:Persistence"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0060.md"
@@ -854,7 +854,7 @@
       "meta": {
         "external_id": "T0061",
         "kill_chain": [
-          "misinfosec:misinformation-tactics:go-physical"
+          "misinformation-tactics:Go Physical"
         ],
         "refs": [
           "https://github.com/misinfosecproject/amitt_framework/blob/master/techniques/T0061.md"
@@ -864,5 +864,5 @@
       "value": "Sell merchandising"
     }
   ],
-  "version": 3
+  "version": 4
 }

--- a/galaxies/misinfosec-amitt-misinformation-pattern.json
+++ b/galaxies/misinfosec-amitt-misinformation-pattern.json
@@ -21,5 +21,5 @@
   "namespace": "misinfosec",
   "type": "amitt-misinformation-pattern",
   "uuid": "4d381145-9a5e-4778-918c-fbf23d78544e",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
The ``kill_chain`` connector in the *cluster* json is not linked to the tag, it is only linked with the ``tab`` and the ``column`` defined in the ``kill_chain_order`` key in the *galaxy* json.