### PR TITLE
merge COVELLITE into Lazarus Group

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -3083,7 +3083,10 @@
           "https://blogs.jpcert.or.jp/en/2020/08/Lazarus-malware.html",
           "https://www.secureworks.com/research/threat-profiles/nickel-gladstone",
           "https://blogs.jpcert.or.jp/en/2020/09/BLINDINGCAN.html",
-          "https://www.welivesecurity.com/2020/11/16/lazarus-supply-chain-attack-south-korea/"
+          "https://www.welivesecurity.com/2020/11/16/lazarus-supply-chain-attack-south-korea/",
+          "https://dragos.com/adversaries.html",
+          "https://dragos.com/media/2017-Review-Industrial-Control-System-Threats.pdf",
+          "https://www.cfr.org/interactive/cyber-operations/covellite"
         ],
         "synonyms": [
           "Operation DarkSeoul",
@@ -3109,19 +3112,13 @@
           "Appleworm",
           "Nickel Academy",
           "APT-C-26",
-          "NICKEL GLADSTONE"
+          "NICKEL GLADSTONE",
+          "COVELLITE"
         ]
       },
       "related": [
         {
           "dest-uuid": "c93fccb1-e8e8-42cf-ae33-2ad1d183913a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "027a1428-6e79-4a4b-82b9-e698e8525c2b",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -6015,51 +6012,6 @@
       ],
       "uuid": "a0082cfa-32e2-42b8-92d8-5c7a7409dcf1",
       "value": "CHRYSENE"
-    },
-    {
-      "description": "Adversaries abusing ICS (based on Dragos Inc adversary list).\nThis threat actor compromises the networks of companies involved in electric power, specifically looking for intellectual property and information about the companies’ operations.",
-      "meta": {
-        "attribution-confidence": "50",
-        "capabilities": "Encoded binaries in documents, evasion techniques",
-        "cfr-suspected-state-sponsor": "Unknown",
-        "cfr-suspected-victims": [
-          "United States"
-        ],
-        "cfr-target-category": [
-          "Private sector"
-        ],
-        "cfr-type-of-incident": "Espionage",
-        "mode-of-operation": "IT compromise with hardened anti-analysis malware against industrial orgs",
-        "refs": [
-          "https://dragos.com/adversaries.html",
-          "https://dragos.com/media/2017-Review-Industrial-Control-System-Threats.pdf",
-          "https://www.cfr.org/interactive/cyber-operations/covellite"
-        ],
-        "since": "2017",
-        "synonyms": [
-          "Lazarus",
-          "Hidden Cobra"
-        ],
-        "victimology": "Electric Utilities, US"
-      },
-      "related": [
-        {
-          "dest-uuid": "c93fccb1-e8e8-42cf-ae33-2ad1d183913a",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "68391641-859f-4a9a-9a1e-3e5cf71ec376",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "027a1428-6e79-4a4b-82b9-e698e8525c2b",
-      "value": "COVELLITE"
     },
     {
       "description": "Adversaries abusing ICS (based on Dragos Inc adversary list).\nThis threat actor targets industrial control systems in Turkey, Europe, and North America.\n    Believed to be linked to Crouching Yeti",


### PR DESCRIPTION
I would propose to move COVELLITE as tracked by Dragos as an alias into Lazarus Group and merge the references. 
Dragos' own description states that it refers to the same group as "Lazarus" and "Hidden Cobra" in that infrastructure and tools are the same: https://www.dragos.com/threat-activity-groups/ - the entry in MISP's threat actor library also reflects that.