### PR TITLE
Updated the `region` cluster 

### DIFF
--- a/clusters/region.json
+++ b/clusters/region.json
@@ -11,13 +11,13 @@
   "values": [
     {
       "meta": {
-        "subregion": [
+        "subregions": [
           "002 - Africa",
+          "009 - Oceania",
+          "010 - Antarctica",
           "019 - Americas",
           "142 - Asia",
-          "150 - Europe",
-          "009 - Oceania",
-          "010 - Antarctica"
+          "150 - Europe"
         ]
       },
       "uuid": "8d87018b-e8bb-472e-841b-4429fb6b9bc0",
@@ -25,7 +25,7 @@
     },
     {
       "meta": {
-        "subregion": [
+        "subregions": [
           "015 - Northern Africa",
           "202 - Sub-Saharan Africa"
         ]
@@ -35,42 +35,31 @@
     },
     {
       "meta": {
-        "subregion": [
-          "419 - Latin America and the Caribbean",
-          "021 - Northern America"
+        "subregions": [
+          "032 - Argentina",
+          "068 - Bolivia (Plurinational State of)",
+          "074 - Bouvet Island",
+          "076 - Brazil",
+          "152 - Chile",
+          "170 - Colombia",
+          "218 - Ecuador",
+          "238 - Falkland Islands (Malvinas)",
+          "239 - South Georgia and the South Sandwich Islands",
+          "254 - French Guiana",
+          "328 - Guyana",
+          "600 - Paraguay",
+          "604 - Peru",
+          "740 - Suriname",
+          "858 - Uruguay",
+          "862 - Venezuela (Bolivarian Republic of)"
         ]
       },
-      "uuid": "a6427c40-6fba-46dc-9995-72e16a4c57a7",
-      "value": "019 - Americas"
+      "uuid": "e9ee6728-d325-4726-be7d-08b5ccf3f3d6",
+      "value": "005 - South America"
     },
     {
       "meta": {
-        "subregion": [
-          "143 - Central Asia",
-          "030 - Eastern Asia",
-          "035 - South-eastern Asia",
-          "034 - Southern Asia",
-          "145 - Western Asia"
-        ]
-      },
-      "uuid": "4b09b683-5650-4a6c-a383-d8f3b686ebc2",
-      "value": "142 - Asia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "151 - Eastern Europe",
-          "154 - Northern Europe",
-          "039 - Southern Europe",
-          "155 - Western Europe"
-        ]
-      },
-      "uuid": "739c285c-fe59-4540-b323-bf713af30347",
-      "value": "150 - Europe"
-    },
-    {
-      "meta": {
-        "subregion": [
+        "subregions": [
           "053 - Australia and New Zealand",
           "054 - Melanesia",
           "057 - Micronesia",
@@ -81,314 +70,75 @@
       "value": "009 - Oceania"
     },
     {
-      "meta": {
-        "subregion": [
-          "012 - Algeria",
-          "818 - Egypt",
-          "434 - Libya",
-          "504 - Morocco",
-          "729 - Sudan",
-          "788 - Tunisia",
-          "732 - Western Sahara"
-        ]
-      },
-      "uuid": "4a65b439-849b-4fdd-b34d-e80f738a4309",
-      "value": "015 - Northern Africa"
+      "value": "010 - Antarctica",
+      "uuid": "6d4ae555-f559-48ac-9777-926a406b7969"
     },
     {
       "meta": {
-        "subregion": [
-          "014 - Eastern Africa",
-          "017 - Middle Africa",
-          "018 - Southern Africa",
-          "011 - Western Africa"
+        "subregions": [
+          "132 - Cabo Verde",
+          "204 - Benin",
+          "270 - Gambia",
+          "288 - Ghana",
+          "324 - Guinea",
+          "384 - C\u00f4te d\u2019Ivoire",
+          "430 - Liberia",
+          "466 - Mali",
+          "478 - Mauritania",
+          "562 - Niger",
+          "566 - Nigeria",
+          "624 - Guinea-Bissau",
+          "654 - Saint Helena",
+          "686 - Senegal",
+          "694 - Sierra Leone",
+          "768 - Togo",
+          "854 - Burkina Faso"
         ]
       },
-      "uuid": "130997e8-c900-4457-829a-447eec3fbb89",
-      "value": "202 - Sub-Saharan Africa"
+      "uuid": "d44cf4b4-8025-4827-960c-b666dfdc5243",
+      "value": "011 - Western Africa"
     },
     {
       "meta": {
-        "subregion": [
-          "029 - Caribbean",
-          "013 - Central America",
-          "005 - South America"
+        "subregions": [
+          "084 - Belize",
+          "188 - Costa Rica",
+          "222 - El Salvador",
+          "320 - Guatemala",
+          "340 - Honduras",
+          "484 - Mexico",
+          "558 - Nicaragua",
+          "591 - Panama"
         ]
       },
-      "uuid": "aef21eb1-eccd-46e1-a4c8-9e9b8452d912",
-      "value": "419 - Latin America and the Caribbean"
+      "uuid": "105247d9-e619-4231-b88e-17dd9aed1580",
+      "value": "013 - Central America"
     },
     {
       "meta": {
-        "subregion": [
-          "060 - Bermuda",
-          "124 - Canada",
-          "304 - Greenland",
-          "666 - Saint Pierre and Miquelon",
-          "840 - United States of America"
-        ]
-      },
-      "uuid": "64974dea-c6c9-462d-9fcf-4456a397d591",
-      "value": "021 - Northern America"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "398 - Kazakhstan",
-          "417 - Kyrgyzstan",
-          "762 - Tajikistan",
-          "795 - Turkmenistan",
-          "860 - Uzbekistan"
-        ]
-      },
-      "uuid": "a5515b7c-594b-4e37-a60f-3bab8808c54c",
-      "value": "143 - Central Asia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "156 - China",
-          "344 - China, Hong Kong Special Administrative Region",
-          "446 - China, Macao Special Administrative Region",
-          "408 - Democratic People's Republic of Korea",
-          "392 - Japan",
-          "496 - Mongolia",
-          "410 - Republic of Korea"
-        ]
-      },
-      "uuid": "aa46fbd1-54df-4e1e-a5d6-7bced5c59803",
-      "value": "030 - Eastern Asia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "096 - Brunei Darussalam",
-          "116 - Cambodia",
-          "360 - Indonesia",
-          "418 - Lao People's Democratic Republic",
-          "458 - Malaysia",
-          "104 - Myanmar",
-          "608 - Philippines",
-          "702 - Singapore",
-          "764 - Thailand",
-          "626 - Timor-Leste",
-          "704 - Viet Nam"
-        ]
-      },
-      "uuid": "990d0e8e-dfd0-45d1-ab8b-758b9139c0fe",
-      "value": "035 - South-eastern Asia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "004 - Afghanistan",
-          "050 - Bangladesh",
-          "064 - Bhutan",
-          "356 - India",
-          "364 - Iran (Islamic Republic of)",
-          "462 - Maldives",
-          "524 - Nepal",
-          "586 - Pakistan",
-          "144 - Sri Lanka"
-        ]
-      },
-      "uuid": "f86776cd-274f-438a-8beb-9349aebda0bb",
-      "value": "034 - Southern Asia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "051 - Armenia",
-          "031 - Azerbaijan",
-          "048 - Bahrain",
-          "196 - Cyprus",
-          "268 - Georgia",
-          "368 - Iraq",
-          "376 - Israel",
-          "400 - Jordan",
-          "414 - Kuwait",
-          "422 - Lebanon",
-          "512 - Oman",
-          "634 - Qatar",
-          "682 - Saudi Arabia",
-          "275 - State of Palestine",
-          "760 - Syrian Arab Republic",
-          "792 - Turkey",
-          "784 - United Arab Emirates",
-          "887 - Yemen"
-        ]
-      },
-      "uuid": "d66b2e98-39fb-4710-b075-5bee2fa00cd4",
-      "value": "145 - Western Asia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "112 - Belarus",
-          "100 - Bulgaria",
-          "203 - Czechia",
-          "348 - Hungary",
-          "616 - Poland",
-          "498 - Republic of Moldova",
-          "642 - Romania",
-          "643 - Russian Federation",
-          "703 - Slovakia",
-          "804 - Ukraine"
-        ]
-      },
-      "uuid": "c7cb0859-5680-4bdb-9c78-46cab3504a62",
-      "value": "151 - Eastern Europe"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "830 - Channel Islands",
-          "248 - Åland Islands",
-          "208 - Denmark",
-          "233 - Estonia",
-          "234 - Faroe Islands",
-          "246 - Finland",
-          "352 - Iceland",
-          "372 - Ireland",
-          "833 - Isle of Man",
-          "428 - Latvia",
-          "440 - Lithuania",
-          "578 - Norway",
-          "744 - Svalbard and Jan Mayen Islands",
-          "752 - Sweden",
-          "826 - United Kingdom of Great Britain and Northern Ireland"
-        ]
-      },
-      "uuid": "f93cb275-0366-4ecc-abf0-a17928d1e177",
-      "value": "154 - Northern Europe"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "008 - Albania",
-          "020 - Andorra",
-          "070 - Bosnia and Herzegovina",
-          "191 - Croatia",
-          "292 - Gibraltar",
-          "300 - Greece",
-          "336 - Holy See",
-          "380 - Italy",
-          "470 - Malta",
-          "499 - Montenegro",
-          "807 - North Macedonia",
-          "620 - Portugal",
-          "674 - San Marino",
-          "688 - Serbia",
-          "705 - Slovenia",
-          "724 - Spain"
-        ]
-      },
-      "uuid": "63880bb3-f959-4200-b8ae-e25d9fa84c22",
-      "value": "039 - Southern Europe"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "040 - Austria",
-          "056 - Belgium",
-          "250 - France",
-          "276 - Germany",
-          "438 - Liechtenstein",
-          "442 - Luxembourg",
-          "492 - Monaco",
-          "528 - Netherlands",
-          "756 - Switzerland"
-        ]
-      },
-      "uuid": "7048c324-c9c2-4c53-a42a-912e78f3aeec",
-      "value": "155 - Western Europe"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "036 - Australia",
-          "162 - Christmas Island",
-          "166 - Cocos (Keeling) Islands",
-          "334 - Heard Island and McDonald Islands",
-          "554 - New Zealand",
-          "574 - Norfolk Island"
-        ]
-      },
-      "uuid": "93dd8987-1466-493f-b5dc-c2b7fe762d75",
-      "value": "053 - Australia and New Zealand"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "242 - Fiji",
-          "540 - New Caledonia",
-          "598 - Papua New Guinea",
-          "090 - Solomon Islands",
-          "548 - Vanuatu"
-        ]
-      },
-      "uuid": "4cb4b767-2db4-4858-bb28-656816350fef",
-      "value": "054 - Melanesia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "316 - Guam",
-          "296 - Kiribati",
-          "584 - Marshall Islands",
-          "583 - Micronesia (Federated States of)",
-          "520 - Nauru",
-          "580 - Northern Mariana Islands",
-          "585 - Palau",
-          "581 - United States Minor Outlying Islands"
-        ]
-      },
-      "uuid": "fbe052e0-a4ab-4d74-8765-5a9786e7bdbc",
-      "value": "057 - Micronesia"
-    },
-    {
-      "meta": {
-        "subregion": [
-          "016 - American Samoa",
-          "184 - Cook Islands",
-          "258 - French Polynesia",
-          "570 - Niue",
-          "612 - Pitcairn",
-          "882 - Samoa",
-          "772 - Tokelau",
-          "776 - Tonga",
-          "798 - Tuvalu",
-          "876 - Wallis and Futuna Islands"
-        ]
-      },
-      "uuid": "a387db42-cdb4-4f75-98c4-5b51a03d0c68",
-      "value": "061 - Polynesia"
-    },
-    {
-      "meta": {
-        "subregion": [
+        "subregions": [
           "086 - British Indian Ocean Territory",
           "108 - Burundi",
           "174 - Comoros",
-          "262 - Djibouti",
-          "232 - Eritrea",
+          "175 - Mayotte",
           "231 - Ethiopia",
+          "232 - Eritrea",
           "260 - French Southern Territories",
+          "262 - Djibouti",
           "404 - Kenya",
           "450 - Madagascar",
           "454 - Malawi",
           "480 - Mauritius",
-          "175 - Mayotte",
           "508 - Mozambique",
-          "638 - Réunion",
+          "638 - R\u00e9union",
           "646 - Rwanda",
           "690 - Seychelles",
           "706 - Somalia",
+          "716 - Zimbabwe",
           "728 - South Sudan",
           "800 - Uganda",
           "834 - United Republic of Tanzania",
-          "894 - Zambia",
-          "716 - Zimbabwe"
+          "894 - Zambia"
         ]
       },
       "uuid": "9b15e8e9-2adb-4aa8-baea-d63ccc434428",
@@ -396,7 +146,22 @@
     },
     {
       "meta": {
-        "subregion": [
+        "subregions": [
+          "012 - Algeria",
+          "434 - Libya",
+          "504 - Morocco",
+          "729 - Sudan",
+          "732 - Western Sahara",
+          "788 - Tunisia",
+          "818 - Egypt"
+        ]
+      },
+      "uuid": "4a65b439-849b-4fdd-b34d-e80f738a4309",
+      "value": "015 - Northern Africa"
+    },
+    {
+      "meta": {
+        "subregions": [
           "024 - Angola",
           "120 - Cameroon",
           "140 - Central African Republic",
@@ -413,12 +178,12 @@
     },
     {
       "meta": {
-        "subregion": [
+        "subregions": [
           "072 - Botswana",
-          "748 - Eswatini",
           "426 - Lesotho",
           "516 - Namibia",
-          "710 - South Africa"
+          "710 - South Africa",
+          "748 - Eswatini"
         ]
       },
       "uuid": "b95340de-8f29-4dbf-ad0f-a4c0be367e59",
@@ -426,42 +191,36 @@
     },
     {
       "meta": {
-        "subregion": [
-          "204 - Benin",
-          "854 - Burkina Faso",
-          "132 - Cabo Verde",
-          "384 - Côte d’Ivoire",
-          "270 - Gambia",
-          "288 - Ghana",
-          "324 - Guinea",
-          "624 - Guinea-Bissau",
-          "430 - Liberia",
-          "466 - Mali",
-          "478 - Mauritania",
-          "562 - Niger",
-          "566 - Nigeria",
-          "654 - Saint Helena",
-          "686 - Senegal",
-          "694 - Sierra Leone",
-          "768 - Togo"
+        "subregions": [
+          "021 - Northern America",
+          "419 - Latin America and the Caribbean"
         ]
       },
-      "uuid": "d44cf4b4-8025-4827-960c-b666dfdc5243",
-      "value": "011 - Western Africa"
+      "uuid": "a6427c40-6fba-46dc-9995-72e16a4c57a7",
+      "value": "019 - Americas"
     },
     {
       "meta": {
-        "subregion": [
-          "660 - Anguilla",
+        "subregions": [
+          "060 - Bermuda",
+          "124 - Canada",
+          "304 - Greenland",
+          "666 - Saint Pierre and Miquelon",
+          "840 - United States of America"
+        ]
+      },
+      "uuid": "64974dea-c6c9-462d-9fcf-4456a397d591",
+      "value": "021 - Northern America"
+    },
+    {
+      "meta": {
+        "subregions": [
           "028 - Antigua and Barbuda",
-          "533 - Aruba",
           "044 - Bahamas",
           "052 - Barbados",
-          "535 - Bonaire, Sint Eustatius and Saba",
           "092 - British Virgin Islands",
           "136 - Cayman Islands",
           "192 - Cuba",
-          "531 - Curaçao",
           "212 - Dominica",
           "214 - Dominican Republic",
           "308 - Grenada",
@@ -470,13 +229,17 @@
           "388 - Jamaica",
           "474 - Martinique",
           "500 - Montserrat",
+          "531 - Cura\u00e7ao",
+          "533 - Aruba",
+          "534 - Sint Maarten (Dutch part)",
+          "535 - Bonaire, Sint Eustatius and Saba",
           "630 - Puerto Rico",
-          "652 - Saint Barthélemy",
+          "652 - Saint Barth\u00e9lemy",
           "659 - Saint Kitts and Nevis",
+          "660 - Anguilla",
           "662 - Saint Lucia",
           "663 - Saint Martin (French Part)",
           "670 - Saint Vincent and the Grenadines",
-          "534 - Sint Maarten (Dutch part)",
           "780 - Trinidad and Tobago",
           "796 - Turks and Caicos Islands",
           "850 - United States Virgin Islands"
@@ -487,50 +250,291 @@
     },
     {
       "meta": {
-        "subregion": [
-          "084 - Belize",
-          "188 - Costa Rica",
-          "222 - El Salvador",
-          "320 - Guatemala",
-          "340 - Honduras",
-          "484 - Mexico",
-          "558 - Nicaragua",
-          "591 - Panama"
+        "subregions": [
+          "156 - China",
+          "344 - China, Hong Kong Special Administrative Region",
+          "392 - Japan",
+          "408 - Democratic People's Republic of Korea",
+          "410 - Republic of Korea",
+          "446 - China,  Macao Special Administrative Region",
+          "496 - Mongolia"
         ]
       },
-      "uuid": "105247d9-e619-4231-b88e-17dd9aed1580",
-      "value": "013 - Central America"
+      "uuid": "aa46fbd1-54df-4e1e-a5d6-7bced5c59803",
+      "value": "030 - Eastern Asia"
     },
     {
       "meta": {
-        "subregion": [
-          "032 - Argentina",
-          "068 - Bolivia (Plurinational State of)",
-          "074 - Bouvet Island",
-          "076 - Brazil",
-          "152 - Chile",
-          "170 - Colombia",
-          "218 - Ecuador",
-          "238 - Falkland Islands (Malvinas)",
-          "254 - French Guiana",
-          "328 - Guyana",
-          "600 - Paraguay",
-          "604 - Peru",
-          "239 - South Georgia and the South Sandwich Islands",
-          "740 - Suriname",
-          "858 - Uruguay",
-          "862 - Venezuela (Bolivarian Republic of)"
+        "subregions": [
+          "004 - Afghanistan",
+          "050 - Bangladesh",
+          "064 - Bhutan",
+          "144 - Sri Lanka",
+          "356 - India",
+          "364 - Iran (Islamic Republic of)",
+          "462 - Maldives",
+          "524 - Nepal",
+          "586 - Pakistan"
         ]
       },
-      "uuid": "e9ee6728-d325-4726-be7d-08b5ccf3f3d6",
-      "value": "005 - South America"
+      "uuid": "f86776cd-274f-438a-8beb-9349aebda0bb",
+      "value": "034 - Southern Asia"
     },
     {
       "meta": {
-        "subregion": [
+        "subregions": [
+          "096 - Brunei Darussalam",
+          "104 - Myanmar",
+          "116 - Cambodia",
+          "360 - Indonesia",
+          "418 - Lao People's Democratic Republic",
+          "458 - Malaysia",
+          "608 - Philippines",
+          "626 - Timor-Leste",
+          "702 - Singapore",
+          "704 - Viet Nam",
+          "764 - Thailand"
+        ]
+      },
+      "uuid": "990d0e8e-dfd0-45d1-ab8b-758b9139c0fe",
+      "value": "035 - South-eastern Asia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "008 - Albania",
+          "020 - Andorra",
+          "070 - Bosnia and Herzegovina",
+          "191 - Croatia",
+          "292 - Gibraltar",
+          "300 - Greece",
+          "336 - Holy See",
+          "380 - Italy",
+          "470 - Malta",
+          "499 - Montenegro",
+          "620 - Portugal",
+          "674 - San Marino",
+          "688 - Serbia",
+          "705 - Slovenia",
+          "724 - Spain",
+          "807 - North Macedonia"
+        ]
+      },
+      "uuid": "63880bb3-f959-4200-b8ae-e25d9fa84c22",
+      "value": "039 - Southern Europe"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "036 - Australia",
+          "162 - Christmas Island",
+          "166 - Cocos (Keeling) Islands",
+          "334 - Heard Island and McDonald Islands",
+          "554 - New Zealand",
+          "574 - Norfolk Island"
+        ]
+      },
+      "uuid": "93dd8987-1466-493f-b5dc-c2b7fe762d75",
+      "value": "053 - Australia and New Zealand"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "090 - Solomon Islands",
+          "242 - Fiji",
+          "540 - New Caledonia",
+          "548 - Vanuatu",
+          "598 - Papua New Guinea"
+        ]
+      },
+      "uuid": "4cb4b767-2db4-4858-bb28-656816350fef",
+      "value": "054 - Melanesia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "296 - Kiribati",
+          "316 - Guam",
+          "520 - Nauru",
+          "580 - Northern Mariana Islands",
+          "581 - United States Minor Outlying Islands",
+          "583 - Micronesia (Federated States of)",
+          "584 - Marshall Islands",
+          "585 - Palau"
+        ]
+      },
+      "uuid": "fbe052e0-a4ab-4d74-8765-5a9786e7bdbc",
+      "value": "057 - Micronesia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "016 - American Samoa",
+          "184 - Cook Islands",
+          "258 - French Polynesia",
+          "570 - Niue",
+          "612 - Pitcairn",
+          "772 - Tokelau",
+          "776 - Tonga",
+          "798 - Tuvalu",
+          "876 - Wallis and Futuna Islands",
+          "882 - Samoa"
+        ]
+      },
+      "uuid": "a387db42-cdb4-4f75-98c4-5b51a03d0c68",
+      "value": "061 - Polynesia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "030 - Eastern Asia",
+          "034 - Southern Asia",
+          "035 - South-eastern Asia",
+          "143 - Central Asia",
+          "145 - Western Asia"
+        ]
+      },
+      "uuid": "4b09b683-5650-4a6c-a383-d8f3b686ebc2",
+      "value": "142 - Asia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "398 - Kazakhstan",
+          "417 - Kyrgyzstan",
+          "762 - Tajikistan",
+          "795 - Turkmenistan",
+          "860 - Uzbekistan"
+        ]
+      },
+      "uuid": "a5515b7c-594b-4e37-a60f-3bab8808c54c",
+      "value": "143 - Central Asia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "031 - Azerbaijan",
+          "048 - Bahrain",
+          "051 - Armenia",
+          "196 - Cyprus",
+          "268 - Georgia",
+          "275 - State of Palestine",
+          "368 - Iraq",
+          "376 - Israel",
+          "400 - Jordan",
+          "414 - Kuwait",
+          "422 - Lebanon",
+          "512 - Oman",
+          "634 - Qatar",
+          "682 - Saudi Arabia",
+          "760 - Syrian Arab Republic",
+          "784 - United Arab Emirates",
+          "792 - Turkey",
+          "887 - Yemen"
+        ]
+      },
+      "uuid": "d66b2e98-39fb-4710-b075-5bee2fa00cd4",
+      "value": "145 - Western Asia"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "039 - Southern Europe",
+          "151 - Eastern Europe",
+          "154 - Northern Europe",
+          "155 - Western Europe"
+        ]
+      },
+      "uuid": "739c285c-fe59-4540-b323-bf713af30347",
+      "value": "150 - Europe"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "100 - Bulgaria",
+          "112 - Belarus",
+          "203 - Czechia",
+          "348 - Hungary",
+          "498 - Republic of Moldova",
+          "616 - Poland",
+          "642 - Romania",
+          "643 - Russian Federation",
+          "703 - Slovakia",
+          "804 - Ukraine"
+        ]
+      },
+      "uuid": "c7cb0859-5680-4bdb-9c78-46cab3504a62",
+      "value": "151 - Eastern Europe"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "208 - Denmark",
+          "233 - Estonia",
+          "234 - Faroe Islands",
+          "246 - Finland",
+          "248 - \u00c5land Islands",
+          "352 - Iceland",
+          "372 - Ireland",
+          "428 - Latvia",
+          "440 - Lithuania",
+          "578 - Norway",
+          "744 - Svalbard and Jan Mayen Islands",
+          "752 - Sweden",
+          "826 - United Kingdom of Great Britain and Northern Ireland",
+          "830 - Channel Islands",
+          "833 - Isle of Man"
+        ]
+      },
+      "uuid": "f93cb275-0366-4ecc-abf0-a17928d1e177",
+      "value": "154 - Northern Europe"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "040 - Austria",
+          "056 - Belgium",
+          "250 - France",
+          "276 - Germany",
+          "438 - Liechtenstein",
+          "442 - Luxembourg",
+          "492 - Monaco",
+          "528 - Netherlands",
+          "756 - Switzerland"
+        ]
+      },
+      "uuid": "7048c324-c9c2-4c53-a42a-912e78f3aeec",
+      "value": "155 - Western Europe"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "011 - Western Africa",
+          "014 - Eastern Africa",
+          "017 - Middle Africa",
+          "018 - Southern Africa"
+        ]
+      },
+      "uuid": "130997e8-c900-4457-829a-447eec3fbb89",
+      "value": "202 - Sub-Saharan Africa"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "005 - South America",
+          "013 - Central America",
+          "029 - Caribbean"
+        ]
+      },
+      "uuid": "aef21eb1-eccd-46e1-a4c8-9e9b8452d912",
+      "value": "419 - Latin America and the Caribbean"
+    },
+    {
+      "meta": {
+        "subregions": [
+          "680 - Sark",
           "831 - Guernsey",
-          "832 - Jersey",
-          "680 - Sark"
+          "832 - Jersey"
         ]
       },
       "uuid": "76adc9e0-215a-4496-8642-b98ac7715d0f",

--- a/clusters/region.json
+++ b/clusters/region.json
@@ -70,8 +70,8 @@
       "value": "009 - Oceania"
     },
     {
-      "value": "010 - Antarctica",
-      "uuid": "6d4ae555-f559-48ac-9777-926a406b7969"
+      "uuid": "6d4ae555-f559-48ac-9777-926a406b7969",
+      "value": "010 - Antarctica"
     },
     {
       "meta": {
@@ -81,7 +81,7 @@
           "270 - Gambia",
           "288 - Ghana",
           "324 - Guinea",
-          "384 - C\u00f4te d\u2019Ivoire",
+          "384 - Côte d’Ivoire",
           "430 - Liberia",
           "466 - Mali",
           "478 - Mauritania",
@@ -130,7 +130,7 @@
           "454 - Malawi",
           "480 - Mauritius",
           "508 - Mozambique",
-          "638 - R\u00e9union",
+          "638 - Réunion",
           "646 - Rwanda",
           "690 - Seychelles",
           "706 - Somalia",
@@ -229,12 +229,12 @@
           "388 - Jamaica",
           "474 - Martinique",
           "500 - Montserrat",
-          "531 - Cura\u00e7ao",
+          "531 - Curaçao",
           "533 - Aruba",
           "534 - Sint Maarten (Dutch part)",
           "535 - Bonaire, Sint Eustatius and Saba",
           "630 - Puerto Rico",
-          "652 - Saint Barth\u00e9lemy",
+          "652 - Saint Barthélemy",
           "659 - Saint Kitts and Nevis",
           "660 - Anguilla",
           "662 - Saint Lucia",
@@ -473,7 +473,7 @@
           "233 - Estonia",
           "234 - Faroe Islands",
           "246 - Finland",
-          "248 - \u00c5land Islands",
+          "248 - Åland Islands",
           "352 - Iceland",
           "372 - Ireland",
           "428 - Latvia",

--- a/tools/UN M49/generate_region_cluster.py
+++ b/tools/UN M49/generate_region_cluster.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+from uuid import uuid4
+
+current_path = Path(__file__).resolve().parent
+
+
+def _generate_cluster_values(cluster_values: dict):
+    values = []
+    for _, cluster_value in sorted(cluster_values.items()):
+        values.append(cluster_value)
+    return values
+
+
+def _parse_csv_input(input_file: Path) -> dict:
+    # We create a mapping to associate the regions and their sub-regions
+    regions_mapping = defaultdict(set)
+    with open(input_file, 'rt', encoding='utf-8') as csvfile:
+        csv_reader = csv.reader(csvfile, delimiter=',')
+        next(csv_reader)
+        for row in csv_reader:
+            '''
+            gc: Global Code
+            gn: Global Name
+            rc: Region Code
+            rn: Region Name
+            src: Sub-region Code
+            srn: Sub-region Name
+            irc: Intermediate Region Code
+            irn: Intermediate Region Name
+            mc: M49 Code
+            coa: Country of Area
+            '''
+            gc, gn, rc, rn, src, srn, irc, irn, mc, coa, *_ = row
+
+            global_region = f'{gc} - {gn}'
+            if rc and rn:
+                # Almost all the areas have a region information
+                region = f'{rc} - {rn}'
+                regions_mapping[global_region].add(region)
+                # Deal with the region information
+                sub_region = f'{src} - {srn}'
+                regions_mapping[region].add(sub_region)
+                country = f'{mc} - {coa}'
+                if irc and irn:
+                    # If the country is located in an intermediate region
+                    inter_region = f'{irc} - {irn}'
+                    # Deal with the sub-region information
+                    regions_mapping[sub_region].add(inter_region)
+                    # Deal with the intermediate region information
+                    regions_mapping[inter_region].add(country)
+                else:
+                    # The country is located in a sub-region
+                    regions_mapping[sub_region].add(country)
+            else:
+                # Should be only Antarctica which has only global region and
+                # country information
+                country = f'{mc} - {coa}'
+                regions_mapping[global_region].add(country)
+                regions_mapping[country] = None
+    return regions_mapping
+
+
+def update_cluster(input_file, filename):
+    with open(filename, 'rt', encoding='utf-8') as f:
+        region_cluster = json.load(f)
+    cluster = {value['value']: value for value in region_cluster['values']}
+    regions_mapping = _parse_csv_input(input_file)
+    is_changed = False
+    for region, subregions in regions_mapping.items():
+        if region not in cluster:
+            cluster_value = {
+                'value': region,
+                'uuid': uuid4().__str__(),
+            }
+            if subregions is not None:
+                cluster_value['meta'] = {
+                    'subregions': sorted(subregions)
+                }
+            cluster[region] = cluster_value
+            is_changed = True
+        else:
+            if subregions != cluster[region].get('meta', {}).get('subregions'):
+                if subregions is not None:
+                    cluster[region]['meta'] = {
+                        'subregions': sorted(subregions)
+                    }
+                is_changed = True
+    if is_changed:
+        region_cluster['values'] = _generate_cluster_values(cluster)
+        with open(filename, 'wt', encoding='utf-8') as f:
+            f.write(json.dumps(region_cluster, indent=2))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Generates/updates the region galaxy cluster')
+    parser.add_argument(
+        '-i', '--input', type=Path, default=current_path / 'UNSD.csv',
+        help="CSV input file"
+    )
+    args = parser.parse_args()
+
+    filename = current_path.parents[1] / 'clusters' / 'region.json'
+    update_cluster(args.input, filename)


### PR DESCRIPTION
Starting from the observation that `Antarctica` was not mentioned as a region, I looked at the CSV file, parsed the values and wanted to compare it with the existing cluster values.

As a result, we have here:
- a script to generate the cluster values based on the CSV file
- an update to the `region` cluster values including:
  - the `Antarctica` entry
  - the meta field `subregion` renamed `subregions`
  - the cluster values and the sub-region values are sorted by region code