### PR TITLE
Fix: rename "Innitial Access" to "Initial Access"

### DIFF
--- a/clusters/mitre-ics-tactics.json
+++ b/clusters/mitre-ics-tactics.json
@@ -271,7 +271,7 @@
         ]
       },
       "uuid": "2366ffb0-91ba-4b8e-bfad-d460c98d43a8",
-      "value": "Innitial Access"
+      "value": "Initial Access"
     }
   ],
   "version": 1


### PR DESCRIPTION
Renamed mitre-ics-tactics "Innitial Access" to "Initial Access".
The original cluster contained a minor spelling mistake.
The fixed naming corresponds to the original ATT&CK framework description https://collaborate.mitre.org/attackics/index.php/Initial_Access