### PR TITLE
merging ScarCruft->APT37

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -3332,39 +3332,6 @@
       "value": "Stealth Falcon"
     },
     {
-      "description": "ScarCruft is a relatively new APT group; victims have been observed in several countries, including Russia, Nepal, South Korea, China, India, Kuwait and Romania. The group has several ongoing operations utilizing multiple exploits — two for Adobe Flash and one for Microsoft Internet Explorer.",
-      "meta": {
-        "refs": [
-          "https://securelist.com/cve-2016-4171-adobe-flash-zero-day-used-in-targeted-attacks/75082/",
-          "https://securelist.com/operation-daybreak/75100/",
-          "https://securelist.com/scarcruft-continues-to-evolve-introduces-bluetooth-harvester/90729/",
-          "https://threatpost.com/scarcruft-apt-group-used-latest-flash-zero-day-in-two-dozen-attacks/118642/"
-        ],
-        "synonyms": [
-          "Operation Daybreak",
-          "Operation Erebus"
-        ]
-      },
-      "related": [
-        {
-          "dest-uuid": "4a2ce82e-1a74-468a-a6fb-bbead541383c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "50cd027f-df14-40b2-aa22-bf5de5061163",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "bb446dc2-4fee-4212-8b2c-3ffa2917e338",
-      "value": "ScarCruft"
-    },
-    {
       "description": "This group created a malware that takes over Android devices and generates $300,000 per month in fraudulent ad revenue.  The group effectively controls an arsenal of over 85 million mobile devices around the world. With the potential to sell access to these devices to the highest bidder",
       "meta": {
         "attribution-confidence": "50",
@@ -5740,18 +5707,23 @@
           "https://www.bleepingcomputer.com/news/security/report-ties-north-korean-attacks-to-new-malware-linked-by-word-macros/",
           "https://unit42.paloaltonetworks.com/unit42-freemilk-highly-targeted-spear-phishing-campaign/",
           "https://blog.talosintelligence.com/2018/01/korea-in-crosshairs.html",
-          "https://attack.mitre.org/groups/G0067/"
+          "https://attack.mitre.org/groups/G0067/",
+          "https://securelist.com/cve-2016-4171-adobe-flash-zero-day-used-in-targeted-attacks/75082/",
+          "https://securelist.com/operation-daybreak/75100/",
+          "https://securelist.com/scarcruft-continues-to-evolve-introduces-bluetooth-harvester/90729/",
+          "https://threatpost.com/scarcruft-apt-group-used-latest-flash-zero-day-in-two-dozen-attacks/118642/"
         ],
         "synonyms": [
           "APT 37",
           "Group 123",
           "Group123",
           "Starcruft",
+          "StarCruft",
+          "ScarCruft",
           "Reaper",
           "Reaper Group",
           "Red Eyes",
           "Ricochet Chollima",
-          "StarCruft",
           "Operation Daybreak",
           "Operation Erebus",
           "Venus 121"
@@ -5760,13 +5732,6 @@
       "related": [
         {
           "dest-uuid": "4a2ce82e-1a74-468a-a6fb-bbead541383c",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "bb446dc2-4fee-4212-8b2c-3ffa2917e338",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],


### PR DESCRIPTION
I would like to propose merging entry "ScarCruft" into "APT37". It really just seems like a redundancy, as both its aliases "Operation Daybreak" and "Operation Erebus" are already present for "APT37", along alias "StarCruft", which just seems to be a less popular variation of the name ("StarCruft" 3.2k google hits vs "ScarCruft" 31.5k google hits). The references of the entry can be fully merged as well - they do not overlap so far.