### PR TITLE
Add alias for Tick

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -4790,6 +4790,7 @@
           "https://www.secureworks.com/research/threat-profiles/bronze-butler"
         ],
         "synonyms": [
+          "Nian",
           "BRONZE BUTLER",
           "REDBALDKNIGHT",
           "STALKER PANDA"


### PR DESCRIPTION
## Summary

The group is tracked as Nian in certain threat intel groups for its use of Chinese New Year greeting cards as its phishing decoy.