### PR TITLE
chg: [cryptominers] Adds Krane

### DIFF
--- a/clusters/cryptominers.json
+++ b/clusters/cryptominers.json
@@ -52,7 +52,17 @@
       },
       "uuid": "3dd091c9-608f-44d6-ac0c-5dfdf9bb4518",
       "value": "Blue Mockingbird Cryptominer"
+    },
+    {
+      "description": "The Krane malware uses SSH brute-force techniques to drop the XMRig cryptominer on the target to mine for the Hashvault pool.",
+      "meta": {
+        "refs": [
+          "https://cujo.com/threat-alert-krane-malware/"
+        ]
+      },
+      "uuid": "a0c0ab05-c390-425c-9311-f64bf7ca9145",
+      "value": "Krane"
     }
   ],
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
Source: https://cujo.com/threat-alert-krane-malware/

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>