### PR TITLE
Threat actors/ghost emperor alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ Category: *tea-matrix* - source: ** - total: *7* elements
 
 [Threat Actor](https://www.misp-galaxy.org/threat-actor) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign. threat-actor-classification meta can be used to clarify the understanding of the threat-actor if also considered as operation, campaign or activity group.
 
-Category: *actor* - source: *MISP Project* - total: *799* elements
+Category: *actor* - source: *MISP Project* - total: *798* elements
 
 [[HTML](https://www.misp-galaxy.org/threat-actor)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json)]
 

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -12802,26 +12802,6 @@
       "value": "TetrisPhantom"
     },
     {
-      "description": "Trend Micro found that Earth Estries relies heavily on DLL sideloading to load various tools within its arsenal. Aside from the backdoors previously mentioned, this intrusion set also utilizes commonly used remote control tools like Cobalt Strike, PlugX, or Meterpreter stagers interchangeably in various attack stages. These tools come as encrypted payloads loaded by custom loader DLLs.",
-      "meta": {
-        "refs": [
-          "https://www.trendmicro.com/en_us/research/23/h/earth-estries-targets-government-tech-for-cyberespionage.html",
-          "https://www.sentinelone.com/labs/cyber-soft-power-chinas-continental-takeover/"
-        ]
-      },
-      "related": [
-        {
-          "dest-uuid": "3c3ca8f3-c6ab-4c5d-9bd0-be6677d6cdeb",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
-      "uuid": "1f7f4a51-c4a8-4365-ade3-83b222e7cb67",
-      "value": "Earth Estries"
-    },
-    {
       "description": "GoldenJackal activity is characterized by the use of compromised WordPress websites as a method to host C2-related logic. Kaspersky believes the attackers upload a malicious PHP file that is used as a relay to forward web requests to another backbone C2 server. They developed a collection of .NET malware tools known as Jackal.",
       "meta": {
         "cfr-suspected-victims": [
@@ -15300,23 +15280,17 @@
           "https://www.ncsc.gov.uk/files/NCSC-MAR-SparrowDoor.pdf",
           "https://cloud.google.com/blog/topics/threat-intelligence/unc4841-post-barracuda-zero-day-remediation",
           "https://www.sygnia.co/blog/ghost-emperor-demodex-rootkit/",
-          "https://www.wsj.com/politics/national-security/china-cyberattack-internet-providers-260bd835"
+          "https://www.wsj.com/politics/national-security/china-cyberattack-internet-providers-260bd835",
+          "https://www.picussecurity.com/resource/blog/salt-typhoon-telecommunications-threat",
+          "https://thehackernews.com/2024/11/chinese-hackers-exploit-t-mobile-and.html"
         ],
         "synonyms": [
           "FamousSparrow",
           "UNC2286",
-          "Salt Typhoon"
+          "Salt Typhoon",
+          "Earth Estries"
         ]
       },
-      "related": [
-        {
-          "dest-uuid": "1f7f4a51-c4a8-4365-ade3-83b222e7cb67",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "similar"
-        }
-      ],
       "uuid": "3c3ca8f3-c6ab-4c5d-9bd0-be6677d6cdeb",
       "value": "GhostEmperor"
     },


### PR DESCRIPTION
This PR adds Earth Estries as an alias of Ghost Emperor and removes it as an independent TA. Also adds reference articles where Earth Estries is mentioned as an alias of Ghost Emperor. 