### PR TITLE
Kimsuki -> Black Banshee

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -5163,11 +5163,13 @@
         "country": "KP",
         "refs": [
           "https://securelist.com/the-kimsuky-operation-a-north-korean-apt/57915/",
-          "https://www.cfr.org/interactive/cyber-operations/kimsuky"
+          "https://www.cfr.org/interactive/cyber-operations/kimsuky",
+          "https://www.pwc.co.uk/issues/cyber-security-data-privacy/research/tracking-kimsuky-north-korea-based-cyber-espionage-group-part-2.html"
         ],
         "synonyms": [
           "Kimsuky",
-          "Velvet Chollima"
+          "Velvet Chollima",
+          "Black Banshee"
         ]
       },
       "uuid": "bcaaad6f-0597-4b89-b69b-84a6be2b7bc3",


### PR DESCRIPTION
PWC refers to Kimsuki as Black Banshee (https://www.pwc.co.uk/issues/cyber-security-data-privacy/research/tracking-kimsuky-north-korea-based-cyber-espionage-group-part-2.html)