### PR TITLE
Update threat-actor.json

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -8210,7 +8210,11 @@
       "meta": {
         "refs": [
           "https://www.microsoft.com/security/blog/2019/12/12/gallium-targeting-global-telecom/",
-          "https://www.youtube.com/watch?v=fBFm2fiEPTg"
+          "https://www.youtube.com/watch?v=fBFm2fiEPTg",
+          "https://troopers.de/troopers22/talks/7cv8pz/"
+        ],
+        "synonyms": [
+          "Red Dev 4"
         ]
       },
       "related": [
@@ -9196,5 +9200,5 @@
       "value": "UNC3524"
     }
   ],
-  "version": 220
+  "version": 221
 }


### PR DESCRIPTION
adding Red Dev 4 as alias for GALLIUM as used by PwC.