### PR TITLE
chg [misp-galaxy] update Nigeria from name to 2-digit code

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -11770,7 +11770,7 @@
     {
       "description": "When the first member of Scattered Canary, who, for the purposes of this report, we call\nAlpha, began his operations, he was a lone wolf—working mostly Craigslist scams as he learned\nthe tricks of the trade from a mentor. However, within a few years, he had honed his craft\nenough to expand into romance scams, where he met his first “employee,” Beta. Once they\nhad secured enough mules via their romance scams to launder their stolen money, they shifted\nfrom targeting individuals to targeting enterprises, and the group’s BEC operation was born.",
       "meta": {
-        "country": "Nigeria",
+        "country": "NG",
         "motive": "Cybercrime",
         "references": [
           "https://cofense.com/blog/gift-card-fraud-ecosystem-shifts-what-paxfuls-closing-means-for-business-email-compromise/",


### PR DESCRIPTION
This PR updates the Scattered Canary threat actor country from Nigeria to the 2-digit NG ISO code to match the naming convention of the other threat actors