### PR TITLE
Changed links for revoked Att&ck techniques to v6 permalinks

### DIFF
--- a/clusters/mitre-attack-pattern.json
+++ b/clusters/mitre-attack-pattern.json
@@ -860,7 +860,7 @@
       "meta": {
         "external_id": "CAPEC-270",
         "refs": [
-          "https://attack.mitre.org/techniques/T1060",
+          "https://attack.mitre.org/versions/v6/techniques/T1060",
           "https://capec.mitre.org/data/definitions/270.html",
           "http://msdn.microsoft.com/en-us/library/aa376977",
           "https://support.microsoft.com/help/310593/description-of-the-runonceex-registry-key",
@@ -2218,7 +2218,7 @@
       "meta": {
         "external_id": "T1084",
         "refs": [
-          "https://attack.mitre.org/techniques/T1084",
+          "https://attack.mitre.org/versions/v6/techniques/T1084",
           "https://www.secureworks.com/blog/wmi-persistence",
           "https://www.defcon.org/images/defcon-22/dc-22-presentations/Kazanciyan-Hastings/DEFCON-22-Ryan-Kazanciyan-Matt-Hastings-Investigating-Powershell-Attacks.pdf",
           "https://www2.fireeye.com/rs/fireye/images/rpt-m-trends-2015.pdf",
@@ -2243,7 +2243,7 @@
       "meta": {
         "external_id": "T1094",
         "refs": [
-          "https://attack.mitre.org/techniques/T1094",
+          "https://attack.mitre.org/versions/v6/techniques/T1094",
           "https://arxiv.org/ftp/arxiv/papers/1408/1408.1136.pdf"
         ]
       },
@@ -2309,7 +2309,7 @@
       "meta": {
         "external_id": "T1183",
         "refs": [
-          "https://attack.mitre.org/techniques/T1183",
+          "https://attack.mitre.org/versions/v6/techniques/T1183",
           "https://blogs.msdn.microsoft.com/mithuns/2010/03/24/image-file-execution-options-ifeo/",
           "https://docs.microsoft.com/windows-hardware/drivers/debugger/gflags-overview",
           "https://docs.microsoft.com/windows-hardware/drivers/debugger/registry-entries-for-silent-process-exit",
@@ -2336,7 +2336,7 @@
       "meta": {
         "external_id": "T1198",
         "refs": [
-          "https://attack.mitre.org/techniques/T1198",
+          "https://attack.mitre.org/versions/v6/techniques/T1198",
           "https://msdn.microsoft.com/library/ms537359.aspx",
           "https://msdn.microsoft.com/library/windows/desktop/aa388208.aspx",
           "https://specterops.io/assets/resources/SpecterOps_Subverting_Trust_in_Windows.pdf",
@@ -3032,7 +3032,7 @@
       "meta": {
         "external_id": "T1171",
         "refs": [
-          "https://attack.mitre.org/techniques/T1171",
+          "https://attack.mitre.org/versions/v6/techniques/T1171",
           "https://en.wikipedia.org/wiki/Link-Local_Multicast_Name_Resolution",
           "https://technet.microsoft.com/library/cc958811.aspx",
           "https://byt3bl33d3r.github.io/practical-guide-to-ntlm-relaying-in-2017-aka-getting-a-foothold-in-under-5-minutes.html",
@@ -4370,7 +4370,7 @@
       "meta": {
         "external_id": "CAPEC-556",
         "refs": [
-          "https://attack.mitre.org/techniques/T1042",
+          "https://attack.mitre.org/versions/v6/techniques/T1042",
           "https://capec.mitre.org/data/definitions/556.html",
           "https://support.microsoft.com/en-us/help/18539/windows-7-change-default-programs",
           "http://msdn.microsoft.com/en-us/library/bb166549.aspx",
@@ -4543,7 +4543,7 @@
       "meta": {
         "external_id": "T1503",
         "refs": [
-          "https://attack.mitre.org/techniques/T1503",
+          "https://attack.mitre.org/versions/v6/techniques/T1503",
           "https://blog.talosintelligence.com/2018/02/olympic-destroyer.html",
           "https://docs.microsoft.com/en-us/windows/desktop/api/dpapi/nf-dpapi-cryptunprotectdata",
           "https://www.proofpoint.com/us/threat-insight/post/new-vega-stealer-shines-brightly-targeted-campaign",
@@ -4593,7 +4593,7 @@
       "meta": {
         "external_id": "CAPEC-471",
         "refs": [
-          "https://attack.mitre.org/techniques/T1038",
+          "https://attack.mitre.org/versions/v6/techniques/T1038",
           "https://capec.mitre.org/data/definitions/471.html",
           "http://msdn.microsoft.com/en-US/library/ms682586",
           "https://www.owasp.org/index.php/Binary_planting",
@@ -4654,7 +4654,7 @@
       "meta": {
         "external_id": "CAPEC-17",
         "refs": [
-          "https://attack.mitre.org/techniques/T1044",
+          "https://attack.mitre.org/versions/v6/techniques/T1044",
           "https://capec.mitre.org/data/definitions/17.html",
           "https://www.mozilla.org/en-US/security/advisories/mfsa2012-98/",
           "http://seclists.org/fulldisclosure/2015/Dec/34"
@@ -4828,7 +4828,7 @@
       "meta": {
         "external_id": "CAPEC-478",
         "refs": [
-          "https://attack.mitre.org/techniques/T1058",
+          "https://attack.mitre.org/versions/v6/techniques/T1058",
           "https://capec.mitre.org/data/definitions/478.html",
           "https://msdn.microsoft.com/library/windows/desktop/ms724878.aspx",
           "https://trustedsignal.blogspot.com/2014/05/kansa-service-related-collectors-and.html",
@@ -4878,7 +4878,7 @@
       "meta": {
         "external_id": "T1066",
         "refs": [
-          "https://attack.mitre.org/techniques/T1066"
+          "https://attack.mitre.org/versions/v6/techniques/T1066"
         ]
       },
       "related": [
@@ -4922,7 +4922,7 @@
       "meta": {
         "external_id": "T1088",
         "refs": [
-          "https://attack.mitre.org/techniques/T1088",
+          "https://attack.mitre.org/versions/v6/techniques/T1088",
           "https://technet.microsoft.com/en-us/itpro/windows/keep-secure/how-user-account-control-works",
           "https://technet.microsoft.com/en-US/magazine/2009.07.uac.aspx",
           "https://msdn.microsoft.com/en-us/library/ms679687.aspx",
@@ -4976,7 +4976,7 @@
       "meta": {
         "external_id": "T1181",
         "refs": [
-          "https://attack.mitre.org/techniques/T1181",
+          "https://attack.mitre.org/versions/v6/techniques/T1181",
           "https://msdn.microsoft.com/library/windows/desktop/ms633574.aspx",
           "https://msdn.microsoft.com/library/windows/desktop/ms633584.aspx",
           "https://msdn.microsoft.com/library/windows/desktop/ms633591.aspx",
@@ -5029,7 +5029,7 @@
       "meta": {
         "external_id": "T1122",
         "refs": [
-          "https://attack.mitre.org/techniques/T1122",
+          "https://attack.mitre.org/versions/v6/techniques/T1122",
           "https://msdn.microsoft.com/library/ms694363.aspx",
           "https://blog.gdatasoftware.com/2014/10/23941-com-object-hijacking-the-discreet-way-of-persistence",
           "https://www.elastic.co/blog/how-hunt-detecting-persistence-evasion-com"
@@ -5106,7 +5106,7 @@
       "meta": {
         "external_id": "T1215",
         "refs": [
-          "https://attack.mitre.org/techniques/T1215",
+          "https://attack.mitre.org/versions/v6/techniques/T1215",
           "https://www.tldp.org/LDP/lkmpg/2.4/lkmpg.pdf",
           "http://www.tldp.org/LDP/lkmpg/2.4/html/x437.html",
           "https://volatility-labs.blogspot.com/2012/10/phalanx-2-revealed-using-volatility-to.html",
@@ -5138,7 +5138,7 @@
       "meta": {
         "external_id": "T1126",
         "refs": [
-          "https://attack.mitre.org/techniques/T1126",
+          "https://attack.mitre.org/versions/v6/techniques/T1126",
           "https://technet.microsoft.com/bb490717.aspx"
         ]
       },
@@ -5265,7 +5265,7 @@
       "meta": {
         "external_id": "T1514",
         "refs": [
-          "https://attack.mitre.org/techniques/T1514",
+          "https://attack.mitre.org/versions/v6/techniques/T1514",
           "https://developer.apple.com/documentation/security/1540038-authorizationexecutewithprivileg",
           "https://speakerdeck.com/patrickwardle/defcon-2017-death-by-1000-installers-its-all-broken?slide=8",
           "https://www.carbonblack.com/2019/02/12/tau-threat-intelligence-notification-new-macos-malware-variant-of-shlayer-osx-discovered/",
@@ -5334,7 +5334,7 @@
       "meta": {
         "external_id": "T1158",
         "refs": [
-          "https://attack.mitre.org/techniques/T1158",
+          "https://attack.mitre.org/versions/v6/techniques/T1158",
           "https://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/",
           "https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/",
           "https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/pdf/reports/Unit_42/unit42-wirelurker.pdf"
@@ -5377,7 +5377,7 @@
       "meta": {
         "external_id": "T1522",
         "refs": [
-          "https://attack.mitre.org/techniques/T1522",
+          "https://attack.mitre.org/versions/v6/techniques/T1522",
           "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html",
           "https://redlock.io/blog/instance-metadata-api-a-modern-day-trojan-horse"
         ]
@@ -6411,7 +6411,7 @@
       "meta": {
         "external_id": "T1156",
         "refs": [
-          "https://attack.mitre.org/techniques/T1156",
+          "https://attack.mitre.org/versions/v6/techniques/T1156",
           "https://researchcenter.paloaltonetworks.com/2017/04/unit42-new-iotlinux-malware-targets-dvrs-forms-botnet/"
         ]
       },
@@ -9146,7 +9146,7 @@
       "meta": {
         "external_id": "CAPEC-579",
         "refs": [
-          "https://attack.mitre.org/techniques/T1004",
+          "https://attack.mitre.org/versions/v6/techniques/T1004",
           "https://capec.mitre.org/data/definitions/579.html",
           "https://blog.cylance.com/windows-registry-persistence-part-2-the-run-keys-and-search-order",
           "https://technet.microsoft.com/en-us/sysinternals/bb963902"
@@ -9192,7 +9192,7 @@
       "meta": {
         "external_id": "T1500",
         "refs": [
-          "https://attack.mitre.org/techniques/T1500",
+          "https://attack.mitre.org/versions/v6/techniques/T1500",
           "https://www.clearskysec.com/wp-content/uploads/2018/11/MuddyWater-Operations-in-Lebanon-and-Oman.pdf",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/windows-app-runs-on-mac-downloads-info-stealer-and-adware/"
         ]
@@ -9281,7 +9281,7 @@
       "meta": {
         "external_id": "T1101",
         "refs": [
-          "https://attack.mitre.org/techniques/T1101",
+          "https://attack.mitre.org/versions/v6/techniques/T1101",
           "http://docplayer.net/20839173-Analysis-of-malicious-security-support-provider-dlls.html",
           "https://technet.microsoft.com/en-us/library/dn408187.aspx"
         ]
@@ -9367,7 +9367,7 @@
       "meta": {
         "external_id": "CAPEC-479",
         "refs": [
-          "https://attack.mitre.org/techniques/T1130",
+          "https://attack.mitre.org/versions/v6/techniques/T1130",
           "https://capec.mitre.org/data/definitions/479.html",
           "https://en.wikipedia.org/wiki/Root_certificate",
           "http://www.trendmicro.com/cloud-content/us/pdfs/security-intelligence/white-papers/wp-finding-holes-operation-emmental.pdf",
@@ -9395,7 +9395,7 @@
       "meta": {
         "external_id": "CAPEC-551",
         "refs": [
-          "https://attack.mitre.org/techniques/T1031",
+          "https://attack.mitre.org/versions/v6/techniques/T1031",
           "https://capec.mitre.org/data/definitions/551.html",
           "https://twitter.com/r0wdy_/status/936365549553991680",
           "https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc753662(v=ws.11)",
@@ -9474,7 +9474,7 @@
       "meta": {
         "external_id": "CAPEC-187",
         "refs": [
-          "https://attack.mitre.org/techniques/T1017",
+          "https://attack.mitre.org/versions/v6/techniques/T1017",
           "https://capec.mitre.org/data/definitions/187.html"
         ]
       },
@@ -9523,7 +9523,7 @@
       "meta": {
         "external_id": "CAPEC-639",
         "refs": [
-          "https://attack.mitre.org/techniques/T1081",
+          "https://attack.mitre.org/versions/v6/techniques/T1081",
           "https://capec.mitre.org/data/definitions/639.html",
           "http://carnal0wnage.attackresearch.com/2014/05/mimikatz-against-virtual-machine-memory.html",
           "http://blogs.technet.com/b/srd/archive/2014/05/13/ms14-025-an-update-for-group-policy-preferences.aspx",
@@ -9639,7 +9639,7 @@
       "meta": {
         "external_id": "T1032",
         "refs": [
-          "https://attack.mitre.org/techniques/T1032",
+          "https://attack.mitre.org/versions/v6/techniques/T1032",
           "http://www.sans.org/reading-room/whitepapers/analyst/finding-hidden-threats-decrypting-ssl-34840",
           "https://insights.sei.cmu.edu/cert/2015/03/the-risks-of-ssl-inspection.html",
           "https://www.fidelissecurity.com/sites/default/files/FTA_1018_looking_at_the_sky_for_a_dark_comet.pdf",
@@ -9677,7 +9677,7 @@
       "meta": {
         "external_id": "T1024",
         "refs": [
-          "https://attack.mitre.org/techniques/T1024",
+          "https://attack.mitre.org/versions/v6/techniques/T1024",
           "https://www.f-secure.com/documents/996508/1030745/cosmicduke_whitepaper.pdf",
           "https://www.fidelissecurity.com/sites/default/files/FTA_1018_looking_at_the_sky_for_a_dark_comet.pdf",
           "https://arxiv.org/ftp/arxiv/papers/1408/1408.1136.pdf"
@@ -9720,7 +9720,7 @@
       "meta": {
         "external_id": "T1502",
         "refs": [
-          "https://attack.mitre.org/techniques/T1502",
+          "https://attack.mitre.org/versions/v6/techniques/T1502",
           "https://blog.didierstevens.com/2009/11/22/quickpost-selectmyparent-or-playing-with-the-windows-process-tree/",
           "https://docs.microsoft.com/windows/security/identity-protection/user-account-control/how-user-account-control-works",
           "https://www.countercept.com/blog/detecting-parent-pid-spoofing/",
@@ -9837,7 +9837,7 @@
       "meta": {
         "external_id": "CAPEC-555",
         "refs": [
-          "https://attack.mitre.org/techniques/T1028",
+          "https://attack.mitre.org/versions/v6/techniques/T1028",
           "https://capec.mitre.org/data/definitions/555.html",
           "http://msdn.microsoft.com/en-us/library/aa384426",
           "https://www.slideshare.net/kieranjacobsen/lateral-movement-with-power-shell-2",
@@ -9901,7 +9901,7 @@
       "meta": {
         "external_id": "T1063",
         "refs": [
-          "https://attack.mitre.org/techniques/T1063"
+          "https://attack.mitre.org/versions/v6/techniques/T1063"
         ]
       },
       "related": [
@@ -10115,7 +10115,7 @@
       "meta": {
         "external_id": "T1506",
         "refs": [
-          "https://attack.mitre.org/techniques/T1506",
+          "https://attack.mitre.org/versions/v6/techniques/T1506",
           "https://wunderwuzzi23.github.io/blog/passthecookie.html",
           "https://unit42.paloaltonetworks.com/mac-malware-steals-cryptocurrency-exchanges-cookies/"
         ]
@@ -10137,7 +10137,7 @@
       "meta": {
         "external_id": "T1065",
         "refs": [
-          "https://attack.mitre.org/techniques/T1065",
+          "https://attack.mitre.org/versions/v6/techniques/T1065",
           "https://arxiv.org/ftp/arxiv/papers/1408/1408.1136.pdf"
         ]
       },
@@ -10175,7 +10175,7 @@
       "meta": {
         "external_id": "CAPEC-644",
         "refs": [
-          "https://attack.mitre.org/techniques/T1075",
+          "https://attack.mitre.org/versions/v6/techniques/T1075",
           "https://capec.mitre.org/data/definitions/644.html",
           "https://apps.nsa.gov/iaarchive/library/reports/spotting-the-adversary-with-windows-event-log-monitoring.cfm"
         ]
@@ -10263,7 +10263,7 @@
       "meta": {
         "external_id": "CAPEC-555",
         "refs": [
-          "https://attack.mitre.org/techniques/T1076",
+          "https://attack.mitre.org/versions/v6/techniques/T1076",
           "https://capec.mitre.org/data/definitions/555.html",
           "https://technet.microsoft.com/en-us/windowsserver/ee236407.aspx",
           "http://blog.crowdstrike.com/adversary-tricks-crowdstrike-treats/",
@@ -10289,7 +10289,7 @@
       "meta": {
         "external_id": "T1096",
         "refs": [
-          "https://attack.mitre.org/techniques/T1096",
+          "https://attack.mitre.org/versions/v6/techniques/T1096",
           "https://posts.specterops.io/host-based-threat-modeling-indicator-design-a9dbbb53d5ea",
           "https://blogs.technet.microsoft.com/askcore/2010/08/25/ntfs-file-attributes/",
           "http://msdn.microsoft.com/en-us/library/aa364404",
@@ -10351,7 +10351,7 @@
       "meta": {
         "external_id": "CAPEC-561",
         "refs": [
-          "https://attack.mitre.org/techniques/T1077",
+          "https://attack.mitre.org/versions/v6/techniques/T1077",
           "https://capec.mitre.org/data/definitions/561.html",
           "https://en.wikipedia.org/wiki/Server_Message_Block",
           "https://technet.microsoft.com/en-us/library/cc787851.aspx",
@@ -10379,7 +10379,7 @@
       "meta": {
         "external_id": "CAPEC-645",
         "refs": [
-          "https://attack.mitre.org/techniques/T1097",
+          "https://attack.mitre.org/versions/v6/techniques/T1097",
           "https://capec.mitre.org/data/definitions/645.html",
           "https://adsecurity.org/?p=556",
           "http://blog.gentilkiwi.com/securite/mimikatz/pass-the-ticket-kerberos",
@@ -10404,7 +10404,7 @@
       "meta": {
         "external_id": "CAPEC-578",
         "refs": [
-          "https://attack.mitre.org/techniques/T1089",
+          "https://attack.mitre.org/versions/v6/techniques/T1089",
           "https://capec.mitre.org/data/definitions/578.html"
         ]
       },
@@ -10425,7 +10425,7 @@
       "meta": {
         "external_id": "CAPEC-649",
         "refs": [
-          "https://attack.mitre.org/techniques/T1151",
+          "https://attack.mitre.org/versions/v6/techniques/T1151",
           "https://capec.mitre.org/data/definitions/649.html",
           "https://arstechnica.com/security/2016/07/after-hiatus-in-the-wild-mac-backdoors-are-suddenly-back/"
         ]
@@ -10480,7 +10480,7 @@
       "meta": {
         "external_id": "T1214",
         "refs": [
-          "https://attack.mitre.org/techniques/T1214",
+          "https://attack.mitre.org/versions/v6/techniques/T1214",
           "https://pentestlab.blog/2017/04/19/stored-credentials/"
         ]
       },
@@ -10584,7 +10584,7 @@
       "meta": {
         "external_id": "T1128",
         "refs": [
-          "https://attack.mitre.org/techniques/T1128",
+          "https://attack.mitre.org/versions/v6/techniques/T1128",
           "https://technet.microsoft.com/library/bb490939.aspx",
           "https://htmlpreview.github.io/?https://github.com/MatthewDemaske/blogbackup/blob/master/netshell.html",
           "https://github.com/outflankbv/NetshHelperBeacon"
@@ -10796,7 +10796,7 @@
       "meta": {
         "external_id": "T1173",
         "refs": [
-          "https://attack.mitre.org/techniques/T1173",
+          "https://attack.mitre.org/versions/v6/techniques/T1173",
           "https://www.bleepingcomputer.com/news/microsoft/microsoft-disables-dde-feature-in-word-to-prevent-further-malware-attacks/",
           "https://portal.msrc.microsoft.com/security-guidance/advisory/ADV170021",
           "https://technet.microsoft.com/library/security/4053440",
@@ -10927,7 +10927,7 @@
       "meta": {
         "external_id": "T1146",
         "refs": [
-          "https://attack.mitre.org/techniques/T1146"
+          "https://attack.mitre.org/versions/v6/techniques/T1146"
         ]
       },
       "related": [
@@ -10947,7 +10947,7 @@
       "meta": {
         "external_id": "T1174",
         "refs": [
-          "https://attack.mitre.org/techniques/T1174",
+          "https://attack.mitre.org/versions/v6/techniques/T1174",
           "http://carnal0wnage.attackresearch.com/2013/09/stealing-passwords-every-time-they.html",
           "https://clymb3r.wordpress.com/2013/09/15/intercepting-password-changes-with-function-hooking/"
         ]
@@ -10982,7 +10982,7 @@
       "meta": {
         "external_id": "CAPEC-163",
         "refs": [
-          "https://attack.mitre.org/techniques/T1194",
+          "https://attack.mitre.org/versions/v6/techniques/T1194",
           "https://capec.mitre.org/data/definitions/163.html"
         ]
       },
@@ -11036,7 +11036,7 @@
       "meta": {
         "external_id": "T1166",
         "refs": [
-          "https://attack.mitre.org/techniques/T1166",
+          "https://attack.mitre.org/versions/v6/techniques/T1166",
           "http://man7.org/linux/man-pages/man2/setuid.2.html",
           "https://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials/"
         ]
@@ -11058,7 +11058,7 @@
       "meta": {
         "external_id": "T1168",
         "refs": [
-          "https://attack.mitre.org/techniques/T1168",
+          "https://attack.mitre.org/versions/v6/techniques/T1168",
           "https://linux.die.net/man/5/crontab",
           "https://linux.die.net/man/1/at",
           "https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/ScheduledJobs.html",
@@ -11085,7 +11085,7 @@
       "meta": {
         "external_id": "T1196",
         "refs": [
-          "https://attack.mitre.org/techniques/T1196",
+          "https://attack.mitre.org/versions/v6/techniques/T1196",
           "https://msdn.microsoft.com/library/windows/desktop/cc144185.aspx",
           "https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp-cpl-malware.pdf",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/control-panel-files-used-as-malicious-attachments/",
@@ -11123,7 +11123,7 @@
       "meta": {
         "external_id": "T1223",
         "refs": [
-          "https://attack.mitre.org/techniques/T1223",
+          "https://attack.mitre.org/versions/v6/techniques/T1223",
           "https://docs.microsoft.com/previous-versions/windows/desktop/htmlhelp/microsoft-html-help-1-4-sdk",
           "https://msdn.microsoft.com/windows/desktop/ms644670",
           "https://msdn.microsoft.com/windows/desktop/ms524405",
@@ -11587,7 +11587,7 @@
       "meta": {
         "external_id": "T1492",
         "refs": [
-          "https://attack.mitre.org/techniques/T1492",
+          "https://attack.mitre.org/versions/v6/techniques/T1492",
           "https://content.fireeye.com/apt/rpt-apt38",
           "https://www.justice.gov/opa/press-release/file/1092091/download"
         ]
@@ -11696,7 +11696,7 @@
       "meta": {
         "external_id": "T1527",
         "refs": [
-          "https://attack.mitre.org/techniques/T1527",
+          "https://attack.mitre.org/versions/v6/techniques/T1527",
           "https://auth0.com/blog/why-should-use-accesstokens-to-secure-an-api/",
           "https://developer.okta.com/blog/2018/06/20/what-happens-if-your-jwt-is-stolen",
           "https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens",
@@ -12000,7 +12000,7 @@
       "meta": {
         "external_id": "T1483",
         "refs": [
-          "https://attack.mitre.org/techniques/T1483",
+          "https://attack.mitre.org/versions/v6/techniques/T1483",
           "http://go.cybereason.com/rs/996-YZT-709/images/Cybereason-Lab-Analysis-Dissecting-DGAs-Eight-Real-World-DGA-Variants.pdf",
           "https://umbrella.cisco.com/blog/2016/10/10/domain-generation-algorithms-effective/",
           "https://unit42.paloaltonetworks.com/threat-brief-understanding-domain-generation-algorithms-dga/",
@@ -12050,7 +12050,7 @@
       "meta": {
         "external_id": "T1493",
         "refs": [
-          "https://attack.mitre.org/techniques/T1493",
+          "https://attack.mitre.org/versions/v6/techniques/T1493",
           "https://content.fireeye.com/apt/rpt-apt38",
           "https://www.justice.gov/opa/press-release/file/1092091/download"
         ]
@@ -12107,7 +12107,7 @@
       "meta": {
         "external_id": "T1536",
         "refs": [
-          "https://attack.mitre.org/techniques/T1536",
+          "https://attack.mitre.org/versions/v6/techniques/T1536",
           "https://www.techrepublic.com/blog/the-enterprise-cloud/backing-up-and-restoring-snapshots-on-amazon-ec2-machines/",
           "https://cloud.google.com/compute/docs/disks/restore-and-delete-snapshots"
         ]
@@ -12316,7 +12316,7 @@
       "meta": {
         "external_id": "T1494",
         "refs": [
-          "https://attack.mitre.org/techniques/T1494",
+          "https://attack.mitre.org/versions/v6/techniques/T1494",
           "https://content.fireeye.com/apt/rpt-apt38",
           "https://www.justice.gov/opa/press-release/file/1092091/download"
         ]
@@ -12442,7 +12442,7 @@
       "meta": {
         "external_id": "T1487",
         "refs": [
-          "https://attack.mitre.org/techniques/T1487",
+          "https://attack.mitre.org/versions/v6/techniques/T1487",
           "https://www.symantec.com/connect/blogs/shamoon-attacks",
           "https://www.fireeye.com/blog/threat-research/2016/11/fireeye_respondsto.html",
           "http://researchcenter.paloaltonetworks.com/2016/11/unit42-shamoon-2-return-disttrack-wiper/",
@@ -12467,7 +12467,7 @@
       "meta": {
         "external_id": "T1488",
         "refs": [
-          "https://attack.mitre.org/techniques/T1488",
+          "https://attack.mitre.org/versions/v6/techniques/T1488",
           "https://www.operationblockbuster.com/wp-content/uploads/2016/02/Operation-Blockbuster-Report.pdf",
           "https://operationblockbuster.com/wp-content/uploads/2016/02/Operation-Blockbuster-Destructive-Malware-Report.pdf",
           "https://www.justice.gov/opa/press-release/file/1092091/download"
@@ -12887,7 +12887,7 @@
       "meta": {
         "external_id": "CAPEC-641",
         "refs": [
-          "https://attack.mitre.org/techniques/T1073",
+          "https://attack.mitre.org/versions/v6/techniques/T1073",
           "https://capec.mitre.org/data/definitions/641.html",
           "https://msdn.microsoft.com/en-us/library/aa375365",
           "https://www.fireeye.com/content/dam/fireeye-www/global/en/current-threats/pdfs/rpt-dll-sideloading.pdf"
@@ -12910,7 +12910,7 @@
       "meta": {
         "external_id": "T1164",
         "refs": [
-          "https://attack.mitre.org/techniques/T1164",
+          "https://attack.mitre.org/versions/v6/techniques/T1164",
           "https://www.virusbulletin.com/uploads/pdf/conference/vb2014/VB2014-Wardle.pdf"
         ]
       },
@@ -12959,7 +12959,7 @@
       "meta": {
         "external_id": "T1178",
         "refs": [
-          "https://attack.mitre.org/techniques/T1178",
+          "https://attack.mitre.org/versions/v6/techniques/T1178",
           "https://msdn.microsoft.com/library/windows/desktop/aa379571.aspx",
           "https://msdn.microsoft.com/library/ms679833.aspx",
           "https://support.microsoft.com/help/243330/well-known-security-identifiers-in-windows-operating-systems",
@@ -12985,7 +12985,7 @@
       "meta": {
         "external_id": "T1188",
         "refs": [
-          "https://attack.mitre.org/techniques/T1188"
+          "https://attack.mitre.org/versions/v6/techniques/T1188"
         ]
       },
       "related": [
@@ -16374,7 +16374,7 @@
       "meta": {
         "external_id": "CAPEC-650",
         "refs": [
-          "https://attack.mitre.org/techniques/T1100",
+          "https://attack.mitre.org/versions/v6/techniques/T1100",
           "https://capec.mitre.org/data/definitions/650.html",
           "https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-i.html",
           "https://www.us-cert.gov/ncas/alerts/TA15-314A"
@@ -16449,7 +16449,7 @@
       "meta": {
         "external_id": "T1002",
         "refs": [
-          "https://attack.mitre.org/techniques/T1002",
+          "https://attack.mitre.org/versions/v6/techniques/T1002",
           "https://en.wikipedia.org/wiki/List_of_file_signatures"
         ]
       },
@@ -16497,7 +16497,7 @@
       "meta": {
         "external_id": "CAPEC-550",
         "refs": [
-          "https://attack.mitre.org/techniques/T1050",
+          "https://attack.mitre.org/versions/v6/techniques/T1050",
           "https://capec.mitre.org/data/definitions/550.html",
           "https://technet.microsoft.com/en-us/library/cc772408.aspx",
           "https://docs.microsoft.com/windows/security/threat-protection/auditing/event-4697",
@@ -16549,7 +16549,7 @@
       "meta": {
         "external_id": "CAPEC-572",
         "refs": [
-          "https://attack.mitre.org/techniques/T1009",
+          "https://attack.mitre.org/versions/v6/techniques/T1009",
           "https://capec.mitre.org/data/definitions/572.html",
           "https://www.welivesecurity.com/2018/03/13/oceanlotus-ships-new-backdoor/",
           "https://securelist.com/old-malware-tricks-to-bypass-detection-in-the-age-of-big-data/78010/",
@@ -16691,7 +16691,7 @@
       "meta": {
         "external_id": "T1103",
         "refs": [
-          "https://attack.mitre.org/techniques/T1103",
+          "https://attack.mitre.org/versions/v6/techniques/T1103",
           "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process",
           "https://support.microsoft.com/en-us/kb/197571",
           "https://msdn.microsoft.com/en-us/library/dn280412",
@@ -16715,7 +16715,7 @@
       "meta": {
         "external_id": "T1013",
         "refs": [
-          "https://attack.mitre.org/techniques/T1013",
+          "https://attack.mitre.org/versions/v6/techniques/T1013",
           "http://msdn.microsoft.com/en-us/library/dd183341",
           "https://www.defcon.org/images/defcon-22/dc-22-presentations/Bloxham/DEFCON-22-Brady-Bloxham-Windows-API-Abuse-UPDATED.pdf",
           "https://technet.microsoft.com/en-us/sysinternals/bb963902"
@@ -16738,7 +16738,7 @@
       "meta": {
         "external_id": "CAPEC-558",
         "refs": [
-          "https://attack.mitre.org/techniques/T1015",
+          "https://attack.mitre.org/versions/v6/techniques/T1015",
           "https://capec.mitre.org/data/definitions/558.html",
           "https://www.fireeye.com/blog/threat-research/2012/08/hikit-rootkit-advanced-persistent-attack-techniques-part-1.html",
           "https://www.slideshare.net/DennisMaldonado5/sticky-keys-to-the-kingdom",
@@ -16785,7 +16785,7 @@
       "meta": {
         "external_id": "T1150",
         "refs": [
-          "https://attack.mitre.org/techniques/T1150",
+          "https://attack.mitre.org/versions/v6/techniques/T1150",
           "https://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/"
         ]
       },
@@ -16806,7 +16806,7 @@
       "meta": {
         "external_id": "T1501",
         "refs": [
-          "https://attack.mitre.org/techniques/T1501",
+          "https://attack.mitre.org/versions/v6/techniques/T1501",
           "http://man7.org/linux/man-pages/man1/systemd.1.html",
           "https://www.freedesktop.org/wiki/Software/systemd/",
           "https://www.anomali.com/blog/rocke-evolves-its-arsenal-with-a-new-malware-family-written-in-golang",
@@ -16893,7 +16893,7 @@
       "meta": {
         "external_id": "T1160",
         "refs": [
-          "https://attack.mitre.org/techniques/T1160",
+          "https://attack.mitre.org/versions/v6/techniques/T1160",
           "https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html",
           "https://www.virusbulletin.com/uploads/pdf/conference/vb2014/VB2014-Wardle.pdf",
           "https://www.synack.com/wp-content/uploads/2016/03/RSA_OSX_Malware.pdf",
@@ -16917,7 +16917,7 @@
       "meta": {
         "external_id": "T1107",
         "refs": [
-          "https://attack.mitre.org/techniques/T1107",
+          "https://attack.mitre.org/versions/v6/techniques/T1107",
           "http://blog.trendmicro.com/trendlabs-security-intelligence/in-depth-look-apt-attack-tools-of-the-trade/"
         ]
       },
@@ -16978,7 +16978,7 @@
       "meta": {
         "external_id": "T1109",
         "refs": [
-          "https://attack.mitre.org/techniques/T1109",
+          "https://attack.mitre.org/versions/v6/techniques/T1109",
           "https://www.smartmontools.org/",
           "https://www.itworld.com/article/2853992/3-tools-to-check-your-hard-drives-health-and-make-sure-its-not-already-dying-on-you.html"
         ]
@@ -17000,7 +17000,7 @@
       "meta": {
         "external_id": "CAPEC-532",
         "refs": [
-          "https://attack.mitre.org/techniques/T1019",
+          "https://attack.mitre.org/versions/v6/techniques/T1019",
           "https://capec.mitre.org/data/definitions/532.html",
           "https://en.wikipedia.org/wiki/BIOS",
           "https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface",
@@ -17029,7 +17029,7 @@
       "meta": {
         "external_id": "T1022",
         "refs": [
-          "https://attack.mitre.org/techniques/T1022",
+          "https://attack.mitre.org/versions/v6/techniques/T1022",
           "http://www.netsec.colostate.edu/~zhang/DetectingEncryptedBotnetTraffic.pdf",
           "https://en.wikipedia.org/wiki/List_of_file_signatures"
         ]
@@ -17065,7 +17065,7 @@
       "meta": {
         "external_id": "CAPEC-132",
         "refs": [
-          "https://attack.mitre.org/techniques/T1023",
+          "https://attack.mitre.org/versions/v6/techniques/T1023",
           "https://capec.mitre.org/data/definitions/132.html"
         ]
       },
@@ -17196,7 +17196,7 @@
       "meta": {
         "external_id": "T1206",
         "refs": [
-          "https://attack.mitre.org/techniques/T1206",
+          "https://attack.mitre.org/versions/v6/techniques/T1206",
           "https://www.sudo.ws/",
           "https://www.cybereason.com/blog/labs-proton-b-what-this-mac-malware-actually-does"
         ]
@@ -17218,7 +17218,7 @@
       "meta": {
         "external_id": "T1209",
         "refs": [
-          "https://attack.mitre.org/techniques/T1209",
+          "https://attack.mitre.org/versions/v6/techniques/T1209",
           "https://docs.microsoft.com/windows-server/networking/windows-time-service/windows-time-service-top",
           "https://msdn.microsoft.com/library/windows/desktop/ms725475.aspx",
           "https://github.com/scottlundgren/w32time",
@@ -17333,7 +17333,7 @@
       "meta": {
         "external_id": "T1035",
         "refs": [
-          "https://attack.mitre.org/techniques/T1035"
+          "https://attack.mitre.org/versions/v6/techniques/T1035"
         ]
       },
       "related": [
@@ -17367,7 +17367,7 @@
       "meta": {
         "external_id": "T1093",
         "refs": [
-          "https://attack.mitre.org/techniques/T1093",
+          "https://attack.mitre.org/versions/v6/techniques/T1093",
           "http://www.autosectools.com/process-hollowing.pdf",
           "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"
         ]
@@ -17412,7 +17412,7 @@
       "meta": {
         "external_id": "CAPEC-571",
         "refs": [
-          "https://attack.mitre.org/techniques/T1054",
+          "https://attack.mitre.org/versions/v6/techniques/T1054",
           "https://capec.mitre.org/data/definitions/571.html",
           "https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?name=Backdoor:Win32/Lamin.A",
           "https://docs.microsoft.com/en-us/windows/desktop/etw/consuming-events",
@@ -17459,7 +17459,7 @@
       "meta": {
         "external_id": "T1504",
         "refs": [
-          "https://attack.mitre.org/techniques/T1504",
+          "https://attack.mitre.org/versions/v6/techniques/T1504",
           "https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6",
           "https://www.welivesecurity.com/2019/05/29/turla-powershell-usage/",
           "https://witsendandshady.blogspot.com/2019/06/lab-notes-persistence-and-privilege.html",
@@ -17483,7 +17483,7 @@
       "meta": {
         "external_id": "CAPEC-570",
         "refs": [
-          "https://attack.mitre.org/techniques/T1045",
+          "https://attack.mitre.org/versions/v6/techniques/T1045",
           "https://capec.mitre.org/data/definitions/570.html",
           "http://en.wikipedia.org/wiki/Executable_compression",
           "https://www.welivesecurity.com/wp-content/uploads/2018/01/WP-FinFisher.pdf"
@@ -17741,7 +17741,7 @@
       "meta": {
         "external_id": "T1079",
         "refs": [
-          "https://attack.mitre.org/techniques/T1079",
+          "https://attack.mitre.org/versions/v6/techniques/T1079",
           "http://www.sans.org/reading-room/whitepapers/analyst/finding-hidden-threats-decrypting-ssl-34840",
           "https://insights.sei.cmu.edu/cert/2015/03/the-risks-of-ssl-inspection.html",
           "https://www.fidelissecurity.com/sites/default/files/FTA_1018_looking_at_the_sky_for_a_dark_comet.pdf",
@@ -17829,7 +17829,7 @@
       "meta": {
         "external_id": "T1131",
         "refs": [
-          "https://attack.mitre.org/techniques/T1131",
+          "https://attack.mitre.org/versions/v6/techniques/T1131",
           "https://msdn.microsoft.com/library/windows/desktop/aa374733.aspx",
           "http://docplayer.net/20839173-Analysis-of-malicious-security-support-provider-dlls.html",
           "https://technet.microsoft.com/en-us/library/dn408187.aspx"
@@ -17961,7 +17961,7 @@
       "meta": {
         "external_id": "CAPEC-569",
         "refs": [
-          "https://attack.mitre.org/techniques/T1141",
+          "https://attack.mitre.org/versions/v6/techniques/T1141",
           "https://capec.mitre.org/data/definitions/569.html",
           "https://baesystemsai.blogspot.com/2015/06/new-mac-os-malware-exploits-mackeeper.html",
           "https://logrhythm.com/blog/do-you-trust-your-computer/",
@@ -18011,7 +18011,7 @@
       "meta": {
         "external_id": "T1161",
         "refs": [
-          "https://attack.mitre.org/techniques/T1161",
+          "https://attack.mitre.org/versions/v6/techniques/T1161",
           "https://www.blackhat.com/docs/us-15/materials/us-15-Wardle-Writing-Bad-A-Malware-For-OS-X.pdf",
           "https://www.rsaconference.com/writable/presentations/file_upload/ht-r03-malware-persistence-on-os-x-yosemite_final.pdf"
         ]
@@ -18033,7 +18033,7 @@
       "meta": {
         "external_id": "T1116",
         "refs": [
-          "https://attack.mitre.org/techniques/T1116",
+          "https://attack.mitre.org/versions/v6/techniques/T1116",
           "https://en.wikipedia.org/wiki/Code_signing",
           "http://www.thesafemac.com/new-signed-malware-called-janicab/",
           "https://securelist.com/why-you-shouldnt-completely-trust-files-signed-with-digital-certificates/68593/",
@@ -18208,7 +18208,7 @@
       "meta": {
         "external_id": "CAPEC-564",
         "refs": [
-          "https://attack.mitre.org/techniques/T1162",
+          "https://attack.mitre.org/versions/v6/techniques/T1162",
           "https://capec.mitre.org/data/definitions/564.html",
           "https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLoginItems.html",
           "https://www.virusbulletin.com/uploads/pdf/conference/vb2014/VB2014-Wardle.pdf",
@@ -18233,7 +18233,7 @@
       "meta": {
         "external_id": "T1172",
         "refs": [
-          "https://attack.mitre.org/techniques/T1172",
+          "https://attack.mitre.org/versions/v6/techniques/T1172",
           "http://www.icir.org/vern/papers/meek-PETS-2015.pdf"
         ]
       },
@@ -18254,7 +18254,7 @@
       "meta": {
         "external_id": "T1182",
         "refs": [
-          "https://attack.mitre.org/techniques/T1182",
+          "https://attack.mitre.org/versions/v6/techniques/T1182",
           "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process",
           "https://technet.microsoft.com/en-us/sysinternals/bb963902",
           "https://forum.sysinternals.com/appcertdlls_topic12546.html"
@@ -18277,7 +18277,7 @@
       "meta": {
         "external_id": "CAPEC-163",
         "refs": [
-          "https://attack.mitre.org/techniques/T1192",
+          "https://attack.mitre.org/versions/v6/techniques/T1192",
           "https://capec.mitre.org/data/definitions/163.html",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/pawn-storm-abuses-open-authentication-advanced-social-engineering-attacks"
         ]
@@ -18346,7 +18346,7 @@
       "meta": {
         "external_id": "T1143",
         "refs": [
-          "https://attack.mitre.org/techniques/T1143",
+          "https://attack.mitre.org/versions/v6/techniques/T1143",
           "https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Core/About/about_PowerShell_exe?view=powershell-5.1",
           "https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/"
         ]
@@ -18425,7 +18425,7 @@
       "meta": {
         "external_id": "T1138",
         "refs": [
-          "https://attack.mitre.org/techniques/T1138",
+          "https://attack.mitre.org/versions/v6/techniques/T1138",
           "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process",
           "https://www.blackhat.com/docs/eu-15/materials/eu-15-Pierce-Defending-Against-Malicious-Application-Compatibility-Shims-wp.pdf"
         ]
@@ -18461,7 +18461,7 @@
       "meta": {
         "external_id": "CAPEC-163",
         "refs": [
-          "https://attack.mitre.org/techniques/T1193",
+          "https://attack.mitre.org/versions/v6/techniques/T1193",
           "https://capec.mitre.org/data/definitions/163.html"
         ]
       },
@@ -18482,7 +18482,7 @@
       "meta": {
         "external_id": "T1139",
         "refs": [
-          "https://attack.mitre.org/techniques/T1139",
+          "https://attack.mitre.org/versions/v6/techniques/T1139",
           "http://www.slideshare.net/StephanBorosh/external-to-da-the-os-x-way"
         ]
       },
@@ -18503,7 +18503,7 @@
       "meta": {
         "external_id": "T1144",
         "refs": [
-          "https://attack.mitre.org/techniques/T1144",
+          "https://attack.mitre.org/versions/v6/techniques/T1144",
           "https://www.virusbulletin.com/uploads/pdf/conference/vb2014/VB2014-Wardle.pdf",
           "https://derflounder.wordpress.com/2012/11/20/clearing-the-quarantine-extended-attribute-from-downloaded-applications/",
           "https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update",
@@ -18550,7 +18550,7 @@
       "meta": {
         "external_id": "T1145",
         "refs": [
-          "https://attack.mitre.org/techniques/T1145",
+          "https://attack.mitre.org/versions/v6/techniques/T1145",
           "https://en.wikipedia.org/wiki/Public-key_cryptography",
           "https://kasperskycontenthub.com/wp-content/uploads/sites/43/vlpdfs/unveilingthemask_v1.0.pdf",
           "https://researchcenter.paloaltonetworks.com/2016/06/unit42-prince-of-persia-game-over/"
@@ -18617,7 +18617,7 @@
       "meta": {
         "external_id": "T1147",
         "refs": [
-          "https://attack.mitre.org/techniques/T1147",
+          "https://attack.mitre.org/versions/v6/techniques/T1147",
           "https://www2.cybereason.com/research-osx-pirrit-mac-os-x-secuirty"
         ]
       },
@@ -18659,7 +18659,7 @@
       "meta": {
         "external_id": "T1184",
         "refs": [
-          "https://attack.mitre.org/techniques/T1184",
+          "https://attack.mitre.org/versions/v6/techniques/T1184",
           "https://www.slideshare.net/morisson/mistrusting-and-abusing-ssh-13526219",
           "https://www.blackhat.com/presentations/bh-usa-05/bh-us-05-boileau.pdf",
           "https://www.clockwork.com/news/2012/09/28/602/ssh_agent_hijacking",
@@ -18772,7 +18772,7 @@
       "meta": {
         "external_id": "T1165",
         "refs": [
-          "https://attack.mitre.org/techniques/T1165",
+          "https://attack.mitre.org/versions/v6/techniques/T1165",
           "https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/StartupItems.html",
           "https://www.virusbulletin.com/uploads/pdf/conference/vb2014/VB2014-Wardle.pdf"
         ]
@@ -18813,7 +18813,7 @@
       "meta": {
         "external_id": "CAPEC-471",
         "refs": [
-          "https://attack.mitre.org/techniques/T1157",
+          "https://attack.mitre.org/versions/v6/techniques/T1157",
           "https://capec.mitre.org/data/definitions/471.html",
           "https://www.blackhat.com/docs/us-15/materials/us-15-Wardle-Writing-Bad-A-Malware-For-OS-X.pdf",
           "https://www.rsaconference.com/writable/presentations/file_upload/ht-r03-malware-persistence-on-os-x-yosemite_final.pdf"
@@ -18869,7 +18869,7 @@
       "meta": {
         "external_id": "T1159",
         "refs": [
-          "https://attack.mitre.org/techniques/T1159",
+          "https://attack.mitre.org/versions/v6/techniques/T1159",
           "https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html",
           "https://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials/",
           "https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/",
@@ -18932,7 +18932,7 @@
       "meta": {
         "external_id": "T1167",
         "refs": [
-          "https://attack.mitre.org/techniques/T1167",
+          "https://attack.mitre.org/versions/v6/techniques/T1167",
           "http://juusosalonen.com/post/30923743427/breaking-into-the-os-x-keychain",
           "http://www.slideshare.net/StephanBorosh/external-to-da-the-os-x-way",
           "https://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials/"
@@ -18955,7 +18955,7 @@
       "meta": {
         "external_id": "T1186",
         "refs": [
-          "https://attack.mitre.org/techniques/T1186",
+          "https://attack.mitre.org/versions/v6/techniques/T1186",
           "https://msdn.microsoft.com/library/windows/desktop/bb968806.aspx",
           "https://msdn.microsoft.com/library/windows/desktop/dd979526.aspx",
           "https://msdn.microsoft.com/library/windows/desktop/aa365738.aspx",
@@ -18981,7 +18981,7 @@
       "meta": {
         "external_id": "T1177",
         "refs": [
-          "https://attack.mitre.org/techniques/T1177",
+          "https://attack.mitre.org/versions/v6/techniques/T1177",
           "https://technet.microsoft.com/library/cc961760.aspx",
           "https://technet.microsoft.com/library/dn408187.aspx",
           "https://technet.microsoft.com/en-us/sysinternals/bb963902",
@@ -20945,7 +20945,7 @@
       "meta": {
         "external_id": "T1163",
         "refs": [
-          "https://attack.mitre.org/techniques/T1163",
+          "https://attack.mitre.org/versions/v6/techniques/T1163",
           "https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/StartupItems.html",
           "https://www.virusbulletin.com/uploads/pdf/conference/vb2014/VB2014-Wardle.pdf"
         ]
@@ -20967,7 +20967,7 @@
       "meta": {
         "external_id": "T1121",
         "refs": [
-          "https://attack.mitre.org/techniques/T1121",
+          "https://attack.mitre.org/versions/v6/techniques/T1121",
           "https://msdn.microsoft.com/en-us/library/04za0hca.aspx",
           "https://msdn.microsoft.com/en-us/library/tzat5yw6.aspx",
           "https://lolbas-project.github.io/lolbas/Binaries/Regsvcs/",
@@ -21048,7 +21048,7 @@
       "meta": {
         "external_id": "T1170",
         "refs": [
-          "https://attack.mitre.org/techniques/T1170",
+          "https://attack.mitre.org/versions/v6/techniques/T1170",
           "https://en.wikipedia.org/wiki/HTML_Application",
           "https://msdn.microsoft.com/library/ms536471.aspx",
           "https://www.cylance.com/content/dam/cylance/pdfs/reports/Op_Dust_Storm_Report.pdf",
@@ -21076,7 +21076,7 @@
       "meta": {
         "external_id": "T1180",
         "refs": [
-          "https://attack.mitre.org/techniques/T1180",
+          "https://attack.mitre.org/versions/v6/techniques/T1180",
           "https://en.wikipedia.org/wiki/Screensaver",
           "https://www.welivesecurity.com/wp-content/uploads/2017/08/eset-gazer.pdf"
         ]
@@ -21098,7 +21098,7 @@
       "meta": {
         "external_id": "T1085",
         "refs": [
-          "https://attack.mitre.org/techniques/T1085",
+          "https://attack.mitre.org/versions/v6/techniques/T1085",
           "https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp-cpl-malware.pdf",
           "https://thisissecurity.stormshield.com/2014/08/20/poweliks-command-line-confusion/"
         ]
@@ -21145,7 +21145,7 @@
       "meta": {
         "external_id": "T1208",
         "refs": [
-          "https://attack.mitre.org/techniques/T1208",
+          "https://attack.mitre.org/versions/v6/techniques/T1208",
           "https://blogs.technet.microsoft.com/motiba/2018/02/23/detecting-kerberoasting-activity-using-azure-security-center/",
           "https://msdn.microsoft.com/library/ms677949.aspx",
           "https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spns-setspn-syntax-setspn-exe.aspx",
@@ -21230,7 +21230,7 @@
       "meta": {
         "external_id": "T1067",
         "refs": [
-          "https://attack.mitre.org/techniques/T1067",
+          "https://attack.mitre.org/versions/v6/techniques/T1067",
           "https://www.fireeye.com/content/dam/fireeye-www/regional/fr_FR/offers/pdfs/ig-mtrends-2016.pdf",
           "http://www.symantec.com/connect/blogs/are-mbr-infections-back-fashion"
         ]
@@ -21252,7 +21252,7 @@
       "meta": {
         "external_id": "T1086",
         "refs": [
-          "https://attack.mitre.org/techniques/T1086",
+          "https://attack.mitre.org/versions/v6/techniques/T1086",
           "https://technet.microsoft.com/en-us/scriptcenter/dd742419.aspx",
           "https://github.com/mattifestation/PowerSploit",
           "https://github.com/jaredhaight/PSAttack",
@@ -21280,7 +21280,7 @@
       "meta": {
         "external_id": "T1099",
         "refs": [
-          "https://attack.mitre.org/techniques/T1099",
+          "https://attack.mitre.org/versions/v6/techniques/T1099",
           "http://windowsir.blogspot.com/2013/07/howto-determinedetect-use-of-anti.html"
         ]
       },
@@ -21301,7 +21301,7 @@
       "meta": {
         "external_id": "T1117",
         "refs": [
-          "https://attack.mitre.org/techniques/T1117",
+          "https://attack.mitre.org/versions/v6/techniques/T1117",
           "https://support.microsoft.com/en-us/kb/249873",
           "https://lolbas-project.github.io/lolbas/Binaries/Regsvr32/",
           "https://www.carbonblack.com/2016/04/28/threat-advisory-squiblydoo-continues-trend-of-attackers-using-native-os-tools-to-live-off-the-land/",
@@ -21325,7 +21325,7 @@
       "meta": {
         "external_id": "T1118",
         "refs": [
-          "https://attack.mitre.org/techniques/T1118",
+          "https://attack.mitre.org/versions/v6/techniques/T1118",
           "https://msdn.microsoft.com/en-us/library/50614e95.aspx",
           "https://lolbas-project.github.io/lolbas/Binaries/Installutil/"
         ]
@@ -21347,7 +21347,7 @@
       "meta": {
         "external_id": "T1191",
         "refs": [
-          "https://attack.mitre.org/techniques/T1191",
+          "https://attack.mitre.org/versions/v6/techniques/T1191",
           "https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2003/cc786431(v=ws.10)",
           "https://twitter.com/ItsReallyNick/status/958789644165894146",
           "https://msitpros.com/?p=3960",
@@ -21373,7 +21373,7 @@
       "meta": {
         "external_id": "T1142",
         "refs": [
-          "https://attack.mitre.org/techniques/T1142",
+          "https://attack.mitre.org/versions/v6/techniques/T1142",
           "https://en.wikipedia.org/wiki/Keychain_(software)",
           "http://www.slideshare.net/StephanBorosh/external-to-da-the-os-x-way"
         ]
@@ -21395,7 +21395,7 @@
       "meta": {
         "external_id": "T1152",
         "refs": [
-          "https://attack.mitre.org/techniques/T1152",
+          "https://attack.mitre.org/versions/v6/techniques/T1152",
           "https://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/"
         ]
       },
@@ -21440,7 +21440,7 @@
       "meta": {
         "external_id": "T1154",
         "refs": [
-          "https://attack.mitre.org/techniques/T1154",
+          "https://attack.mitre.org/versions/v6/techniques/T1154",
           "https://ss64.com/bash/trap.html",
           "https://bash.cyberciti.biz/guide/Trap_statement"
         ]
@@ -21462,7 +21462,7 @@
       "meta": {
         "external_id": "CAPEC-13",
         "refs": [
-          "https://attack.mitre.org/techniques/T1148",
+          "https://attack.mitre.org/versions/v6/techniques/T1148",
           "https://capec.mitre.org/data/definitions/13.html"
         ]
       },
@@ -21511,7 +21511,7 @@
       "meta": {
         "external_id": "T1155",
         "refs": [
-          "https://attack.mitre.org/techniques/T1155",
+          "https://attack.mitre.org/versions/v6/techniques/T1155",
           "https://www.mcafee.com/blogs/other-blogs/mcafee-labs/macro-malware-targets-macs/"
         ]
       },
@@ -21532,7 +21532,7 @@
       "meta": {
         "external_id": "T1519",
         "refs": [
-          "https://attack.mitre.org/techniques/T1519",
+          "https://attack.mitre.org/versions/v6/techniques/T1519",
           "https://www.xorrior.com/emond-persistence/",
           "http://www.magnusviri.com/Mac/what-is-emond.html",
           "https://www.sentinelone.com/blog/how-malware-persists-on-macos/"
@@ -21555,7 +21555,7 @@
       "meta": {
         "external_id": "T1169",
         "refs": [
-          "https://attack.mitre.org/techniques/T1169",
+          "https://attack.mitre.org/versions/v6/techniques/T1169",
           "https://blog.malwarebytes.com/threat-analysis/2017/04/new-osx-dok-malware-intercepts-web-traffic/"
         ]
       },
@@ -21576,7 +21576,7 @@
       "meta": {
         "external_id": "T1179",
         "refs": [
-          "https://attack.mitre.org/techniques/T1179",
+          "https://attack.mitre.org/versions/v6/techniques/T1179",
           "https://msdn.microsoft.com/library/windows/desktop/ms644959.aspx",
           "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process",
           "https://www.adlice.com/userland-rootkits-part-1-iat-hooks/",
@@ -21675,5 +21675,5 @@
       "value": "Keychain - T1579"
     }
   ],
-  "version": 14
+  "version": 15
 }


### PR DESCRIPTION
Example:

"Custom Command and Control Protocol - T1094" contains a link to the page https://attack.mitre.org/techniques/T1094 for further explanation.

Mitre currently redirects that page to https://attack.mitre.org/techniques/T1095/ "Non-Application Layer Protocol – T1095". All links in 'revoked' techniques have been updated to their v6 permalink version that does not get redirected.