### PR TITLE
fix(target-information): Somalia iso-code

### DIFF
--- a/clusters/target-information.json
+++ b/clusters/target-information.json
@@ -6660,13 +6660,13 @@
         "capital": [
           "Mogadishu"
         ],
-        "countrycode": [
-          "SO",
-          "SOM"
-        ],
         "currency": [
           "Somali shilling",
           "SOS"
+        ],
+        "iso-code": [
+          "SO",
+          "SOM"
         ],
         "official-languages": [
           "Somali",


### PR DESCRIPTION
Somalia is the only one country in the JSON using `countrycode` instead of `iso-code`.