### PR TITLE
Add threat actor group Scarab

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -9051,6 +9051,24 @@
       },
       "uuid": "d9e5be22-1a04-4956-af6c-37af02330980",
       "value": "LAPSUS"
+    },
+    {
+      "description": "Scarab APT was first spotted in 2015, but is believed to have been active since at least 2012, conducting surgical attacks against a small number of individuals across the world, including Russia and the United States. The backdoor deployed by Scarab in their campaigns is most commonly known as Scieron.",
+      "meta": {
+        "cfr-suspected-victims": [
+          "Russia",
+          "Ukraine",
+          "United States"
+        ],
+        "cfr-type-of-incident": "Espionage",
+        "country": "CN",
+        "refs": [
+          "https://web.archive.org/web/20150124025612/http://www.symantec.com:80/connect/blogs/scarab-attackers-took-aim-select-russian-targets-2012",
+          "https://www.sentinelone.com/labs/chinese-threat-actor-scarab-targeting-ukraine"
+        ]
+      },
+      "uuid": "ef59014b-79bb-408f-97f1-3c585a240ca7",
+      "value": "Scarab"
     }
   ],
   "version": 215


### PR DESCRIPTION
Scarab was recently associated with the `UAC-0026` campaign against Ukraine https://www.sentinelone.com/labs/chinese-threat-actor-scarab-targeting-ukraine, but was active since 2012, and spotted in 2015