### PR TITLE
Symantec uses Palmerworm as alias for BlackTech

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -7406,12 +7406,14 @@
           "https://www.welivesecurity.com/2018/07/09/certificates-stolen-taiwanese-tech-companies-plead-malware-campaign/",
           "https://www.welivesecurity.com/2019/05/14/plead-malware-mitm-asus-webstorage/",
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
-          "https://www.slideshare.net/codeblue_jp/cb19-cyber-threat-landscape-in-japan-revealing-threat-in-the-shadow-by-chi-en-shen-ashley-oleg-bondarenko"
+          "https://www.slideshare.net/codeblue_jp/cb19-cyber-threat-landscape-in-japan-revealing-threat-in-the-shadow-by-chi-en-shen-ashley-oleg-bondarenko",
+          "https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/palmerworm-blacktech-espionage-apt"
         ],
         "synonyms": [
           "CIRCUIT PANDA",
           "Temp.Overboard",
-          "HUAPI"
+          "HUAPI",
+          "Palmerworm"
         ]
       },
       "uuid": "320c42f7-eab7-4ef9-b09a-74396caa6c3e",


### PR DESCRIPTION
Adding Palmerworm as Symantec alias for BlackTech (with reference).