### PR TITLE
[threat actors] Fix threat actors related to Lotus Panda

### DIFF
--- a/clusters/mitre-enterprise-attack-intrusion-set.json
+++ b/clusters/mitre-enterprise-attack-intrusion-set.json
@@ -1216,13 +1216,6 @@
           "type": "similar"
         },
         {
-          "dest-uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "f047ee18-7985-4946-8bfb-4ed754d3a0dd",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -1409,13 +1402,6 @@
         },
         {
           "dest-uuid": "5e0a7cf2-6107-4d5f-9dd0-9df38b1fcba8",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],

--- a/clusters/mitre-intrusion-set.json
+++ b/clusters/mitre-intrusion-set.json
@@ -9233,13 +9233,6 @@
           "type": "uses"
         },
         {
-          "dest-uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
           "dest-uuid": "fb261c56-b80e-43a9-8351-c84081e7213d",
           "tags": [
             "estimative-language:likelihood-probability=\"almost-certain\""
@@ -18419,13 +18412,6 @@
             "estimative-language:likelihood-probability=\"almost-certain\""
           ],
           "type": "uses"
-        },
-        {
-          "dest-uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         },
         {
           "dest-uuid": "ff6caf67-ea1f-4895-b80e-4bb0fc31c6db",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -807,7 +807,6 @@
           "https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07205555/TheNaikonAPT-MsnMM1.pdf",
           "https://usa.kaspersky.com/resource-center/threats/naikon-targeted-attacks",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/bkdr_rarstone-new-rat-to-watch-out-for/",
-          "https://securelist.com/the-chronicles-of-the-hellsing-apt-the-empire-strikes-back/69567/",
           "https://threatconnect.com/blog/tag/naikon/",
           "https://attack.mitre.org/groups/G0019/",
           "https://www.secureworks.com/research/threat-profiles/bronze-geneva",
@@ -1138,8 +1137,8 @@
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
         "refs": [
-          "https://securelist.com/analysis/publications/69567/the-chronicles-of-the-hellsing-apt-the-empire-strikes-back/",
-          "https://www.cfr.org/interactive/cyber-operations/hellsing"
+          "https://www.cfr.org/interactive/cyber-operations/hellsing",
+          "https://securelist.com/the-chronicles-of-the-hellsing-apt-the-empire-strikes-back/69567/"
         ]
       },
       "uuid": "af482dde-9e47-48d5-9cb2-cf8f6d6303d3",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -9845,8 +9845,7 @@
         ],
         "synonyms": [
           "Conimes",
-          "Cycldek",
-          "ATK34"
+          "Cycldek"
         ]
       },
       "uuid": "8d73715a-8bbd-4eaa-ae24-2f1b1c84cf21",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6448,10 +6448,12 @@
           "https://www.cfr.org/interactive/cyber-operations/thrip",
           "https://www.symantec.com/blogs/threat-intelligence/thrip-hits-satellite-telecoms-defense-targets",
           "https://attack.mitre.org/groups/G0076/",
-          "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
+          "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
+          "https://cyberthreat.thalesgroup.com/sites/default/files/2022-05/THALES%20THREAT%20HANDBOOK%202022%20Light%20Version_1.pdf"
         ],
         "synonyms": [
-          "G0076"
+          "G0076",
+          "UTK78"
         ]
       },
       "uuid": "98be4300-a9ef-11e8-9a95-bb9221083cfc",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -820,7 +820,7 @@
         ],
         "synonyms": [
           "PLA Unit 78020",
-          "Override Panda",
+          "OVERRIDE PANDA",
           "Camerashy",
           "BRONZE GENEVA",
           "G0019",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -822,7 +822,6 @@
           "PLA Unit 78020",
           "Override Panda",
           "Camerashy",
-          "Lotus Panda",
           "BRONZE GENEVA",
           "G0019",
           "APT 30",
@@ -893,7 +892,8 @@
           "BRONZE ELGIN",
           "ATK1",
           "G0030",
-          "Red Salamander"
+          "Red Salamander",
+          "Lotus Panda"
         ]
       },
       "related": [

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6329,7 +6329,7 @@
         ],
         "synonyms": [
           "G0076",
-          "UTK78"
+          "ATK78"
         ]
       },
       "uuid": "98be4300-a9ef-11e8-9a95-bb9221083cfc",
@@ -9846,7 +9846,7 @@
         "synonyms": [
           "Conimes",
           "Cycldek",
-          "ATK78"
+          "ATK34"
         ]
       },
       "uuid": "8d73715a-8bbd-4eaa-ae24-2f1b1c84cf21",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -894,7 +894,7 @@
           "ATK1",
           "G0030",
           "Red Salamander",
-          "Lotus Panda"
+          "LOTUS PANDA"
         ]
       },
       "related": [

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -824,7 +824,8 @@
           "Camerashy",
           "BRONZE GENEVA",
           "G0019",
-          "APT 30",
+          "APT30",
+          "BRONZE STERLING",
           "G0013"
         ]
       },

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -805,21 +805,20 @@
           "https://www.fireeye.com/blog/threat-research/2014/03/spear-phishing-the-news-cycle-apt-actors-leverage-interest-in-the-disappearance-of-malaysian-flight-mh-370.html",
           "https://www.cfr.org/interactive/cyber-operations/apt-30",
           "https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07205555/TheNaikonAPT-MsnMM1.pdf",
+          "https://usa.kaspersky.com/resource-center/threats/naikon-targeted-attacks",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/bkdr_rarstone-new-rat-to-watch-out-for/",
           "https://securelist.com/the-chronicles-of-the-hellsing-apt-the-empire-strikes-back/69567/",
           "https://threatconnect.com/blog/tag/naikon/",
           "https://attack.mitre.org/groups/G0019/",
-          "https://www.secureworks.com/research/threat-profiles/bronze-geneva"
+          "https://www.secureworks.com/research/threat-profiles/bronze-geneva",
+          "https://cyware.com/news/chinese-naikon-group-back-with-new-espionage-attack-66a8413d",
+          "https://cluster25.io/2022/04/29/lotus-panda-awake-last-strike/"
         ],
         "synonyms": [
           "PLA Unit 78020",
-          "APT 30",
-          "APT30",
           "Override Panda",
           "Camerashy",
-          "APT.Naikon",
           "Lotus Panda",
-          "Hellsing",
           "BRONZE GENEVA",
           "G0019"
         ]
@@ -910,50 +909,6 @@
       ],
       "uuid": "32fafa69-fe3c-49db-afd4-aac2664bcf0d",
       "value": "Lotus Blossom"
-    },
-    {
-      "meta": {
-        "attribution-confidence": "50",
-        "country": "CN",
-        "refs": [
-          "http://www.crowdstrike.com/blog/rhetoric-foreshadows-cyber-activity-in-the-south-china-sea/"
-        ],
-        "synonyms": [
-          "Elise"
-        ]
-      },
-      "related": [
-        {
-          "dest-uuid": "2a158b0a-7ef8-43cb-9985-bf34d1e12050",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "2f1fd017-9df6-4759-91fb-e7039609b5ff",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "f047ee18-7985-4946-8bfb-4ed754d3a0dd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "5e0a7cf2-6107-4d5f-9dd0-9df38b1fcba8",
-      "value": "Lotus Panda"
     },
     {
       "description": "We have investigated their intrusions since 2013 and have been battling them nonstop over the last year at several large telecommunications and technology companies. The determination of this China-based adversary is truly impressive: they are like a dog with a bone.\nHURRICANE PANDA's preferred initial vector of compromise and persistence is a China Chopper webshell – a tiny and easily obfuscated 70 byte text file that consists of an ‘eval()’ command, which is then used to provide full command execution and file upload/download capabilities to the attackers. This script is typically uploaded to a web server via a SQL injection or WebDAV vulnerability, which is often trivial to uncover in a company with a large external web presence.\nOnce inside, the adversary immediately moves on to execution of a credential theft tool such as Mimikatz (repacked to avoid AV detection). If they are lucky to have caught an administrator who might be logged into that web server at the time, they will have gained domain administrator credentials and can now roam your network at will via ‘net use’ and ‘wmic’ commands executed through the webshell terminal.",
@@ -3612,7 +3567,8 @@
           "https://www.ptsecurity.com/ww-en/analytics/pt-esc-threat-intelligence/eagle-eye-is-back-apt30/",
           "https://www2.fireeye.com/rs/fireye/images/rpt-apt30.pdf",
           "https://attack.mitre.org/wiki/Group/G0013",
-          "https://www.cfr.org/interactive/cyber-operations/apt-30"
+          "https://www.cfr.org/interactive/cyber-operations/apt-30",
+          "https://www.mandiant.com/sites/default/files/2021-09/rpt-apt30.pdf"
         ],
         "synonyms": [
           "APT30",
@@ -6504,7 +6460,6 @@
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
         ],
         "synonyms": [
-          "LOTUS PANDA",
           "G0076"
         ]
       },
@@ -6534,11 +6489,7 @@
         "country": "PK",
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/stealth-mango-and-tangelo",
-          "https://attack.mitre.org/groups/G0076"
-        ],
-        "synonyms": [
-          "ATK78",
-          "G0076"
+          "https://www.lookout.com/blog/stealth-mango"
         ]
       },
       "uuid": "f82b352e-a9f8-11e8-8be8-fbcf6eddd58c",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -812,7 +812,11 @@
           "https://attack.mitre.org/groups/G0019/",
           "https://www.secureworks.com/research/threat-profiles/bronze-geneva",
           "https://cyware.com/news/chinese-naikon-group-back-with-new-espionage-attack-66a8413d",
-          "https://cluster25.io/2022/04/29/lotus-panda-awake-last-strike/"
+          "https://cluster25.io/2022/04/29/lotus-panda-awake-last-strike/",
+          "https://www.ptsecurity.com/ww-en/analytics/pt-esc-threat-intelligence/eagle-eye-is-back-apt30/",
+          "https://www2.fireeye.com/rs/fireye/images/rpt-apt30.pdf",
+          "https://attack.mitre.org/wiki/Group/G0013",
+          "https://www.mandiant.com/sites/default/files/2021-09/rpt-apt30.pdf"
         ],
         "synonyms": [
           "PLA Unit 78020",
@@ -820,7 +824,9 @@
           "Camerashy",
           "Lotus Panda",
           "BRONZE GENEVA",
-          "G0019"
+          "G0019",
+          "APT 30",
+          "G0013"
         ]
       },
       "related": [
@@ -833,13 +839,6 @@
         },
         {
           "dest-uuid": "5e0a7cf2-6107-4d5f-9dd0-9df38b1fcba8",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -3485,78 +3484,6 @@
       ],
       "uuid": "f3179cfb-9c86-4980-bd6b-e4fa74adaaa7",
       "value": "ProjectSauron"
-    },
-    {
-      "description": "APT 30 is a threat group suspected to be associated with the Chinese government. While Naikon shares some characteristics with APT30, the two groups do not appear to be exact matches.",
-      "meta": {
-        "attribution-confidence": "50",
-        "cfr-suspected-state-sponsor": "China",
-        "cfr-suspected-victims": [
-          "India",
-          "Saudi Arabia",
-          "Vietnam",
-          "Myanmar",
-          "Singapore",
-          "Thailand",
-          "Malaysia",
-          "Cambodia",
-          "China",
-          "Phillipines",
-          "South Korea",
-          "United States",
-          "Indonesia",
-          "Laos"
-        ],
-        "cfr-target-category": [
-          "Government",
-          "Private sector"
-        ],
-        "cfr-type-of-incident": "Espionage",
-        "country": "CN",
-        "refs": [
-          "https://www.ptsecurity.com/ww-en/analytics/pt-esc-threat-intelligence/eagle-eye-is-back-apt30/",
-          "https://www2.fireeye.com/rs/fireye/images/rpt-apt30.pdf",
-          "https://attack.mitre.org/wiki/Group/G0013",
-          "https://www.cfr.org/interactive/cyber-operations/apt-30",
-          "https://www.mandiant.com/sites/default/files/2021-09/rpt-apt30.pdf"
-        ],
-        "synonyms": [
-          "APT30",
-          "G0013"
-        ]
-      },
-      "related": [
-        {
-          "dest-uuid": "2a158b0a-7ef8-43cb-9985-bf34d1e12050",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "2f1fd017-9df6-4759-91fb-e7039609b5ff",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "5e0a7cf2-6107-4d5f-9dd0-9df38b1fcba8",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "f047ee18-7985-4946-8bfb-4ed754d3a0dd",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "f26144c5-8593-4e78-831a-11f6452d809b",
-      "value": "APT 30"
     },
     {
       "description": "TA530, who we previously examined in relation to large-scale personalized phishing campaigns",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -890,7 +890,6 @@
         "synonyms": [
           "Spring Dragon",
           "ST Group",
-          "Esile",
           "DRAGONFISH",
           "BRONZE ELGIN",
           "ATK1",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -1139,15 +1139,7 @@
         "country": "CN",
         "refs": [
           "https://securelist.com/analysis/publications/69567/the-chronicles-of-the-hellsing-apt-the-empire-strikes-back/",
-          "https://www.cfr.org/interactive/cyber-operations/hellsing",
-          "https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-august-goblin-panda/",
-          "https://securelist.com/cycldek-bridging-the-air-gap/97157/",
-          "https://www.fortinet.com/blog/threat-research/cta-security-playbook--goblin-panda.html"
-        ],
-        "synonyms": [
-          "Goblin Panda",
-          "Conimes",
-          "Cycldek"
+          "https://www.cfr.org/interactive/cyber-operations/hellsing"
         ]
       },
       "uuid": "af482dde-9e47-48d5-9cb2-cf8f6d6303d3",
@@ -9989,6 +9981,41 @@
       },
       "uuid": "d58030e2-5673-4836-9aff-ab6d55da0bc0",
       "value": "SLIME29"
+    },
+    {
+      "description": "Goblin Panda is one of a handful of elite Chinese advanced persistent threat (APT) groups. Most Chinese APTs target the United States and NATO, but Goblin Panda focuses primarily on Southeast Asia.",
+      "meta": {
+        "attribution-confidence": "75",
+        "cfr-suspected-state-sponsor": "China",
+        "cfr-suspected-victims": [
+          "Malaysia",
+          "India",
+          "Indonesia",
+          "Japan",
+          "Philippines",
+          "Southeast Asia",
+          "South Korea",
+          "Vietnam"
+        ],
+        "cfr-target-category": [
+          "Private Sector"
+        ],
+        "country": "CN",
+        "refs": [
+          "https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-august-goblin-panda/",
+          "https://securelist.com/cycldek-bridging-the-air-gap/97157/",
+          "https://www.fortinet.com/blog/threat-research/cta-security-playbook--goblin-panda.html",
+          "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
+          "https://cyberthreat.thalesgroup.com/sites/default/files/2022-05/THALES%20THREAT%20HANDBOOK%202022%20Light%20Version_1.pdf"
+        ],
+        "synonyms": [
+          "Conimes",
+          "Cycldek",
+          "ATK78"
+        ]
+      },
+      "uuid": "8d73715a-8bbd-4eaa-ae24-2f1b1c84cf21",
+      "value": "Goblin Panda"
     }
   ],
   "version": 239

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -8484,6 +8484,29 @@
       },
       "uuid": "f43a3828-a3b6-11ec-80e1-55a8e5815c2c",
       "value": "BadPotato"
+    },
+    {
+      "description": "The Esile campaign was named after certain strings found in the unpacked malware file that it sends out. All of the malware related to this campaign are detected as BKDR_ESILE variants.",
+      "meta": {
+        "refs": [
+          "https://www.trendmicro.com/vinfo/de/security/news/cyber-attacks/esile-targeted-attack-campaign-hits-apac-governments",
+          "https://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/esile"
+        ],
+        "synonyms": [
+          "BKDR_ESILE"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32fafa69-fe3c-49db-afd4-aac2664bcf0d",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "7d34ca56-ce69-465f-b8c8-ffd02c4b619d",
+      "value": "Esile"
     }
   ],
   "version": 150


### PR DESCRIPTION
There were a few conflicting aliases around Naikon/Lotus Panda:
![image](https://user-images.githubusercontent.com/23531109/185004347-7b1d39dc-f837-4ee6-9f3d-c62b07801fe7.png)

Here are my the changes I suggest to fix the conflicts:
 - Remove the `Lotus Panda` threat actor. `Lotus Panda` is an alias of `Naikon`
 - Remove `Lotus Panda` alias from `Thrip`
 - Remove `Hellsing` alias from `Naikon`
 - Remove `APT30` alias from `Naikon`
 - Remove `Thrip` alias from `Stealth Mango and Tangelo`