### PR TITLE
adding Kaspersky's name for Microcin.

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -5658,7 +5658,13 @@
       "meta": {
         "refs": [
           "https://securelist.com/a-simple-example-of-a-complex-cyberattack/82636/",
-          "https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07170759/Microcin_Technical_4PDF_eng_final_s.pdf"
+          "https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07170759/Microcin_Technical_4PDF_eng_final_s.pdf",
+          "https://securelist.com/apt-trends-report-q2-2019/91897/",
+          "https://www.welivesecurity.com/2020/05/14/mikroceen-spying-backdoor-high-profile-networks-central-asia/",
+          "https://decoded.avast.io/luigicamastra/apt-group-planted-backdoors-targeting-high-profile-networks-in-central-asia/"
+        ],
+        "synonyms": [
+          "SixLittleMonkeys"
         ]
       },
       "uuid": "0a6b31cd-54cd-4f82-9b87-aab780604632",


### PR DESCRIPTION
name as listed in https://securelist.com/apt-trends-report-q2-2019/91897/ - additionally adding refs from ESET and Avast.