### PR TITLE
chg: [stealer] Adds Album Stealer

### DIFF
--- a/clusters/stealer.json
+++ b/clusters/stealer.json
@@ -186,7 +186,17 @@
       ],
       "uuid": "e550f534-dc8b-4f94-a276-ce3d5d9c8115",
       "value": "DarkCloud Stealer"
+    },
+    {
+      "description": "The Zscaler ThreatLabz research team has spotted a new information stealer named Album. Album Stealer is disguised as a photo album that drops decoy adult images while performing malicious activity in the background. The threat group launching these attacks may be located in Vietnam.",
+      "meta": {
+        "refs": [
+          "https://www.zscaler.com/blogs/security-research/album-stealer-targets-facebook-adult-only-content-seekers"
+        ]
+      },
+      "uuid": "7f95ebda-2c7b-49a4-ad57-bd5766a1f651",
+      "value": "Album Stealer"
     }
   ],
-  "version": 10
+  "version": 11
 }


### PR DESCRIPTION
Source: https://www.zscaler.com/blogs/security-research/album-stealer-targets-facebook-adult-only-content-seekers

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>