### PR TITLE
add sofacy alias to apt28

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -2185,7 +2185,8 @@
           "T-APT-12",
           "APT-C-20",
           "UAC-0028",
-          "FROZENLAKE"
+          "FROZENLAKE",
+          "Sofacy"
         ]
       },
       "related": [


### PR DESCRIPTION
when value "Sofacy" was changed to "APT28", it seems Sofacy was not added to aliases, so it's missing right now.