### PR TITLE
Adds Ragnatela RAT

### DIFF
--- a/clusters/rat.json
+++ b/clusters/rat.json
@@ -3497,7 +3497,26 @@
       },
       "uuid": "35198ca6-6f8d-49cd-be1b-65f21b2e7e00",
       "value": "DarkWatchman"
+    },
+    {
+      "description": "Malwarebytes Lab identified a new variant of the BADNEWS RAT called Ragnatela. It is being distributed via spear phishing emails to targets of interest in Pakistan. Ragnatela, which means spider web in Italian, is also the project name and panel used by Patchwork APT. Ironically, the threat actor infected themselves with their own RAT.",
+      "meta": {
+        "refs": [
+          "https://blog.malwarebytes.com/threat-intelligence/2022/01/patchwork-apt-caught-in-its-own-web/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "e9595678-d269-469e-ae6b-75e49259de63",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        }
+      ],
+      "uuid": "e79cb167-6639-46a3-9646-b12535aa21b6",
+      "value": "Ragnatela"
     }
   ],
-  "version": 37
+  "version": 38
 }


### PR DESCRIPTION
Ref.: https://blog.malwarebytes.com/threat-intelligence/2022/01/patchwork-apt-caught-in-its-own-web/

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>