### PR TITLE
[threat-actors] Remove gorilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ Category: *tea-matrix* - source: ** - total: *7* elements
 
 [Threat Actor](https://www.misp-galaxy.org/threat-actor) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign. threat-actor-classification meta can be used to clarify the understanding of the threat-actor if also considered as operation, campaign or activity group.
 
-Category: *actor* - source: *MISP Project* - total: *799* elements
+Category: *actor* - source: *MISP Project* - total: *798* elements
 
 [[HTML](https://www.misp-galaxy.org/threat-actor)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json)]
 

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -17507,16 +17507,6 @@
       "value": "Water Barghest"
     },
     {
-      "description": "Gorilla is a threat-actor operating a DoS-as-a-service service controlled on Telegram.",
-      "meta": {
-        "refs": [
-          "https://www.ncsc.admin.ch/ncsc/en/home/aktuell/im-fokus/2024/gorilla_bericht.html"
-        ]
-      },
-      "uuid": "192be820-af1a-4967-b38c-73326fa9ca9f",
-      "value": "Gorilla"
-    },
-    {
       "description": "TAG-100 is a cyber-espionage APT that targets government and private sector organizations globally, exploiting vulnerabilities in internet-facing devices such as Citrix NetScaler and F5 BIG-IP for initial access. The group employs open-source tools like Pantegana and SparkRAT for persistence and post-exploitation activities, including credential theft and email data exfiltration. TAG-100 has compromised entities in at least ten countries, including two Asia-Pacific intergovernmental organizations, and focuses on sectors like education, finance, and local government. Their operations highlight the challenges of attribution due to the use of off-the-shelf tools and techniques that overlap with other state-sponsored groups.",
       "meta": {
         "country": "CN",


### PR DESCRIPTION
This PR removes gorilla from the list of threat actors. The [reference article](https://www.ncsc.admin.ch/ncsc/en/home/aktuell/im-fokus/2024/gorilla_bericht.html) mentions Gorilla as a botnet instead of a threat actor. There is Gorilla Services mentioned in the article, but it is difficult to definitely conclude that it is the name of a threat actor instead of just a telegram channel.

![Screenshot 2025-01-30 at 5 00 34 PM](https://github.com/user-attachments/assets/ac297e1f-5318-4ad9-a41a-2814a540d4a6)
