### PR TITLE
Add threat actor common raven

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -8862,7 +8862,18 @@
       },
       "uuid": "e7aff414-fc21-43eb-ad5d-9a46e07be9f5",
       "value": "BelialDemon"
+    },
+    {
+      "description": "Threat actor Common Raven has been actively targeting financial sector institutions, compromising their SWIFT payment infrastructure to send out fraudulent payments.",
+      "meta": {
+        "refs": [
+          "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-common-raven-iocs",
+          "https://www2.swift.com/isac/report/10118"
+        ]
+      },
+      "uuid": "da581c60-7c3d-4de6-b54c-cafea1c58389",
+      "value": "Common Raven"
     }
   ],
-  "version": 206
+  "version": 207
 }


### PR DESCRIPTION
Hope it's okay with this first public reference... it would help us for the ISAC MISP instance to have it directly in the main misp galaxies to refer to

Would understand if still not enough public info though