### PR TITLE
[threat-actors] Clean TA505 aliases

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6442,14 +6442,14 @@
           "https://www.secureworks.com/research/threat-profiles/gold-tahoe",
           "https://www.telekom.com/en/blog/group/article/eager-beaver-a-short-overview-of-the-restless-threat-actor-ta505-609546",
           "https://blog.fox-it.com/2020/11/16/ta505-a-brief-history-of-their-time/",
-          "https://www.secureworks.com/blog/how-cyber-adversaries-are-adapting-to-exploit-the-global-pandemic"
+          "https://www.secureworks.com/blog/how-cyber-adversaries-are-adapting-to-exploit-the-global-pandemic",
+          "https://cyberthreat.thalesgroup.com/attackers/ATK103"
         ],
         "synonyms": [
           "SectorJ04 Group",
           "GRACEFUL SPIDER",
           "GOLD TAHOE",
           "Dudear",
-          "TEMP.Warlock",
           "G0092",
           "ATK103"
         ]
@@ -8061,8 +8061,7 @@
         ],
         "synonyms": [
           "TEMP.Warlock",
-          "UNC902",
-          "GRACEFUL SPIDER"
+          "UNC902"
         ]
       },
       "uuid": "c01aadc6-1087-4e8e-8d5c-a27eba409fe3",


### PR DESCRIPTION
Per https://www.mandiant.com/resources/blog/fin11-email-campaigns-precursor-for-ransomware-data-theft :
> Notably, FIN11 includes a subset of the activity [security researchers call TA505](https://www.proofpoint.com/us/threat-insight/post/threat-actor-profile-ta505-dridex-globeimposter), but we do not attribute TA505’s early operations to FIN11 and caution against using the names interchangeably. Attribution of both historic TA505 activity and more recent FIN11 activity is complicated by the actors’ use of criminal service providers.

![image](https://user-images.githubusercontent.com/23531109/189983045-af9fbd6d-aac1-4ee3-91bc-4f7e003facc4.png)
