### PR TITLE
removing DePrimon

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -7997,21 +7997,6 @@
       "value": "Attor"
     },
     {
-      "description": "DePriMon is an unusually advanced downloader whose developers have put extra effort into setting up the architecture and crafting the critical components.",
-      "meta": {
-        "cfr-target-category": [
-          "Private sector",
-          "Finance"
-        ],
-        "cfr-type-of-incident": "Espionage",
-        "refs": [
-          "https://www.welivesecurity.com/2019/11/21/deprimon-default-print-monitor-malicious-downloader"
-        ]
-      },
-      "uuid": "443faf38-ad93-4421-8a53-47ad84b195fa",
-      "value": "DePriMon"
-    },
-    {
       "description": "According to 360 TIC the actor has carried out continuous cyber espionage activities since 2011 on key units and departments of the Chinese government, military industry, scientific research, and finance. The organization focuses on information related to the nuclear industry and scientific research. The targets were mainly concentrated in mainland China...[M]ore than 670 malware samples have been collected from the group, including more than 60 malicious plugins specifically for lateral movement; more than 40 C2 domain names and IPs related to the organization have also been discovered.",
       "meta": {
         "cfr-target-category": [


### PR DESCRIPTION
DePrimon is not a TA, added malfamily (waiting for approval) to Malpedia to better reflect that.