### PR TITLE
Update threat-actor.json

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -15274,7 +15274,6 @@
           "https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2021/09/30094337/GhostEmperor_technical-details_PDF_eng.pdf",
           "https://www.welivesecurity.com/2021/09/23/famoussparrow-suspicious-hotel-guest/",
           "https://www.ncsc.gov.uk/files/NCSC-MAR-SparrowDoor.pdf",
-          "https://cloud.google.com/blog/topics/threat-intelligence/unc4841-post-barracuda-zero-day-remediation",
           "https://www.sygnia.co/blog/ghost-emperor-demodex-rootkit/",
           "https://www.wsj.com/politics/national-security/china-cyberattack-internet-providers-260bd835"
         ],


### PR DESCRIPTION
Removed link reference to UNC4841 activity from GhostEmperor value. After research and speaking with authors of the report, these two clusters of activity are unrelated.