### PR TITLE
chg [threat-actors] Add RedGolf

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -7901,7 +7901,8 @@
           "G0044",
           "Earth Baku",
           "Amoeba",
-          "HOODOO"
+          "HOODOO",
+          "Brass Typhoon"
         ]
       },
       "related": [
@@ -11259,7 +11260,67 @@
       },
       "uuid": "8ca38564-5515-45f5-9f3b-a4091546e10b",
       "value": "Anonymous Sudan"
+    },
+    {
+      "description": "Recorded Future’s Insikt Group has identified a large cluster of new operational infrastructure associated with use of the custom Windows and Linux backdoor KEYPLUG. We attribute this activity to a threat activity group tracked as RedGolf, which is highly likely to be a Chinese state-sponsored group. RedGolf closely overlaps with threat activity reported in open sources under the aliases APT41/BARIUM and has likely carried out state-sponsored espionage activity in parallel with financially motivated operations for personal gain from at least 2014 onward.",
+      "meta": {
+        "cfr-suspected-state-sponsor": "China",
+        "cfr-target-category": [
+          "Aviation",
+          "Automotive",
+          "Education",
+          "Intergovernmental",
+          "Media and Entertainment",
+          "Information Technology",
+          "Religious Organizations"
+        ],
+        "country": "CN",
+        "motive": "state-sponsored espionage and financially motivated",
+        "references": [
+          "https://go.recordedfuture.com/hubfs/reports/cta-2023-0330.pdf",
+          "https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "9c124874-042d-48cd-b72b-ccdc51ecbbd6",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "overlaps"
+        },
+        {
+          "dest-uuid": "036bd099-fe80-46c2-9c4c-e5c6df8dcdee",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1a1d3ea4-972e-4c48-8d85-08d9db8f1550",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "9c124874-042d-48cd-b72b-ccdc51ecbbd6",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2c4bfc14-3ea4-4ced-806a-fcac30b2a9d7",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "uses"
+        }
+      ],
+      "uuid": "eff0c059-5449-4207-9860-715475139595",
+      "value": "RedGolf"
     }
   ],
-  "version": 271
+  "version": 272
 }


### PR DESCRIPTION
Source: https://go.recordedfuture.com/hubfs/reports/cta-2023-0330.pdf

@adulau How can I cluster unique infrastructure TTP? I would like to add also GhostWolf because not RedGolf overlaps with APT41. The GhostWolf infra overlaps with the infra of APT41. Furthermore what would be a good place to add more information about the company Chengdu 404 Network Technology?

p.s. Adds new Microsoft mapping for APT41: https://github.com/microsoft/mstic/blob/master/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json#L14-L19