### PR TITLE
Adding alias Thallium and merging STOLEN PENCIL

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -5148,16 +5148,22 @@
         "refs": [
           "https://securelist.com/the-kimsuky-operation-a-north-korean-apt/57915/",
           "https://www.cfr.org/interactive/cyber-operations/kimsuky",
-          "https://www.pwc.co.uk/issues/cyber-security-data-privacy/research/tracking-kimsuky-north-korea-based-cyber-espionage-group-part-2.html"
+          "https://www.pwc.co.uk/issues/cyber-security-data-privacy/research/tracking-kimsuky-north-korea-based-cyber-espionage-group-part-2.html",
+          "https://youtu.be/hAsKp43AZmM?t=1027",
+          "https://www.bloomberglaw.com/document/public/subdoc/X67FPNDOUBV9VOPS35A4864BFIU?imagename=1",
+          "https://www.netscout.com/blog/asert/stolen-pencil-campaign-targets-academia",
+          "https://unit42.paloaltonetworks.com/new-babyshark-malware-targets-u-s-national-security-think-tanks/",
+          "https://attack.mitre.org/groups/G0086/"
         ],
         "synonyms": [
-          "Kimsuky",
           "Velvet Chollima",
-          "Black Banshee"
+          "Black Banshee",
+          "Thallium",
+          "Operation Stolen Pencil"
         ]
       },
       "uuid": "bcaaad6f-0597-4b89-b69b-84a6be2b7bc3",
-      "value": "Kimsuki"
+      "value": "Kimsuky"
     },
     {
       "description": "While investigating some of the smaller name servers that APT28/Sofacy routinely use to host their infrastructure, Cylance discovered another prolonged campaign that appeared to exclusively target Japanese companies and individuals that began around August 2016. The later registration style was eerily close to previously registered APT28 domains, however, the malware used in the attacks did not seem to line up at all. During the course of our investigation, JPCERT published this analysis of one of the group’s backdoors. Cylance tracks this threat group internally as ‘Snake Wine’.\nThe Snake Wine group has proven to be highly adaptable and has continued to adopt new tactics in order to establish footholds inside victim environments. The exclusive interest in Japanese government, education, and commerce will likely continue into the future as the group is just starting to build and utilize their existing current attack infrastructure.",
@@ -7194,19 +7200,6 @@
       },
       "uuid": "ec3fda76-8c1c-4019-8109-3f92e6b15633",
       "value": "Ratpak Spider"
-    },
-    {
-      "description": "ASERT has learned of an APT campaign, possibly originating from DPRK, we are calling STOLEN PENCIL that is targeting academic institutions since at least May 2018.",
-      "meta": {
-        "refs": [
-          "https://asert.arbornetworks.com/stolen-pencil-campaign-targets-academia/",
-          "https://unit42.paloaltonetworks.com/new-babyshark-malware-targets-u-s-national-security-think-tanks/",
-          "https://www.netscout.com/blog/asert/stolen-pencil-campaign-targets-academia",
-          "https://attack.mitre.org/groups/G0086/"
-        ]
-      },
-      "uuid": "769aeaa6-d193-4e90-a818-d74c6ff7b845",
-      "value": "STOLEN PENCIL"
     },
     {
       "meta": {


### PR DESCRIPTION
Pretty much confirmed from the Crowdstrike talk at **ATT&CKon 2.0**, also Netscout named the campaign as STOLEN PENCIL. And community preferred _"y" over "i"_. :)
Thanks to [Matt Dahl](https://twitter.com/voodoodahl1) for ref to complaint.