### PR TITLE
Update threat-actor.json to replace Phantomcore to be Head Mare as the correct TA group's name

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -16075,15 +16075,17 @@
       "value": "Water Orthrus"
     },
     {
-      "description": "PhantomCore is a threat actor group known for using a remote access malware called PhantomRAT. They have been observed executing malicious code through specially crafted RAR archives, different from previous attacks exploiting vulnerabilities. The attribution of their campaign to Ukraine is uncertain due to limited visibility inside Russian networks. PhantomCore's use of RAR archives in their attack chain has been previously observed in other threat actor groups like Forest Blizzard.",
+      "description": "Head Mare is a hacktivism focussed threat actor group known for targeting Russia and Belarus sectors using a remote access malware called PhantomRAT. They have been observed executing malicious code through specially crafted RAR archives, different from previous attacks exploiting vulnerabilities. The attribution of their campaign to Ukraine is uncertain due to limited visibility inside Russian networks. PhantomCore's use of RAR archives in their attack chain has been previously observed in other threat actor groups like Forest Blizzard.",
       "meta": {
         "refs": [
           "https://therecord.media/russian-researchers-winrar-bug-ukraine-espionage",
-          "https://www.facct.ru/blog/phantomdl-loader"
+          "https://www.facct.ru/blog/phantomdl-loader",
+          "https://securelist.com/head-mare-hacktivists/113555/",
+          "https://cyble.com/blog/head-mare-deploys-phantomcore-against-russia/"
         ]
       },
       "uuid": "485947c7-edb6-4a07-9276-2114dc767551",
-      "value": "PhantomCore"
+      "value": "Head Mare"
     },
     {
       "description": "CiberInteligenciaSV is a threat actor that leaked 5.1 million Salvadoran records on Breach Forums. They have also compromised El Salvador's state Bitcoin wallet, Chivo, leaking its source code and VPN credentials. The group aims to obscure their involvement by associating with the Guacamaya group and its proxies.",


### PR DESCRIPTION
the phantomcore threat actor groups is referenced by many as the hacktivism group "Head Mare". The original name came from the malware they deployed. Changed the name and description of the original TA profile called "Phantomcore".