### PR TITLE
[threat-actors] Fix Axiom/Winnti/Suckfly/APT41 conflicts

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -520,8 +520,6 @@
           "https://www.youtube.com/watch?v=NFJqD-LcpIg"
         ],
         "synonyms": [
-          "APT 17",
-          "Deputy Dog",
           "Group 8",
           "APT17",
           "Hidden Lynx",
@@ -529,8 +527,9 @@
           "Dogfish",
           "BRONZE KEYSTONE",
           "G0025",
-          "Group72",
-          "G0001"
+          "Group 72",
+          "G0001",
+          "Axiom"
         ]
       },
       "related": [
@@ -3576,7 +3575,8 @@
         "synonyms": [
           "G0039",
           "APT22",
-          "BRONZE OLIVE"
+          "BRONZE OLIVE",
+          "Group 46"
         ]
       },
       "related": [
@@ -7592,7 +7592,6 @@
           "Double Dragon",
           "G0096",
           "TA415",
-          "Winnti Group",
           "Blackfly",
           "Grayfly",
           "LEAD",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -486,7 +486,17 @@
         "attribution-confidence": "50",
         "cfr-suspected-state-sponsor": "China",
         "cfr-suspected-victims": [
-          "United States"
+          "United States",
+          "Netherlands",
+          "Italy",
+          "Japan",
+          "United Kingdom",
+          "Belgium",
+          "Russia",
+          "Indonesia",
+          "Germany",
+          "Switzerland",
+          "China"
         ],
         "cfr-target-category": [
           "Government",
@@ -504,7 +514,10 @@
           "https://web.archive.org/web/20130920000343/https://www.symantec.com/connect/blogs/hidden-lynx-professional-hackers-hire",
           "https://www.recordedfuture.com/hidden-lynx-analysis/",
           "https://www.secureworks.com/research/threat-profiles/bronze-keystone",
-          "https://attack.mitre.org/groups/G0025/"
+          "https://attack.mitre.org/groups/G0025/",
+          "cfr.org/cyber-operations/axiom",
+          "https://attack.mitre.org/groups/G0001/",
+          "https://www.youtube.com/watch?v=NFJqD-LcpIg"
         ],
         "synonyms": [
           "APT 17",
@@ -515,19 +528,14 @@
           "Tailgater Team",
           "Dogfish",
           "BRONZE KEYSTONE",
-          "G0025"
+          "G0025",
+          "Group72",
+          "G0001"
         ]
       },
       "related": [
         {
           "dest-uuid": "090242d7-73fc-4738-af68-20162f7a5aae",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -599,72 +607,6 @@
       ],
       "uuid": "9a683d9c-8f7d-43df-bba2-ad0ca71e277c",
       "value": "Wekby"
-    },
-    {
-      "description": "Axiom is a suspected Chinese cyber espionage group that has targeted the aerospace, defense, government, manufacturing, and media sectors since at least 2008. Some reporting suggests a degree of overlap between Axiom and Winnti Group but the two groups appear to be distinct based on differences in reporting on TTPs and targeting.",
-      "meta": {
-        "attribution-confidence": "50",
-        "cfr-suspected-state-sponsor": "China",
-        "cfr-suspected-victims": [
-          "United States",
-          "Netherlands",
-          "Italy",
-          "Japan",
-          "United Kingdom",
-          "Belgium",
-          "Russia",
-          "Indonesia",
-          "Germany",
-          "Switzerland",
-          "China"
-        ],
-        "cfr-target-category": [
-          "Government",
-          "Private sector"
-        ],
-        "cfr-type-of-incident": "Espionage",
-        "country": "CN",
-        "refs": [
-          "cfr.org/cyber-operations/axiom",
-          "https://attack.mitre.org/groups/G0001/"
-        ],
-        "synonyms": [
-          "Group72",
-          "G0001"
-        ]
-      },
-      "related": [
-        {
-          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "090242d7-73fc-4738-af68-20162f7a5aae",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "a0cb9370-e39b-44d5-9f50-ef78e412b973",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
-        {
-          "dest-uuid": "9c124874-042d-48cd-b72b-ccdc51ecbbd6",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
-      "value": "Axiom"
     },
     {
       "description": "Adversary group targeting financial, technology, non-profit organisations.",
@@ -7672,7 +7614,7 @@
           "type": "uses"
         },
         {
-          "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
+          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
           "tags": [
             "estimative-language:likelihood-probability=\"very-likely\""
           ],

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -635,14 +635,14 @@
       },
       "related": [
         {
-          "dest-uuid": "090242d7-73fc-4738-af68-20162f7a5aae",
+          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         },
         {
-          "dest-uuid": "99e30d89-9361-4b73-a999-9e5ff9320bcb",
+          "dest-uuid": "090242d7-73fc-4738-af68-20162f7a5aae",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -607,19 +607,14 @@
         "cfr-suspected-state-sponsor": "China",
         "cfr-suspected-victims": [
           "United States",
-          "Netherlands",
-          "Italy",
-          "Japan",
+          "South Korea",
+          "Universities in Hong Kong",
           "United Kingdom",
-          "Belgium",
-          "Russia",
-          "Indonesia",
-          "Germany",
-          "Switzerland",
-          "China"
+          "China",
+          "Japan",
+          "Hong Kong"
         ],
         "cfr-target-category": [
-          "Government",
           "Private sector"
         ],
         "cfr-type-of-incident": "Espionage",
@@ -629,7 +624,6 @@
           "https://securelist.com/winnti-more-than-just-a-game/37029/",
           "http://williamshowalter.com/a-universal-windows-bootkit/",
           "https://www.microsoft.com/security/blog/2017/01/25/detecting-threat-actors-in-recent-german-industrial-attacks-with-windows-defender-atp/",
-          "https://www.cfr.org/interactive/cyber-operations/axiom",
           "https://securelist.com/games-are-over/70991/",
           "https://medium.com/chronicle-blog/winnti-more-than-just-windows-and-gates-e4f03436031a",
           "https://www.dw.com/en/thyssenkrupp-victim-of-cyber-attack/a-36695341",
@@ -644,14 +638,11 @@
           "https://www.secureworks.com/research/threat-profiles/bronze-export",
           "https://www.pwc.co.uk/cyber-security/assets/cyber-threats-2019-retrospect.pdf",
           "https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer",
-          "https://assets.documentcloud.org/documents/7210602/FLASH-AC-000133-TT-Published.pdf"
+          "https://assets.documentcloud.org/documents/7210602/FLASH-AC-000133-TT-Published.pdf",
+          "https://www.cfr.org/cyber-operations/winnti-umbrella"
         ],
         "synonyms": [
           "Winnti Umbrella",
-          "Winnti Group",
-          "Suckfly",
-          "APT41",
-          "Group72",
           "Blackfly",
           "LEAD",
           "WICKED SPIDER",
@@ -691,10 +682,24 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "9c124874-042d-48cd-b72b-ccdc51ecbbd6",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "2943148b-8bc5-4bcb-b85e-f00c2174dd47",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
-      "value": "Axiom"
+      "value": "Winnti"
     },
     {
       "description": "Adversary group targeting financial, technology, non-profit organisations.",
@@ -3656,7 +3661,8 @@
         "refs": [
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=62e325ae-f551-4855-b9cf-28a7d52d1534&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=7a60af1f-7786-446c-976b-7c71a16e9d3b&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
-          "https://attack.mitre.org/groups/G0039/"
+          "https://attack.mitre.org/groups/G0039/",
+          "https://exchange.xforce.ibmcloud.com/collection/Suckfly-APT-aa8af56fd12d25c98fc49ca5341160ab"
         ],
         "synonyms": [
           "G0039"
@@ -6289,30 +6295,6 @@
       "value": "Inception Framework"
     },
     {
-      "description": "This threat actor targets software companies and political organizations in the United States, China, Japan, and South Korea. It primarily acts to support cyber operations conducted by other threat actors affiliated with Chinese intelligence services.\nBelieved to be associated with the Axiom, APT 17, and Mirage threat actors. Believed to share the same tools and infrastructure as the threat actors that carried out Operation Aurora, the 2015 targeting of video game companies, the 2015 targeting of the Thai government, and the 2017 targeting of Chinese-language news websites",
-      "meta": {
-        "attribution-confidence": "50",
-        "cfr-suspected-state-sponsor": "China",
-        "cfr-suspected-victims": [
-          "United States",
-          "South Korea",
-          "United Kingdom",
-          "China",
-          "Japan"
-        ],
-        "cfr-target-category": [
-          "Private sector"
-        ],
-        "cfr-type-of-incident": "Espionage",
-        "country": "CN",
-        "refs": [
-          "https://www.cfr.org/interactive/cyber-operations/winnti-umbrella"
-        ]
-      },
-      "uuid": "9cebfaa8-a797-11e8-99e0-3ffa312b9a10",
-      "value": "Winnti Umbrella"
-    },
-    {
       "description": "This threat actor targets Uighurs—a minority ethnic group located primarily in northwestern China—and devices from Chinese mobile phone manufacturer Xiaomi, for espionage purposes.",
       "meta": {
         "attribution-confidence": "50",
@@ -7683,7 +7665,15 @@
         "country": "CN",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2019/08/apt41-dual-espionage-and-cyber-crime-operation.html",
-          "https://unit42.paloaltonetworks.com/apt41-using-new-speculoos-backdoor-to-target-organizations-globally/"
+          "https://unit42.paloaltonetworks.com/apt41-using-new-speculoos-backdoor-to-target-organizations-globally/",
+          "https://www.mandiant.com/resources/report-apt41-double-dragon-a-dual-espionage-and-cyber-crime-operation",
+          "https://www.cfr.org/cyber-operations/apt-41",
+          "https://attack.mitre.org/groups/G0096/"
+        ],
+        "synonyms": [
+          "Double Dragon",
+          "G0096",
+          "TA415"
         ]
       },
       "related": [
@@ -7693,6 +7683,13 @@
             "estimative-language:likelihood-probability=\"very-likely\""
           ],
           "type": "uses"
+        },
+        {
+          "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "similar"
         }
       ],
       "uuid": "9c124874-042d-48cd-b72b-ccdc51ecbbd6",
@@ -9882,6 +9879,50 @@
       },
       "uuid": "e1e70539-8916-45c2-9b01-891c1c5bd8a1",
       "value": "TA558"
+    },
+    {
+      "description": "Axiom is a suspected Chinese cyber espionage group that has targeted the aerospace, defense, government, manufacturing, and media sectors since at least 2008. Some reporting suggests a degree of overlap between Axiom and Winnti Group but the two groups appear to be distinct based on differences in reporting on TTPs and targeting.",
+      "meta": {
+        "cfr-suspected-state-sponsor": "China",
+        "cfr-suspected-victims": [
+          "United States",
+          "Netherlands",
+          "Italy",
+          "Japan",
+          "United Kingdom",
+          "Belgium",
+          "Russia",
+          "Indonesia",
+          "Germany",
+          "Switzerland",
+          "China"
+        ],
+        "cfr-target-category": [
+          "Government",
+          "Private sector"
+        ],
+        "cfr-type-of-incident": "Espionage",
+        "country": "CN",
+        "refs": [
+          "cfr.org/cyber-operations/axiom",
+          "https://attack.mitre.org/groups/G0001/"
+        ],
+        "synonyms": [
+          "Group72",
+          "G0001"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "similar"
+        }
+      ],
+      "uuid": "2943148b-8bc5-4bcb-b85e-f00c2174dd47",
+      "value": "Axiom"
     }
   ],
   "version": 241

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -529,7 +529,9 @@
           "G0025",
           "Group 72",
           "G0001",
-          "Axiom"
+          "Axiom",
+          "Earth Baku",
+          "Amoeba"
         ]
       },
       "related": [

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -601,67 +601,39 @@
       "value": "Wekby"
     },
     {
-      "description": "The Winnti grouping of activity is large and may actually be a number of linked groups rather than a single discrete entity. Kaspersky describe Winnti as: 'The Winnti group has been attacking companies in the online video game industry since 2009 and is currently still active. The groups objectives are stealing digital certificates signed by legitimate software vendors in addition to intellectual property theft, including the source code of online game projects. The majority of the victims are from South East Asia.'",
+      "description": "Axiom is a suspected Chinese cyber espionage group that has targeted the aerospace, defense, government, manufacturing, and media sectors since at least 2008. Some reporting suggests a degree of overlap between Axiom and Winnti Group but the two groups appear to be distinct based on differences in reporting on TTPs and targeting.",
       "meta": {
         "attribution-confidence": "50",
         "cfr-suspected-state-sponsor": "China",
         "cfr-suspected-victims": [
           "United States",
-          "South Korea",
-          "Universities in Hong Kong",
-          "United Kingdom",
-          "China",
+          "Netherlands",
+          "Italy",
           "Japan",
-          "Hong Kong"
+          "United Kingdom",
+          "Belgium",
+          "Russia",
+          "Indonesia",
+          "Germany",
+          "Switzerland",
+          "China"
         ],
         "cfr-target-category": [
+          "Government",
           "Private sector"
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
         "refs": [
-          "https://securelist.com/winnti-faq-more-than-just-a-game/57585/",
-          "https://securelist.com/winnti-more-than-just-a-game/37029/",
-          "http://williamshowalter.com/a-universal-windows-bootkit/",
-          "https://www.microsoft.com/security/blog/2017/01/25/detecting-threat-actors-in-recent-german-industrial-attacks-with-windows-defender-atp/",
-          "https://securelist.com/games-are-over/70991/",
-          "https://medium.com/chronicle-blog/winnti-more-than-just-windows-and-gates-e4f03436031a",
-          "https://www.dw.com/en/thyssenkrupp-victim-of-cyber-attack/a-36695341",
-          "https://www.bleepingcomputer.com/news/security/teamviewer-confirms-undisclosed-breach-from-2016/",
-          "https://blog.trendmicro.com/trendlabs-security-intelligence/winnti-abuses-github/",
-          "https://www.dw.com/en/bayer-points-finger-at-wicked-panda-in-cyberattack/a-48196004",
-          "https://www.welivesecurity.com/2019/03/11/gaming-industry-scope-attackers-asia/",
-          "https://401trg.com/burning-umbrella/",
-          "https://attack.mitre.org/groups/G0044/",
-          "https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-july-wicked-spider/",
-          "https://www.secureworks.com/research/threat-profiles/bronze-atlas",
-          "https://www.secureworks.com/research/threat-profiles/bronze-export",
-          "https://www.pwc.co.uk/cyber-security/assets/cyber-threats-2019-retrospect.pdf",
-          "https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer",
-          "https://assets.documentcloud.org/documents/7210602/FLASH-AC-000133-TT-Published.pdf",
-          "https://www.cfr.org/cyber-operations/winnti-umbrella"
+          "cfr.org/cyber-operations/axiom",
+          "https://attack.mitre.org/groups/G0001/"
         ],
         "synonyms": [
-          "Winnti Umbrella",
-          "Blackfly",
-          "LEAD",
-          "WICKED SPIDER",
-          "WICKED PANDA",
-          "BARIUM",
-          "BRONZE ATLAS",
-          "BRONZE EXPORT",
-          "Red Kelpie",
-          "G0044"
+          "Group72",
+          "G0001"
         ]
       },
       "related": [
-        {
-          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        },
         {
           "dest-uuid": "090242d7-73fc-4738-af68-20162f7a5aae",
           "tags": [
@@ -689,17 +661,10 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
-        },
-        {
-          "dest-uuid": "2943148b-8bc5-4bcb-b85e-f00c2174dd47",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
         }
       ],
       "uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
-      "value": "Winnti"
+      "value": "Axiom"
     },
     {
       "description": "Adversary group targeting financial, technology, non-profit organisations.",
@@ -7618,7 +7583,9 @@
       "meta": {
         "cfr-suspected-state-sponsor": "People's Republic of China",
         "cfr-suspected-victims": [
+          "China",
           "France",
+          "Hong Kong",
           "India",
           "Italy",
           "Japan",
@@ -7646,12 +7613,33 @@
           "Intergovernmental",
           "Media and Entertainment",
           "Pharmaceuticals",
+          "Private sector",
           "Retail",
           "Telecommunications",
           "Travel"
         ],
         "country": "CN",
         "refs": [
+          "https://securelist.com/winnti-faq-more-than-just-a-game/57585/",
+          "https://securelist.com/winnti-more-than-just-a-game/37029/",
+          "http://williamshowalter.com/a-universal-windows-bootkit/",
+          "https://www.microsoft.com/security/blog/2017/01/25/detecting-threat-actors-in-recent-german-industrial-attacks-with-windows-defender-atp/",
+          "https://securelist.com/games-are-over/70991/",
+          "https://medium.com/chronicle-blog/winnti-more-than-just-windows-and-gates-e4f03436031a",
+          "https://www.dw.com/en/thyssenkrupp-victim-of-cyber-attack/a-36695341",
+          "https://www.bleepingcomputer.com/news/security/teamviewer-confirms-undisclosed-breach-from-2016/",
+          "https://blog.trendmicro.com/trendlabs-security-intelligence/winnti-abuses-github/",
+          "https://www.dw.com/en/bayer-points-finger-at-wicked-panda-in-cyberattack/a-48196004",
+          "https://www.welivesecurity.com/2019/03/11/gaming-industry-scope-attackers-asia/",
+          "https://401trg.com/burning-umbrella/",
+          "https://attack.mitre.org/groups/G0044/",
+          "https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-july-wicked-spider/",
+          "https://www.secureworks.com/research/threat-profiles/bronze-atlas",
+          "https://www.secureworks.com/research/threat-profiles/bronze-export",
+          "https://www.pwc.co.uk/cyber-security/assets/cyber-threats-2019-retrospect.pdf",
+          "https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer",
+          "https://assets.documentcloud.org/documents/7210602/FLASH-AC-000133-TT-Published.pdf",
+          "https://www.cfr.org/cyber-operations/winnti-umbrella",
           "https://www.fireeye.com/blog/threat-research/2019/08/apt41-dual-espionage-and-cyber-crime-operation.html",
           "https://unit42.paloaltonetworks.com/apt41-using-new-speculoos-backdoor-to-target-organizations-globally/",
           "https://www.mandiant.com/resources/report-apt41-double-dragon-a-dual-espionage-and-cyber-crime-operation",
@@ -7661,7 +7649,18 @@
         "synonyms": [
           "Double Dragon",
           "G0096",
-          "TA415"
+          "TA415",
+          "Winnti Group",
+          "Blackfly",
+          "Grayfly",
+          "LEAD",
+          "BARIUM",
+          "WICKED SPIDER",
+          "WICKED PANDA",
+          "BRONZE ATLAS",
+          "BRONZE EXPORT",
+          "Red Kelpie",
+          "G0044"
         ]
       },
       "related": [
@@ -7676,6 +7675,13 @@
           "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
           "tags": [
             "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "c5947e1c-1cbc-434c-94b8-27c7e3be0fff",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
         }
@@ -9867,50 +9873,6 @@
       },
       "uuid": "e1e70539-8916-45c2-9b01-891c1c5bd8a1",
       "value": "TA558"
-    },
-    {
-      "description": "Axiom is a suspected Chinese cyber espionage group that has targeted the aerospace, defense, government, manufacturing, and media sectors since at least 2008. Some reporting suggests a degree of overlap between Axiom and Winnti Group but the two groups appear to be distinct based on differences in reporting on TTPs and targeting.",
-      "meta": {
-        "cfr-suspected-state-sponsor": "China",
-        "cfr-suspected-victims": [
-          "United States",
-          "Netherlands",
-          "Italy",
-          "Japan",
-          "United Kingdom",
-          "Belgium",
-          "Russia",
-          "Indonesia",
-          "Germany",
-          "Switzerland",
-          "China"
-        ],
-        "cfr-target-category": [
-          "Government",
-          "Private sector"
-        ],
-        "cfr-type-of-incident": "Espionage",
-        "country": "CN",
-        "refs": [
-          "cfr.org/cyber-operations/axiom",
-          "https://attack.mitre.org/groups/G0001/"
-        ],
-        "synonyms": [
-          "Group72",
-          "G0001"
-        ]
-      },
-      "related": [
-        {
-          "dest-uuid": "24110866-cb22-4c85-a7d2-0413e126694b",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "2943148b-8bc5-4bcb-b85e-f00c2174dd47",
-      "value": "Axiom"
     }
   ],
   "version": 241

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -3662,10 +3662,14 @@
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=62e325ae-f551-4855-b9cf-28a7d52d1534&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=7a60af1f-7786-446c-976b-7c71a16e9d3b&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
           "https://attack.mitre.org/groups/G0039/",
-          "https://exchange.xforce.ibmcloud.com/collection/Suckfly-APT-aa8af56fd12d25c98fc49ca5341160ab"
+          "https://exchange.xforce.ibmcloud.com/collection/Suckfly-APT-aa8af56fd12d25c98fc49ca5341160ab",
+          "http://www.slideshare.net/CTruncer/ever-present-persistence-established-footholds-seen-in-the-wild",
+          "https://www.secureworks.com/research/threat-profiles/bronze-olive"
         ],
         "synonyms": [
-          "G0039"
+          "G0039",
+          "APT22",
+          "BRONZE OLIVE"
         ]
       },
       "related": [
@@ -4806,22 +4810,6 @@
       },
       "uuid": "a47b79ae-7a0c-4308-9efc-294af19cc795",
       "value": "APT5"
-    },
-    {
-      "meta": {
-        "attribution-confidence": "50",
-        "country": "CN",
-        "refs": [
-          "http://www.slideshare.net/CTruncer/ever-present-persistence-established-footholds-seen-in-the-wild",
-          "https://www.secureworks.com/research/threat-profiles/bronze-olive"
-        ],
-        "synonyms": [
-          "APT22",
-          "BRONZE OLIVE"
-        ]
-      },
-      "uuid": "7a2457d6-148a-4ce1-9e79-aa43352ee842",
-      "value": "APT 22"
     },
     {
       "description": "Tick is a cyber espionage group with likely Chinese origins that has been active since at least 2008. The group appears to have close ties to the Chinese National University of Defense and Technology, which is possibly linked to the PLA. This threat actor targets organizations in the critical infrastructure, heavy industry, manufacturing, and international relations sectors for espionage purposes.  The attacks appear to be centered on political, media, and engineering sectors. STALKER PANDA has been observed conducting targeted attacks against Japan, Taiwan, Hong Kong, and the United States.",


### PR DESCRIPTION
There were some alias conflicts between entities around Winnti:
![image](https://user-images.githubusercontent.com/23531109/185514597-651b38d2-0120-4439-9ee7-7268f7534a93.png)

### Winnti

There were 2 entities about winnti. Keeping the bigger one

### Sukcfly

Removing the alias from winnti, it's different from it

### Axiom

Both CFR (https://www.cfr.org/cyber-operations/axiom) and MITRE (https://attack.mitre.org/groups/G0001/) says that despite overlap with Winnti, the 2 groups are different

### APT 41

Is sometimes included as an alias of Winnti, but seems to be different 


Let me know if this separation sounds good, or if some of them should be merged.