### PR TITLE
Update threat-actor.json

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1400,6 +1400,7 @@
         "synonyms": [
           "IceFog",
           "Dagger Panda"
+          "Trident"
         ]
       },
       "uuid": "32c534b9-abec-4823-b223-a810f897b47b",


### PR DESCRIPTION
Added on line 1403: Trident per campaign malicious RTF documents to exploit CVE-2017-11882 and CVE-2012-0158