### PR TITLE
[threat-actors] More aliases of Iranian apts

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -6246,13 +6246,19 @@
           "https://securityaffairs.co/wordpress/56348/intelligence/magic-hound-campaign.html",
           "https://www.cfr.org/cyber-operations/apt-35",
           "https://blogs.microsoft.com/on-the-issues/2019/03/27/new-steps-to-protect-customers-from-hacking/",
-          "https://research.checkpoint.com/2022/apt35-exploits-log4j-vulnerability-to-distribute-new-modular-powershell-toolkit/"
+          "https://research.checkpoint.com/2022/apt35-exploits-log4j-vulnerability-to-distribute-new-modular-powershell-toolkit/",
+          "https://www.microsoft.com/en-us/security/blog/2021/11/16/evolving-trends-in-iranian-threat-actor-activity-mstic-presentation-at-cyberwarcon-2021/",
+          "https://www.sentinelone.com/labs/log4j2-in-the-wild-iranian-aligned-threat-actor-tunnelvision-actively-exploiting-vmware-horizon/",
+          "https://www.secureworks.com/blog/cobalt-mirage-conducts-ransomware-operations-in-us"
         ],
         "synonyms": [
           "Newscaster Team",
           "Magic Hound",
           "G0059",
-          "Phosphorus"
+          "Phosphorus",
+          "Mint Sandstorm",
+          "TunnelVision",
+          "COBALT MIRAGE"
         ]
       },
       "related": [
@@ -11573,7 +11579,8 @@
           "https://www.microsoft.com/en-us/security/blog/2022/09/07/profiling-dev-0270-phosphorus-ransomware-operations/"
         ],
         "synonyms": [
-          "Nemesis Kitten"
+          "Nemesis Kitten",
+          "Storm-0270"
         ]
       },
       "related": [


### PR DESCRIPTION
- Adding 2 renaming from MS (Phosphorus  -> Mint Sandstorm & DEV-0270 -> Storm-0270)
- Adding TunnelVision & Cobalt Mirage as synonyms of Phosphorus (this cluster of Iranian activity may require a bit more of cleaning to better capture all the nuances)