### PR TITLE
Remove Roaming Mantis

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6803,19 +6803,6 @@
       "value": "FASTCash"
     },
     {
-      "description": "According to new research by Kaspersky's GReAT team, the online criminal activities of the Roaming Mantis Group have continued to evolve since they were first discovered in April 2018. As part of their activities, this group hacks into exploitable routers and changes their DNS configuration. This allows the attackers to redirect the router user's traffic to malicious Android apps disguised as Facebook and Chrome or to Apple phishing pages that were used to steal Apple ID credentials.\nRecently, Kaspersky has discovered that this group is testing a new monetization scheme by redirecting iOS users to pages that contain the Coinhive in-browser mining script rather than the normal Apple phishing page. When users are redirected to these pages, they will be shown a blank page in the browser, but their CPU utilization will jump to 90% or higher.",
-      "meta": {
-        "refs": [
-          "https://www.bleepingcomputer.com/news/security/roaming-mantis-group-testing-coinhive-miner-redirects-on-iphones/"
-        ],
-        "synonyms": [
-          "Roaming Mantis Group"
-        ]
-      },
-      "uuid": "b27beb94-ce25-11e8-8e11-2f1a59bd0e91",
-      "value": "Roaming Mantis"
-    },
-    {
       "description": "ESET research reveals a successor to the infamous BlackEnergy APT group targeting critical infrastructure, quite possibly in preparation for damaging attacks",
       "meta": {
         "refs": [


### PR DESCRIPTION
Remove Roaming Mantis from threat-actor definitions because Roaming Mantis is not a name of a group / an actor