### PR TITLE
adding ClearSky alias for Volatile Cedar

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -3918,12 +3918,14 @@
         "refs": [
           "https://blog.checkpoint.com/2015/03/31/volatilecedar/",
           "https://blog.checkpoint.com/2015/06/09/new-data-volatile-cedar/",
-          "https://securelist.com/sinkholing-volatile-cedar-dga-infrastructure/69421/"
+          "https://securelist.com/sinkholing-volatile-cedar-dga-infrastructure/69421/",
+          "https://www.clearskysec.com/wp-content/uploads/2021/01/Lebanese-Cedar-APT.pdf"
         ],
         "synonyms": [
           "Reuse team",
           "Malware reusers",
-          "Dancing Salome"
+          "Dancing Salome",
+          "Lebanese Cedar"
         ]
       },
       "uuid": "cf421ce6-ddfe-419a-bc65-6a9fc953232a",


### PR DESCRIPTION
adding ClearSky report as source and alias to the VolatileCedar entry. As proof from the report: "We attributed the operation to Lebanese Cedar (also known as Volatile Cedar), mainly based on the code overlaps between the 2015 variants of Explosive RAT and Caterpillar WebShell, to the 2020 variants of these malicious  files."