### PR TITLE
chg: [ransomware] Extends the entry for JCrypt

### DIFF
--- a/clusters/ransomware.json
+++ b/clusters/ransomware.json
@@ -24257,9 +24257,77 @@
       "value": "Povisomware"
     },
     {
-      "description": "ransomware",
+      "description": "Ransomware written in C#. Fortunately, all current versions of the MafiaWare666 ransomware are decryptable. The Threat Lab from Avast has developed a free decryption tool for this malware.",
       "meta": {
-        "date": "December 2020"
+        "date": "December 2020",
+        "extensions": [
+          ".jcrypt",
+          ".locked",
+          ".daddycrypt",
+          ".omero",
+          ".ncovid",
+          ".NotStonks",
+          ".crypted",
+          ".iam_watching",
+          ".vn_os",
+          ".wearefriends",
+          ".MALWAREDEVELOPER",
+          ".MALKI",
+          ".poison",
+          ".foxxy",
+          ".ZAHACKED",
+          ".JEBAĆ_BYDGOSZCZ!!!",
+          ".titancrypt",
+          ".crypt",
+          ".MafiaWare666",
+          ".brutusptCrypt",
+          ".bmcrypt",
+          ".cyberone",
+          ".l33ch"
+        ],
+        "payment-method": "Bitcoin",
+        "ransomenotes": [
+          "All of your files have been encrypted.\nTo unlock them, please send 1 bitcoin(s) to BTC address: 1BtUL5dhVXHwKLqSdhjyjK9Pe64Vc6CEH1 Afterwards,\nI please email your transaction ID to: this.email.address@gmail.com\nThank you and have a nice day! Encryption Log: ..."
+        ],
+        "ransomenotes-refs": [
+          "https://1.bp.blogspot.com/-OF8CopM3MUw/X-XLjUmRkYI/AAAAAAAAXpY/1mLe136SuT8DuruWJfwIVY5WnVs5B1gcgCLcBGAsYHQ/s943/txt-note.png"
+        ],
+        "ransomnotes-filenames": [
+          "___RECOVER__FILES__.jcrypt.txt",
+          "_RECOVER__FILES__.jcrypt.txt",
+          "___RECOVER__FILES__.locked.txt",
+          "___RECOVER__FILES__.daddycrypt.txt",
+          "___RECOVER__FILES__.omero.txt",
+          "___RECOVER__FILES__.ncovid.txt",
+          "___RECOVER__FILES__.crypted.txt",
+          "___RECOVER__FILES__.iam_watching.txt",
+          "___RECOVER__FILES__.titancrypt.txt",
+          "_#ODZYSKAJ_PLIKI--.JEBAĆ_BYDGOSZCZ!!!.txt"
+        ],
+        "refs": [
+          "https://id-ransomware.blogspot.com/2020/12/jcrypt-ransomware.html",
+          "https://twitter.com/kangxiaopao/status/1342027328063295488?lang=en",
+          "https://twitter.com/demonslay335/status/1380610583603638277",
+          "https://decoded.avast.io/threatresearch/decrypted-mafiaware666-ransomware/",
+          "https://files.avast.com/files/decryptor/avast_decryptor_mafiaware666.exe"
+        ],
+        "synonyms": [
+          "RIP lmao",
+          "Locked",
+          "Daddycrypt",
+          "Omero",
+          "Crypted",
+          "Ncovid",
+          "NotStonks",
+          "Iam_watching",
+          "Vn_os",
+          "Wearefriends",
+          "MALWAREDEVELOPER",
+          "MALKI",
+          "Poison",
+          "Foxxy",
+          "Mafiaware666"
+        ]
       },
       "uuid": "dd5712e1-efa8-4054-a5df-fdfdbc9c25b6",
       "value": "JCrypt"
@@ -24861,5 +24929,5 @@
       "value": "Karakurt"
     }
   ],
-  "version": 111
+  "version": 112
 }


### PR DESCRIPTION
* Add the reference to MafiaWare666 based on the latest research from the Avast Threat Lab: https://decoded.avast.io/threatresearch/decrypted-mafiaware666-ransomware/
* Add more infos from Andrew Ivanovs the great blog post: https://id-ransomware.blogspot.com/2020/12/jcrypt-ransomware.html

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>