### PR TITLE
clean wagemole alias

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -17765,7 +17765,6 @@
           "UNC5267",
           "Wagemole",
           "Nickel Tapestry",
-          "Contagious Interview",
           "Storm-1877",
           "Void Dokkaebi"
         ]


### PR DESCRIPTION
per https://www.zscaler.com/blogs/security-research/pyongyang-your-payroll-rise-north-korean-remote-workers-west, "contagious interview" is a campaign of wagemole and not an alias of it. This PR cleans the listed alias.

> WageMole threat actors’ first step in applying for a job involves creating fake personas. WageMole threat actors obtain fake passports or other forms of identification, either through the Contagious Interview campaign or by purchasing them from real individuals. Occasionally, they hire foreign nationals residing in the U.S. In addition, WageMole threat actors create fake driver's licenses to verify their identity. In these cases, they appear to use stolen driver's licenses, altering only the photo on the ID while leaving the rest of the information unchanged.