### PR TITLE
Add Mitre vs Thales RosettaStone

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -67,7 +67,8 @@
           "Brown Fox",
           "GIF89a",
           "ShadyRAT",
-          "Shanghai Group"
+          "Shanghai Group",
+          "G0006"
         ]
       },
       "related": [
@@ -149,7 +150,10 @@
           "https://www.cylance.com/content/dam/cylance/pdfs/reports/Op_Dust_Storm_Report.pdf",
           "https://web.archive.org/web/20140816135909/https://www.symantec.com/connect/blogs/inside-back-door-attack",
           "https://attack.mitre.org/groups/G0031/"
-        ]
+        ],
+      "synonyms": [
+        "G0031"
+      ]
       },
       "related": [
         {
@@ -279,7 +283,8 @@
           "4HCrew",
           "SULPHUR",
           "SearchFire",
-          "TG-6952"
+          "TG-6952",
+          "G0024"
         ]
       },
       "related": [
@@ -383,7 +388,9 @@
           "APT-C-06",
           "SIG25",
           "TUNGSTEN BRIDGE",
-          "T-APT-02"
+          "T-APT-02",
+          "G0012",
+          "ATK52"
         ]
       },
       "related": [
@@ -461,11 +468,13 @@
         "country": "CN",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2015/12/the_eps_awakens.html",
-          "https://www.cfr.org/interactive/cyber-operations/apt-16"
+          "https://www.cfr.org/interactive/cyber-operations/apt-16",
+          "https://attack.mitre.org/groups/G0023"
         ],
         "synonyms": [
           "APT16",
-          "SVCMONDR"
+          "SVCMONDR",
+          "G0023"
         ]
       },
       "uuid": "1f73e14f-b882-4032-a565-26dc653b0daf",
@@ -494,7 +503,8 @@
           "https://web.archive.org/web/20141016080249/http://www.symantec.com/connect/blogs/security-vendors-take-action-against-hidden-lynx-malware",
           "https://web.archive.org/web/20130920000343/https://www.symantec.com/connect/blogs/hidden-lynx-professional-hackers-hire",
           "https://www.recordedfuture.com/hidden-lynx-analysis/",
-          "https://www.secureworks.com/research/threat-profiles/bronze-keystone"
+          "https://www.secureworks.com/research/threat-profiles/bronze-keystone",
+          "https://attack.mitre.org/groups/G0025/"
         ],
         "synonyms": [
           "APT 17",
@@ -504,7 +514,8 @@
           "Hidden Lynx",
           "Tailgater Team",
           "Dogfish",
-          "BRONZE KEYSTONE"
+          "BRONZE KEYSTONE",
+          "G0025"
         ]
       },
       "related": [
@@ -557,7 +568,8 @@
         "country": "CN",
         "refs": [
           "https://threatpost.com/apt-gang-branches-out-to-medical-espionage-in-community-health-breach/107828",
-          "https://www.cfr.org/interactive/cyber-operations/apt-18"
+          "https://www.cfr.org/interactive/cyber-operations/apt-18",
+          "https://attack.mitre.org/groups/G0026"
         ],
         "synonyms": [
           "Dynamite Panda",
@@ -565,7 +577,8 @@
           "APT 18",
           "SCANDIUM",
           "PLA Navy",
-          "APT18"
+          "APT18",
+          "G0026"
         ]
       },
       "related": [
@@ -648,7 +661,8 @@
           "BARIUM",
           "BRONZE ATLAS",
           "BRONZE EXPORT",
-          "Red Kelpie"
+          "Red Kelpie",
+          "G0044"
         ]
       },
       "related": [
@@ -731,7 +745,8 @@
           "Group 13",
           "PinkPanther",
           "Sh3llCr3w",
-          "BRONZE FIRESTONE"
+          "BRONZE FIRESTONE",
+          "G0009"
         ]
       },
       "related": [
@@ -807,7 +822,8 @@
           "APT.Naikon",
           "Lotus Panda",
           "Hellsing",
-          "BRONZE GENEVA"
+          "BRONZE GENEVA",
+          "G0019"
         ]
       },
       "related": [
@@ -879,7 +895,9 @@
           "ST Group",
           "Esile",
           "DRAGONFISH",
-          "BRONZE ELGIN"
+          "BRONZE ELGIN",
+          "ATK1",
+          "G0030"
         ]
       },
       "related": [
@@ -1037,7 +1055,8 @@
           "ZipToken",
           "Iron Tiger",
           "BRONZE UNION",
-          "Lucky Mouse"
+          "Lucky Mouse",
+          "G0027"
         ]
       },
       "related": [
@@ -1108,7 +1127,9 @@
           "CVNX",
           "HOGFISH",
           "Cloud Hopper",
-          "BRONZE RIVERSIDE"
+          "BRONZE RIVERSIDE",
+          "ATK41",
+          "G0045"
         ]
       },
       "related": [
@@ -1181,7 +1202,11 @@
           "https://kc.mcafee.com/corporate/index?page=content&id=KB71150",
           "https://securingtomorrow.mcafee.com/wp-content/uploads/2011/02/McAfee_NightDragon_wp_draft_to_customersv1-1.pdf",
           "https://attack.mitre.org/groups/G0014/"
+        ],
+        "synonyms": [
+          "G0014"
         ]
+
       },
       "related": [
         {
@@ -1233,7 +1258,8 @@
           "Lurid",
           "Social Network Team",
           "Royal APT",
-          "BRONZE PALACE"
+          "BRONZE PALACE",
+          "G0004"
         ]
       },
       "uuid": "3501fbf2-098f-47e7-be6a-6b0ff5742ce8",
@@ -1401,7 +1427,8 @@
         ],
         "synonyms": [
           "PittyTiger",
-          "MANGANESE"
+          "MANGANESE",
+          "G0011"
         ]
       },
       "related": [
@@ -1607,7 +1634,8 @@
           "Admin338",
           "Team338",
           "MAGNESIUM",
-          "admin@338"
+          "admin@338",
+          "G0018"
         ]
       },
       "related": [
@@ -1645,7 +1673,8 @@
           "KeyBoy",
           "TropicTrooper",
           "Tropic Trooper",
-          "BRONZE HOBART"
+          "BRONZE HOBART",
+          "G0081"
         ]
       },
       "uuid": "7f16d1f5-04ee-4d99-abf0-87e1f23f9fee",
@@ -1873,7 +1902,8 @@
           "iKittens",
           "Group 83",
           "Newsbeef",
-          "NewsBeef"
+          "NewsBeef",
+          "G0058"
         ]
       },
       "related": [
@@ -1962,6 +1992,7 @@
           "https://www.brighttalk.com/webcast/10703/275683",
           "https://symantec-blogs.broadcom.com/blogs/threat-intelligence/elfin-apt33-espionage",
           "https://www.secureworks.com/research/threat-profiles/cobalt-trinity",
+          "https://attack.mitre.org/groups/G0064/",
           "https://threatconnect.com/blog/research-roundup-activity-on-previously-identified-apt33-domains/"
         ],
         "synonyms": [
@@ -1970,7 +2001,9 @@
           "MAGNALLIUM",
           "Refined Kitten",
           "HOLMIUM",
-          "COBALT TRINITY"
+          "COBALT TRINITY",
+          "G0064",
+          "ATK35"
         ]
       },
       "related": [
@@ -2181,7 +2214,9 @@
           "APT35",
           "APT 35",
           "TEMP.Beanie",
-          "Ghambar"
+          "Ghambar",
+          "G0059",
+          "G0003"
         ]
       },
       "related": [
@@ -2399,7 +2434,9 @@
           "Group 74",
           "SIG40",
           "Grizzly Steppe",
-          "apt_sofacy"
+          "apt_sofacy",
+          "G0007",
+          "ATK5"
         ]
       },
       "related": [
@@ -2457,7 +2494,8 @@
           "https://www.cfr.org/interactive/cyber-operations/dukes",
           "https://pylos.co/2018/11/18/cozybear-in-from-the-cold/",
           "https://cloudblogs.microsoft.com/microsoftsecure/2018/12/03/analysis-of-cyberattack-on-u-s-think-tanks-non-profits-public-sector-by-unidentified-attackers/",
-          "https://www.secureworks.com/research/threat-profiles/iron-hemlock"
+          "https://www.secureworks.com/research/threat-profiles/iron-hemlock",
+          "https://attack.mitre.org/groups/G0016"
         ],
         "synonyms": [
           "Dukes",
@@ -2478,7 +2516,9 @@
           "Hammer Toss",
           "YTTRIUM",
           "Iron Hemlock",
-          "Grizzly Steppe"
+          "Grizzly Steppe",
+          "G0016",
+          "ATK7"
         ]
       },
       "related": [
@@ -2572,7 +2612,9 @@
           "Popeye",
           "SIG23",
           "Iron Hunter",
-          "MAKERSMARK"
+          "MAKERSMARK",
+          "ATK13",
+          "G0010"
         ]
       },
       "related": [
@@ -2646,7 +2688,9 @@
           "Havex",
           "CrouchingYeti",
           "Koala Team",
-          "IRON LIBERTY"
+          "IRON LIBERTY",
+          "G0035",
+          "ATK6"
         ]
       },
       "related": [
@@ -2819,7 +2863,9 @@
         "synonyms": [
           "CARBON SPIDER",
           "GOLD NIAGARA",
-          "Calcium"
+          "Calcium",
+          "ATK32",
+          "G0046"
         ]
       },
       "related": [
@@ -3081,7 +3127,9 @@
           "https://www.hvs-consulting.de/lazarus-report/",
           "https://github.com/hvs-consulting/ioc_signatures/tree/main/Lazarus_APT37",
           "https://blogs.jpcert.or.jp/en/2021/01/Lazarus_tools.html",
-          "https://blogs.jpcert.or.jp/en/2021/01/Lazarus_malware2.html"
+          "https://blogs.jpcert.or.jp/en/2021/01/Lazarus_malware2.html",
+          "https://attack.mitre.org/groups/G0082",
+          "https://attack.mitre.org/groups/G0032"
         ],
         "synonyms": [
           "Operation DarkSeoul",
@@ -3108,7 +3156,12 @@
           "Nickel Academy",
           "APT-C-26",
           "NICKEL GLADSTONE",
-          "COVELLITE"
+          "COVELLITE",
+          "ATK3",
+          "G0032",
+          "ATK117",
+          "G0082"
+          
         ]
       },
       "related": [
@@ -3232,7 +3285,8 @@
         ],
         "synonyms": [
           "Animal Farm",
-          "Snowglobe"
+          "Snowglobe",
+          "ATK8"
         ]
       },
       "uuid": "3b8e7462-c83f-4e7d-9511-2fe430d80aab",
@@ -3385,7 +3439,9 @@
           "Sarit",
           "Quilted Tiger",
           "APT-C-09",
-          "ZINC EMERSON"
+          "ZINC EMERSON",
+          "ATK11",
+          "G0040"
         ]
       },
       "related": [
@@ -3689,7 +3745,9 @@
           "ITG08",
           "MageCart Group 6",
           "White Giant",
-          "GOLD FRANKLIN"
+          "GOLD FRANKLIN",
+          "ATK88",
+          "G0037"
         ]
       },
       "related": [
@@ -3789,7 +3847,9 @@
           "Helix Kitten",
           "APT 34",
           "APT34",
-          "IRN2"
+          "IRN2",
+          "ATK40",
+          "G0049"
         ]
       },
       "related": [
@@ -4455,7 +4515,9 @@
           "Ocean Buffalo",
           "POND LOACH",
           "TIN WOODLAWN",
-          "BISMUTH"
+          "BISMUTH",
+          "ATK17",
+          "G0050"
         ]
       },
       "related": [
@@ -4519,7 +4581,9 @@
           "https://attack.mitre.org/groups/G0068/"
         ],
         "synonyms": [
-          "TwoForOne"
+          "TwoForOne",
+          "G0068",
+          "ATK33"
         ]
       },
       "related": [
@@ -4595,7 +4659,9 @@
         "since": "2017",
         "synonyms": [
           "LeafMiner",
-          "Raspite"
+          "Raspite",
+          "ATK113",
+          "G0061"
         ],
         "victimology": "Electric utility sector"
       },
@@ -5607,7 +5673,9 @@
           "Static Kitten",
           "Seedworm",
           "MERCURY",
-          "COBALT ULSTER"
+          "COBALT ULSTER",
+          "G0069",
+          "ATK51"
         ]
       },
       "related": [
@@ -5716,7 +5784,9 @@
           "Red Eyes",
           "Ricochet Chollima",
           "ScarCruft",
-          "Venus 121"
+          "Venus 121",
+          "ATK4",
+          "G0067"
         ]
       },
       "related": [
@@ -5803,7 +5873,9 @@
           "APT40",
           "BRONZE MOHAWK",
           "GADOLINIUM",
-          "Kryptonite Panda"
+          "Kryptonite Panda",
+          "G0065",
+          "ATK29"
         ]
       },
       "related": [
@@ -6145,7 +6217,9 @@
         ],
         "synonyms": [
           "Gorgon Group",
-          "Subaat"
+          "Subaat",
+          "ATK92",
+          "G0078"
         ]
       },
       "uuid": "e47c2c4d-706b-4098-92a2-b93e7103e131",
@@ -6393,6 +6467,10 @@
           "India",
           "United States"
         ],
+        "synonyms": [
+          "ATK78",
+          "G0076"
+        ],
         "cfr-target-category": [
           "Government",
           "Civil society"
@@ -6524,7 +6602,11 @@
         "country": "RU",
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/cloud-atlas"
-        ]
+        ],
+        "synonyms": [
+          "ATK116",
+          "G0100"
+      ]
       },
       "uuid": "1572f618-bcb3-11e8-841b-1fd7f9cfe126",
       "value": "Cloud Atlas"
@@ -6826,7 +6908,9 @@
           "GRACEFUL SPIDER",
           "GOLD TAHOE",
           "Dudear",
-          "TEMP.Warlock"
+          "TEMP.Warlock",
+          "G0092",
+          "ATK103"
         ]
       },
       "uuid": "03c80674-35f8-4fe0-be2b-226ed0fcd69f",
@@ -7452,7 +7536,9 @@
           "https://attack.mitre.org/groups/G0088/"
         ],
         "synonyms": [
-          "Xenotime"
+          "Xenotime",
+          "G0088",
+          "ATK91"
         ]
       },
       "uuid": "90abfc42-91c6-11e9-89b1-af58de8f7ec2",
@@ -8445,7 +8531,11 @@
           "https://www.rnz.co.nz/news/political/447239/government-points-finger-at-china-over-cyber-attacks",
           "https://www.gov.uk/government/news/uk-and-allies-hold-chinese-state-responsible-for-a-pervasive-pattern-of-hacking",
           "https://www.foreignminister.gov.au/minister/marise-payne/media-release/australia-joins-international-partners-attribution-malicious-cyber-activity-china"
-        ]
+        ],
+      "synonyms": [
+        "ATK233",
+        "G0125"
+      ]
       },
       "uuid": "4f05d6c1-3fc1-4567-91cd-dd4637cc38b5",
       "value": "HAFNIUM"
@@ -8702,7 +8792,9 @@
         ],
         "synonyms": [
           "Shakthak",
-          "TA551"
+          "TA551",
+          "ATK2361",
+          "G01271"
         ]
       },
       "uuid": "36e8c848-4d20-47ea-9fc2-31aa17bf82d1",
@@ -9335,5 +9427,5 @@
       "value": "RansomHouse"
     }
   ],
-  "version": 227
+  "version": 228
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -8793,7 +8793,7 @@
         "synonyms": [
           "Shakthak",
           "TA551",
-          "ATK2361",
+          "ATK236",
           "G01271"
         ]
       },

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -151,9 +151,9 @@
           "https://web.archive.org/web/20140816135909/https://www.symantec.com/connect/blogs/inside-back-door-attack",
           "https://attack.mitre.org/groups/G0031/"
         ],
-      "synonyms": [
-        "G0031"
-      ]
+        "synonyms": [
+          "G0031"
+        ]
       },
       "related": [
         {
@@ -1206,7 +1206,6 @@
         "synonyms": [
           "G0014"
         ]
-
       },
       "related": [
         {
@@ -3161,7 +3160,6 @@
           "G0032",
           "ATK117",
           "G0082"
-          
         ]
       },
       "related": [
@@ -6467,10 +6465,6 @@
           "India",
           "United States"
         ],
-        "synonyms": [
-          "ATK78",
-          "G0076"
-        ],
         "cfr-target-category": [
           "Government",
           "Civil society"
@@ -6479,6 +6473,10 @@
         "country": "PK",
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/stealth-mango-and-tangelo"
+        ],
+        "synonyms": [
+          "ATK78",
+          "G0076"
         ]
       },
       "uuid": "f82b352e-a9f8-11e8-8be8-fbcf6eddd58c",
@@ -6606,7 +6604,7 @@
         "synonyms": [
           "ATK116",
           "G0100"
-      ]
+        ]
       },
       "uuid": "1572f618-bcb3-11e8-841b-1fd7f9cfe126",
       "value": "Cloud Atlas"
@@ -8532,10 +8530,10 @@
           "https://www.gov.uk/government/news/uk-and-allies-hold-chinese-state-responsible-for-a-pervasive-pattern-of-hacking",
           "https://www.foreignminister.gov.au/minister/marise-payne/media-release/australia-joins-international-partners-attribution-malicious-cyber-activity-china"
         ],
-      "synonyms": [
-        "ATK233",
-        "G0125"
-      ]
+        "synonyms": [
+          "ATK233",
+          "G0125"
+        ]
       },
       "uuid": "4f05d6c1-3fc1-4567-91cd-dd4637cc38b5",
       "value": "HAFNIUM"

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -8788,13 +8788,14 @@
       "description": "GOLD CABIN is a financially motivated cybercriminal threat group operating a malware distribution service on behalf of numerous customers since 2018. GOLD CABIN uses malicious documents, often contained in password-protected archives, delivered through email to download and execute payloads. The second-stage payloads are most frequently Gozi ISFB (Ursnif) or IcedID (Bokbot), sometimes using intermediary malware like Valak. GOLD CABIN infrastructure relies on artificial appearing and frequently changing URLs created with a domain generation algorithm (DGA). The URLs host a PHP object that returns the malware as a DLL file.",
       "meta": {
         "refs": [
-          "https://www.secureworks.com/research/threat-profiles/gold-cabin"
+          "https://www.secureworks.com/research/threat-profiles/gold-cabin",
+          "https://attack.mitre.org/groups/G0127/"
         ],
         "synonyms": [
           "Shakthak",
           "TA551",
           "ATK236",
-          "G01271"
+          "G0127"
         ]
       },
       "uuid": "36e8c848-4d20-47ea-9fc2-31aa17bf82d1",


### PR DESCRIPTION
Hi, 

Since the release of https://cyberthreat.thalesgroup.com/sites/default/files/2022-05/THALES%20THREAT%20HANDBOOK%202022%20Light%20Version_1.pdf and the ATK nomenclature...

I definitively need a new rosetta stone !...

I am personally convinced that ATT&CK Group IDs should be the pivot :) 

