### PR TITLE
removing Starcruft

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -5717,8 +5717,6 @@
           "APT 37",
           "Group 123",
           "Group123",
-          "Starcruft",
-          "StarCruft",
           "ScarCruft",
           "Reaper",
           "Reaper Group",


### PR DESCRIPTION
Don't know how `StarCruft` (typo) get into APT37. As it makes no sense, removing it.