### PR TITLE
chg: [mitre] add support for `Analytics` references in `Detection Strategies`

### DIFF
--- a/clusters/mitre-detection-strategy.json
+++ b/clusters/mitre-detection-strategy.json
@@ -19,11 +19,11 @@
       "related": [
         {
           "dest-uuid": "4c16cebd-ac7e-472a-ae12-62966cbd19e2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7b711402-12f7-4985-93df-2693eaf9ebdb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b0c74ef9-c61e-4986-88cb-78da98a355ec",
@@ -43,15 +43,15 @@
       "related": [
         {
           "dest-uuid": "1895e723-dcfb-45d4-80fc-aaa0c3963cc9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8cb0a7da-942b-4771-b9d5-cf558755677a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "acf0fdbb-6fbf-42c0-acc4-75a545c24f90",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e261a979-f354-41a8-963e-6cadac27c4bf",
@@ -75,19 +75,19 @@
         },
         {
           "dest-uuid": "1b53dd1b-c98e-4b25-a7fd-70dad586ebf1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5eefb166-8f2b-45e0-b5c8-bf71984dec08",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "861ee805-c979-44c9-8b0c-86bd3a6f5872",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "904100f0-1af9-4ded-89be-dfda7180bcbc",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1f6a450a-fd29-4e5c-9708-1ae4616c28c3",
@@ -103,15 +103,15 @@
       "related": [
         {
           "dest-uuid": "12849ba4-39da-48c9-bf3d-c51a6cc3f85b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f615721-c62f-4229-9c6e-cb873b2591e5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbfa2ed1-f8d5-44cf-9da8-5e3fed544172",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ef67e13e-5598-4adc-bdb2-998225874fa9",
@@ -131,7 +131,7 @@
       "related": [
         {
           "dest-uuid": "5ca1b37f-31c9-414b-9a31-9f80f553c44a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f63fe421-b1d1-45c0-b8a7-02cd16ff2bed",
@@ -151,15 +151,15 @@
       "related": [
         {
           "dest-uuid": "8307d1d4-4f50-481b-9126-3b145fd68a73",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a4119120-396e-4993-8f9d-bc7b5fc94e7e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bcf48294-2388-4ae6-be22-f9038c54e1db",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c325b232-d5bc-4dde-a3ec-71f3db9e8adc",
@@ -167,7 +167,7 @@
         },
         {
           "dest-uuid": "d27a6df2-b2df-443e-8e01-c90243465ceb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "776a998c-481d-4193-934e-c0af3968c392",
@@ -183,11 +183,11 @@
       "related": [
         {
           "dest-uuid": "3a6fdd1a-59c6-4f46-a761-0de502229da0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "66107cd1-c123-4ad5-bb0b-62d8a9a451a6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c32eb4d-805f-4fc5-bf60-c4d476c131b5",
@@ -195,15 +195,15 @@
         },
         {
           "dest-uuid": "a6e7697d-f0b8-4fcc-b32a-fec5b28cd8f7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dcd6253b-a986-4c8a-bd89-46389007ea83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e707cd33-8e20-4b1d-ad3f-fd3a3233fcdd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "70c9f174-2e96-4086-b59c-d2358e434f8e",
@@ -219,15 +219,15 @@
       "related": [
         {
           "dest-uuid": "09125bb1-29eb-4d40-994a-2e1aa7bcd105",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b8dea721-8e0d-4bcd-bde4-6609afd595e5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bdc546bb-9d92-489e-8aa8-8de1bd08f320",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d467bc38-284b-4a00-96ac-125f447799fc",
@@ -235,7 +235,7 @@
         },
         {
           "dest-uuid": "e518b7e5-6e98-43f6-86c2-f45f684c650f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8bcafe59-0a4b-4314-988b-085bf5cdf7a9",
@@ -251,15 +251,15 @@
       "related": [
         {
           "dest-uuid": "4264c6fb-20b2-4792-8939-c7d8f204338a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "53872bd3-7e5e-4573-ae07-6304bf7e49af",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "668f1c2b-1a5e-4269-92d9-f7126764dd4e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a009cb25-4801-4116-9105-80a91cf15c1b",
@@ -267,7 +267,7 @@
         },
         {
           "dest-uuid": "e619c27e-3d57-489c-8ce9-cbb5f0c195bd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7ad75a00-94f0-4deb-8642-df227a2a8ac6",
@@ -287,7 +287,7 @@
         },
         {
           "dest-uuid": "c3629243-7cd6-4e56-9275-73f5752f0f08",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "759a29fb-8697-46f7-baa3-a891b28c064e",
@@ -303,11 +303,11 @@
       "related": [
         {
           "dest-uuid": "0084089f-6e5f-42c4-8b0d-78e95cd55d0f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "029db14d-fb94-49ee-9d6d-3c7212671377",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1d24cdee-9ea2-4189-b08e-af110bf2435d",
@@ -315,15 +315,15 @@
         },
         {
           "dest-uuid": "3682e3c9-33a7-4328-b0c5-73c8bbcb9b53",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7efdc4e3-8a2e-4d0d-8ced-03155f2c55ac",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d2a45051-b999-4969-aeb0-d7f83d453976",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ee07e9eb-8438-4c7c-8260-88a09fbe98de",
@@ -339,7 +339,7 @@
       "related": [
         {
           "dest-uuid": "00b5d9a8-a794-4d7c-90df-71c4021e0a46",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0c2d00da-7742-49e7-9928-4514e5075d32",
@@ -347,11 +347,11 @@
         },
         {
           "dest-uuid": "b2261c7f-664b-400c-b8ba-8b5bc3bac75a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbd003ec-4208-48bb-9ad5-b9dd627fdd14",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4b2bc278-fc80-4ff8-87a3-a6843a9e683a",
@@ -367,19 +367,19 @@
       "related": [
         {
           "dest-uuid": "1f69e126-e849-43a1-9fca-b5c63a154daa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2a5f1993-7035-4d94-b9d1-7edb1850d4e1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "77450309-6789-4025-9817-d908c4ac9e5b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8ed1a27f-3a60-441d-b92d-dc7b086db459",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f504411-cb96-4dac-a537-8d2bb7679c59",
@@ -387,7 +387,7 @@
         },
         {
           "dest-uuid": "91870bc8-3a81-4d90-84e4-26c99b5642ef",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8577b89d-01e2-4423-8657-caff7ed22737",
@@ -403,7 +403,7 @@
       "related": [
         {
           "dest-uuid": "11cd0577-97e6-4def-a86b-fe167ae4e33d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1e9eb839-294b-48cc-b0d3-c45555a2a004",
@@ -423,7 +423,7 @@
       "related": [
         {
           "dest-uuid": "2a23296d-70f2-4e04-9a97-62d093ad1765",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "391d824f-0ef1-47a0-b0ee-c59a75e27670",
@@ -431,11 +431,11 @@
         },
         {
           "dest-uuid": "552ff82d-467b-4aeb-a4c3-084ca24dbd3e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5e02fe2a-7659-4871-b79e-7ea57373aa37",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "36654ec6-5019-4e79-b299-1fbf3a03e064",
@@ -451,7 +451,7 @@
       "related": [
         {
           "dest-uuid": "578c821c-f8e3-45e7-a9b4-9aed6c84309a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "58af3705-8740-4c68-9329-ec015a7013c2",
@@ -475,7 +475,7 @@
         },
         {
           "dest-uuid": "c345908d-4f74-4341-a203-8c76be2a136b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "994c7fc6-ad85-47e6-9079-fb872ec7e541",
@@ -491,7 +491,7 @@
       "related": [
         {
           "dest-uuid": "3ac58f14-32d6-4ce2-8aa7-e7c429dd6405",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "98034fef-d9fb-4667-8dc4-2eab6231724c",
@@ -511,11 +511,11 @@
       "related": [
         {
           "dest-uuid": "0834f268-5810-4a90-8ef6-279dc0482471",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1c25310b-d8fa-472d-a10e-c327a8fba693",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "39131305-9282-45e4-ac3b-591d2d4fc3ef",
@@ -523,7 +523,7 @@
         },
         {
           "dest-uuid": "8ba8d516-486a-4347-9a48-56a312e83897",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4dfcf95f-0bbb-4ae7-8bd5-91e3e6c51809",
@@ -539,7 +539,7 @@
       "related": [
         {
           "dest-uuid": "d69c9d97-17d6-4dad-a4d4-ec41e7fb34fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ff25900d-76d5-449b-a351-8824e62fc81b",
@@ -559,15 +559,15 @@
       "related": [
         {
           "dest-uuid": "0668f39a-d319-427f-b29b-160399e6f79a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "17290910-5b25-477a-a0c0-c2661ff2585e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "17f9487f-711d-4f28-9de8-209ae39d33d2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f886f2a-874f-4333-b794-aa6075009b1c",
@@ -575,19 +575,19 @@
         },
         {
           "dest-uuid": "72298803-0644-477f-be89-01b173202577",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a4ce8f28-db09-4b0d-bb8d-a77ba3cef3c0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a57ad75c-331e-4607-b358-61f4cddb8a5d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ddab6d30-7e37-462e-b183-39c7ceb2b986",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "dd8477c8-2aad-4db3-b810-fe0d2f605fa8",
@@ -603,11 +603,11 @@
       "related": [
         {
           "dest-uuid": "0848a778-7bcf-48d9-a14a-d29d1e71e656",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2e7a9609-3e4b-477b-828f-f486561d7fa7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "451a9977-d255-43c9-b431-66de80130c8c",
@@ -615,11 +615,11 @@
         },
         {
           "dest-uuid": "48d2effa-7fc0-4790-9cc9-bbe573c29301",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ac933d77-bdb6-45ed-8fb5-87bae6f225cb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1e601759-c5d1-45cc-97a1-972967426794",
@@ -639,7 +639,7 @@
         },
         {
           "dest-uuid": "dc4d944f-975a-4057-8edb-deb023db387c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ec75b064-d8f1-40a7-832c-0ef0bb40214d",
@@ -659,7 +659,7 @@
         },
         {
           "dest-uuid": "e24b6c08-4fd0-40c7-a71a-762cc08d6085",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5fb0bb0d-cc9c-47aa-86f2-567b4ee642ff",
@@ -675,7 +675,7 @@
       "related": [
         {
           "dest-uuid": "3a5eea3b-b447-47c5-832d-6ced137b1597",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d356151-a69d-404e-896b-71618952702a",
@@ -699,15 +699,15 @@
         },
         {
           "dest-uuid": "779b2e27-9318-46a3-aeec-765f5fb09de3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "86f2dfd5-7073-4178-8c83-8628ecf087d4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a6b1e74e-6c05-4d9f-928c-63ddf558798b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "18c9199f-d6b6-4efe-ac90-9a1b7b8c6f36",
@@ -727,7 +727,7 @@
         },
         {
           "dest-uuid": "61729716-59f3-433e-a678-101c18040851",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a62dbd10-5b61-489c-a465-8f792792778e",
@@ -743,23 +743,23 @@
       "related": [
         {
           "dest-uuid": "03216652-ada9-4c1e-88c4-923c2cb60614",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "43ccb88d-8d8a-4ddb-9ffd-3d897fba76a3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9680d434-3470-4a35-bf48-1785ab14d831",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d203b007-e462-4842-82ce-c97f52c17e39",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfad1a86-de44-40b2-95b5-9b18c4103cbb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f005e783-57d4-4837-88ad-dbe7faee1c51",
@@ -783,7 +783,7 @@
         },
         {
           "dest-uuid": "f0fce510-b195-4688-a4ac-b78584febd08",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4554ad15-dc0a-44f8-92b6-b8e7dc64385e",
@@ -803,7 +803,7 @@
         },
         {
           "dest-uuid": "e14e67af-6f6e-47d6-aa19-4012ea99284c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "69b08c7a-c2ab-4e56-935d-ec28143372de",
@@ -819,15 +819,15 @@
       "related": [
         {
           "dest-uuid": "0cb02d2e-dcea-4195-80e7-81ec29b4d546",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "30ae2215-5dd5-4ef2-82bd-965781ef1f42",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5f8b5ef5-8b4a-4713-a694-dc0746669a73",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d4dc46e3-5ba5-45b9-8204-010867cacfcb",
@@ -847,7 +847,7 @@
       "related": [
         {
           "dest-uuid": "04fcf3d4-4547-4e64-bbb7-9faa46dda1f6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "10d51417-ee35-4589-b1ff-b6df1c334e8d",
@@ -855,15 +855,15 @@
         },
         {
           "dest-uuid": "14f4930e-a2a5-45ae-9552-837c0a35e06b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "63583dcb-dbdc-4b9d-a261-3129de12327e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a3bca3ec-fd25-4b9d-bbce-9575ba96b8ef",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e9833c3c-b5ec-421b-bab4-91f74c2b6bd1",
@@ -879,7 +879,7 @@
       "related": [
         {
           "dest-uuid": "2de35397-ef03-4ffe-b531-d7ad61a6f41d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3489cfc5-640f-4bb3-a103-9137b97de79f",
@@ -887,11 +887,11 @@
         },
         {
           "dest-uuid": "5a9238a9-acd0-44f0-bd41-f86ef433775b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8a2537c3-9e9a-482d-81e2-281f88cf8878",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e7870b55-7420-444a-9751-99fb5fbf4cd9",
@@ -907,19 +907,19 @@
       "related": [
         {
           "dest-uuid": "08370ff8-9442-42c0-bfb5-c7f5792c74ea",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "128315ea-6407-4c28-8528-209e799ad8e1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2416a634-3ad9-4f91-a894-8fb0d9d83b76",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a691ee45-94bf-4244-a286-b80c21859d2e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a782ebe2-daba-42c7-bc82-e8e9d923162d",
@@ -927,7 +927,7 @@
         },
         {
           "dest-uuid": "b97a1c6e-bb02-4e14-ae57-6a9e96512657",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "407286ed-c904-412a-9f2d-7426ea7304a4",
@@ -943,15 +943,15 @@
       "related": [
         {
           "dest-uuid": "10e9d109-0a17-41cd-9d0b-67c679bc94b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2fe9bf69-b1a8-4c60-8b20-c11054d31158",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "35a5d72b-6c69-498a-9118-14cd6c85a57a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "718cb208-6446-4572-a2f0-9c799c60091e",
@@ -959,11 +959,11 @@
         },
         {
           "dest-uuid": "b0d018e2-0384-4e27-92ed-c9b181999fa9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c699a4ee-83dd-48d8-94ae-658204066ae9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c0a23061-c4f3-4003-9e81-e81d50b6d1e2",
@@ -983,23 +983,23 @@
         },
         {
           "dest-uuid": "3fdd7ef4-b382-4880-9f72-bf0ad696af85",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5e1d71ce-5653-4580-a609-9832c88e2c87",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "916993bd-600a-43e2-abbf-30c56be84459",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9bcedfe7-c851-418a-b709-dd8883c7fc5e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dd105985-5d61-43f0-b69b-b4fd52632257",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "26fdbcb2-abc1-4844-8e5d-2c6039336cb7",
@@ -1015,15 +1015,15 @@
       "related": [
         {
           "dest-uuid": "3cd889a5-7955-4d38-a49b-89e8d276ceab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "56a814a9-2b6b-4fcc-a530-e9ca62faaa17",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "774d555e-b94b-4dbd-bc3b-fb60d55e6e2d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c726e0a2-a57a-4b7b-a973-d0f013246617",
@@ -1047,7 +1047,7 @@
         },
         {
           "dest-uuid": "5b6f6588-3434-4199-b16f-af44ae546c3d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "541f2335-1046-4621-9829-1a4a305069c5",
@@ -1063,15 +1063,15 @@
       "related": [
         {
           "dest-uuid": "5d329e39-a38b-47cd-8d3d-fa7515280fd7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7faf6f37-f074-4b9d-be19-618c3516486d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e9a5111-038b-4c68-a8bc-6d094723def4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ac08589e-ee59-4935-8667-d845e38fe579",
@@ -1079,15 +1079,15 @@
         },
         {
           "dest-uuid": "bda03bab-3f0b-4bd0-8a8f-77bcb2b1ee7d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e542342f-5a08-408d-b292-797bcb2da5eb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f421cbe1-d42e-45e9-adad-12c6ed0a5cb8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a21019ad-f6d2-4806-be7b-01ba27c63147",
@@ -1103,7 +1103,7 @@
       "related": [
         {
           "dest-uuid": "5d47e6b2-04fb-45ab-be98-7de1baabf508",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a750a9f6-0bde-4bb3-9aae-1e2786e9780c",
@@ -1127,7 +1127,7 @@
         },
         {
           "dest-uuid": "f6f90ad5-3182-4b1a-a612-51b251a8a34c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cfdf2a13-7059-4532-9d1c-f9129b0e3f7b",
@@ -1143,7 +1143,7 @@
       "related": [
         {
           "dest-uuid": "65a1926d-e504-4153-b19f-555e8a06e5a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ebb42bbe-62d7-47d7-a55f-3b08b61d792d",
@@ -1151,7 +1151,7 @@
         },
         {
           "dest-uuid": "f403ae40-31ff-4550-b21f-e1c24315276d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3eb428c7-5192-4ae2-a5a3-022ca9695ec8",
@@ -1167,7 +1167,7 @@
       "related": [
         {
           "dest-uuid": "6b5b9cd2-f6ba-4ed5-bea2-30edbf85501e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "70e52b04-2a0c-4cea-9d18-7149f1df9dc5",
@@ -1187,11 +1187,11 @@
       "related": [
         {
           "dest-uuid": "0729dd54-2fda-460a-8bb3-eee02f0f3c4e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7becb616-f907-4533-a425-08ca42440e3f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7c46b364-8496-4234-8a56-f7e6727e21e1",
@@ -1215,7 +1215,7 @@
         },
         {
           "dest-uuid": "ec6e1f3c-e9ff-4944-a426-863eaf9979ea",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7aa7d45f-64da-4f16-a905-b4881da82c62",
@@ -1231,7 +1231,7 @@
       "related": [
         {
           "dest-uuid": "4f132f21-1287-4fc2-a13e-d7770d856610",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "70d81154-b187-45f9-8ec5-295d01255979",
@@ -1255,7 +1255,7 @@
         },
         {
           "dest-uuid": "e8569cdc-a018-4eee-95d9-5979cebae519",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "63135c50-7c7a-4a44-a053-28abd2388f21",
@@ -1271,7 +1271,7 @@
       "related": [
         {
           "dest-uuid": "a972f507-cf1b-4e2f-acdc-877a7891b7cf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bf96a5a3-3bce-43b7-8597-88545984c07b",
@@ -1291,7 +1291,7 @@
       "related": [
         {
           "dest-uuid": "1a0640f0-e286-405f-9ab3-507c1abb77da",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "910906dd-8c0a-475a-9cc1-5e029e2fad58",
@@ -1315,19 +1315,19 @@
         },
         {
           "dest-uuid": "2016853a-07eb-4df4-a471-69b55f82b34d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5dc85538-115c-4c56-878a-39caaba91e74",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8faa753d-ec3f-4694-9a33-03ce4ccb722f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d442d480-cfb9-43cc-b959-2f81513b432d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "da01afef-b769-4d31-964d-901fabaf6a8f",
@@ -1343,27 +1343,27 @@
       "related": [
         {
           "dest-uuid": "5e1b310a-ce3d-4271-83e0-87cd2862f959",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7735a0b1-f3bc-44fc-a909-75738e77bded",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "791dfdd4-b04d-498a-accc-ee9e2acc7b14",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "839d7053-fc62-433a-8eb2-ed87605160f7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ea1e329-691a-43a7-b56d-affbc00fb9e7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c6f35e44-459c-456b-97a7-997eb2baefb9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
@@ -1383,7 +1383,7 @@
       "related": [
         {
           "dest-uuid": "0aa20e10-ec46-4acf-810e-e8ed038d7744",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cff94884-3b1c-4987-a70b-6d5643c621c3",
@@ -1403,15 +1403,15 @@
       "related": [
         {
           "dest-uuid": "1a13d795-7c26-44b6-ad1b-2ad732dc33c3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d5eb9bd-5e53-4cf8-b86d-7136bbf8f673",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8180320e-ab62-44e5-afae-eba6ba23d769",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dd43c543-bb85-4a6f-aa6e-160d90d06a49",
@@ -1431,7 +1431,7 @@
       "related": [
         {
           "dest-uuid": "26ef9aef-33eb-4df2-ba82-6ace95173c80",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "41d9846c-f6af-4302-a654-24bba2729bc6",
@@ -1451,7 +1451,7 @@
       "related": [
         {
           "dest-uuid": "2b0dd3b6-6949-4dd5-b0dd-7b0b6f431dbe",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "65f2d882-3f41-4d48-8a06-29af77ec9f90",
@@ -1475,7 +1475,7 @@
         },
         {
           "dest-uuid": "de64bfbd-a6ed-4674-b0c5-dd485cba943b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "81ac26e4-c4f6-4368-842f-50033ca8522b",
@@ -1491,11 +1491,11 @@
       "related": [
         {
           "dest-uuid": "3577f79d-0891-451b-a861-1a03a3688a93",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "57a547e1-1086-427c-9ea8-59059dec1938",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "60b508a1-6a5e-46b1-821a-9f7b78752abf",
@@ -1503,11 +1503,11 @@
         },
         {
           "dest-uuid": "d7a9c7c8-81a0-4988-9617-51f191ab32c8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb569d45-a5b6-47df-a098-bdb26ef0597f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "84b5d372-eedb-4b69-bf78-9d4815e2b2b7",
@@ -1523,7 +1523,7 @@
       "related": [
         {
           "dest-uuid": "44500eb7-01f2-4cab-8b76-1227bb48e13e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e49ee9d2-0d98-44ef-85e5-5d3100065744",
@@ -1543,15 +1543,15 @@
       "related": [
         {
           "dest-uuid": "1edab644-3ec0-4c5d-bc26-18744fbc7a6e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "27bd3e33-9a61-4dfb-9fba-205a6c880264",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5935bda3-8d4d-44b4-aca4-8b40cf45f686",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "be055942-6e63-49d7-9fa1-9cb7d8a8f3f4",
@@ -1571,11 +1571,11 @@
       "related": [
         {
           "dest-uuid": "21773356-1c94-4edc-b368-008c86a5929e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5bd6658f-4391-4d77-bed8-9b141b0fa3ae",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "91541e7e-b969-40c6-bbd8-1b5352ec2938",
@@ -1583,7 +1583,7 @@
         },
         {
           "dest-uuid": "e3a0ea8d-0018-4603-912a-4d40d0f75390",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5463d676-c300-4ab8-9980-d3ed37ac4723",
@@ -1599,7 +1599,7 @@
       "related": [
         {
           "dest-uuid": "312f9f86-b987-483c-8b1d-955415eea946",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "93591901-3172-4e94-abf8-6034ab26f44a",
@@ -1623,7 +1623,7 @@
         },
         {
           "dest-uuid": "e32ce63a-7c82-4115-8c50-e43113562132",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6034b1c9-84df-4349-b34f-957ad8ec34d3",
@@ -1643,15 +1643,15 @@
         },
         {
           "dest-uuid": "328d639e-6b8d-400c-9cdd-3c255d343e47",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5becf65d-da9f-46e1-8edc-eea05c9dc6cb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e0b64d4e-79e0-47b8-a95c-414e2b69406d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e2023eb5-d813-4a08-985e-e8c998672037",
@@ -1671,7 +1671,7 @@
         },
         {
           "dest-uuid": "8fcdd234-c8d8-4d95-b381-91c92cb319b6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "22fe898e-3b53-468c-b2b2-dd59abc83297",
@@ -1691,7 +1691,7 @@
         },
         {
           "dest-uuid": "5d4419cc-6925-4f7d-a247-e0a4634fea90",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ec3e5f66-a2b8-48ae-9adf-eb4f5014ba70",
@@ -1707,7 +1707,7 @@
       "related": [
         {
           "dest-uuid": "34fecfa5-24fb-46c1-955f-68ecd4cc402c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "564998d8-ab3e-4123-93fb-eccaa6b9714a",
@@ -1731,7 +1731,7 @@
         },
         {
           "dest-uuid": "c3be6c4a-3b3d-4a37-a1d8-2c4df915a7aa",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3414f3b8-17a2-438c-8bbc-a261a04da8bc",
@@ -1751,15 +1751,15 @@
         },
         {
           "dest-uuid": "3ac9b4c2-9137-4d20-9619-01029d656874",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5aaad268-48fb-4826-9f68-b666e1b4a3bf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f79a68ff-07f4-49ba-849b-9edb636f0b39",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c7471b0b-ac10-4eac-aae6-cfa821e707dd",
@@ -1775,15 +1775,15 @@
       "related": [
         {
           "dest-uuid": "06ec22c9-b32f-49bc-81cc-ed5cee622493",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "35b0b263-f85d-4e6a-8bcb-5e2c1a9da080",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "94340be7-068e-446a-bca2-d414b66912fc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b83e166d-13d7-4b52-8677-dff90c548fd7",
@@ -1807,11 +1807,11 @@
         },
         {
           "dest-uuid": "4f5f4b26-0bf0-4f3d-b8ac-1af660923bd2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b521510b-83bc-46a2-8fc8-65a6975bcfca",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "aea09aae-c0c3-4453-aa44-ea0153e5cb8c",
@@ -1827,7 +1827,7 @@
       "related": [
         {
           "dest-uuid": "6fba9520-c6ce-4a8f-8005-d33546a10406",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c8e87b83-edbb-48d4-9295-4974897525b7",
@@ -1847,15 +1847,15 @@
       "related": [
         {
           "dest-uuid": "2c94147a-a556-4fa1-92f8-d3c4367f6f2e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3ef92295-ecbf-417a-b72a-f6cd189ca3a1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "66bab948-9baa-4f5c-b259-333eb2ac08ad",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b0533c6e-8fea-4788-874f-b799cacc4b92",
@@ -1879,7 +1879,7 @@
         },
         {
           "dest-uuid": "b76aeebb-3915-48ed-ac35-6af54c88c3bb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0b06e42c-ab1c-4fb7-834b-10293e904173",
@@ -1895,15 +1895,15 @@
       "related": [
         {
           "dest-uuid": "2f9c7e44-de3a-4fbd-955a-482ef9f341ed",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3ae8f3c1-c3a1-4c45-9231-1bb6f9c61ee1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c9db399-4f87-477b-be31-536857b7912d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "da051493-ae9c-4b1b-9760-c009c46c9b56",
@@ -1923,23 +1923,23 @@
       "related": [
         {
           "dest-uuid": "52b9bf67-304e-403f-9b81-4d4b9d974ad6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6b11c208-4dbf-4d52-9254-524e622c6250",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c70d5b3-8748-4f88-8fd8-95f79c73d250",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d076faf3-c5bd-4e5c-93a5-8408c9e80fe1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f1a019df-12f0-442e-9b0e-b1a82352389b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ff73aa03-0090-4464-83ac-f89e233c02bc",
@@ -1963,7 +1963,7 @@
         },
         {
           "dest-uuid": "8581bca4-9d34-4c78-87f7-29244581d140",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "012e526a-dacd-4019-a019-bc68733395d2",
@@ -1983,7 +1983,7 @@
         },
         {
           "dest-uuid": "aa3484d0-d7ae-40e2-8a44-6b963883a35d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "387ae9f0-0b8b-49b9-ab85-8f325a583d24",
@@ -2003,7 +2003,7 @@
         },
         {
           "dest-uuid": "43f5598c-5c63-40f4-b936-2978bd0f3aa0",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a44e6677-25d9-495a-91fd-e2611dac9477",
@@ -2019,7 +2019,7 @@
       "related": [
         {
           "dest-uuid": "0a847430-f140-419e-b0fe-bd891bde85a6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e8b28c9-35fe-48ac-a14d-e6cc032dcbcd",
@@ -2043,7 +2043,7 @@
         },
         {
           "dest-uuid": "da853af7-f2e4-45c2-b78f-3d960fff638e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7ee8426e-2b65-44ed-b6d4-3800b92adf2e",
@@ -2059,7 +2059,7 @@
       "related": [
         {
           "dest-uuid": "288a28ac-e1e4-4e7e-9156-d3b975ed45ed",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "78b9e70d-1605-459c-b23d-e3a25036968c",
@@ -2067,11 +2067,11 @@
         },
         {
           "dest-uuid": "99bfd95b-256a-4b1d-bf1d-481f47642c15",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fe1cff12-9772-4ba9-92bc-c26eae79da24",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6c59d987-c339-4743-bdb0-0eb21285deb7",
@@ -2091,7 +2091,7 @@
         },
         {
           "dest-uuid": "d415367c-3624-4a68-a2b7-4734662db190",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1525b951-a0fb-42ac-97b7-05ac6f412020",
@@ -2107,15 +2107,15 @@
       "related": [
         {
           "dest-uuid": "78c505c6-25a1-4cc5-b44a-0574aa019f01",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "83d3222d-6a35-401d-95b5-a09f0eac2201",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8ba0c3e2-9544-47d1-9738-757c35dc19fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c41090b-aa47-4331-986b-8c9a51a91103",
@@ -2123,7 +2123,7 @@
         },
         {
           "dest-uuid": "c024ed9a-02bf-436d-93f5-444e45124e2f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c8b4a2e4-386f-45b3-b32a-8ca4113e5592",
@@ -2143,7 +2143,7 @@
         },
         {
           "dest-uuid": "8c881d82-21c3-482c-8895-c240360eec8e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "13c88a68-15e3-45e5-958b-82fe7b948561",
@@ -2159,11 +2159,11 @@
       "related": [
         {
           "dest-uuid": "0eff49de-834e-42d3-9a7a-3ac032aa9836",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1578f892-0644-4974-bf55-9abb802612fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d74c4a7e-ffbf-432f-9365-7ebf1f787cab",
@@ -2183,11 +2183,11 @@
       "related": [
         {
           "dest-uuid": "51a23f35-4a11-4119-935a-1ffebcda2839",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5a9c1860-23ae-455e-bcab-0e0f91af5548",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7bdca9d5-d500-4d7d-8c52-5fd47baf4c0c",
@@ -2195,7 +2195,7 @@
         },
         {
           "dest-uuid": "7e3c05c9-5e49-416c-a0c9-eb7631ea5e7e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "45665335-5bf0-4553-9398-ea40d550cbff",
@@ -2215,15 +2215,15 @@
         },
         {
           "dest-uuid": "54ae99be-c089-4e96-97f5-52af2892ae25",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bb94692e-e73c-449c-a17e-0658bebbfd93",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ef4f995e-6f20-42b7-802e-555ac54ab7b9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "55e10a13-d18d-4ce5-a773-c4ec6bd68d52",
@@ -2239,7 +2239,7 @@
       "related": [
         {
           "dest-uuid": "3191336e-8cdb-4d41-80a4-aa2ab869f7bf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "42e8de7b-37b2-4258-905a-6897815e58e0",
@@ -2247,19 +2247,19 @@
         },
         {
           "dest-uuid": "6927a2ad-c56f-4e87-9392-6e3eef07e57e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7ebea786-db9c-439d-9caf-d0dd740047f3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3d982ec-2729-4e98-b340-affa13096fd6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f3dfb562-94ef-44ea-be4f-17ac2d0771b5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "408aedab-4a23-41ad-809d-fe9c3805b7f6",
@@ -2279,23 +2279,23 @@
         },
         {
           "dest-uuid": "50102ced-9c8f-47e6-b438-63b2a7fe983d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "531ba452-e3b8-4064-be28-31ddd13b3478",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "704bd588-a82b-4139-92ef-6dc6a48581c8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c64bf26-bda2-47fc-867d-bcc6a51d57a7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "94e5fd96-1fde-41fd-863d-6ef9cb8a3e1a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "32c549cd-a06b-41f2-8063-8937ba7feab6",
@@ -2311,11 +2311,11 @@
       "related": [
         {
           "dest-uuid": "18ba26d6-08e0-4370-8ef0-b2dd73bfe0b3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "26940057-e464-49f9-8f76-ceaca4b9d982",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6add2ab5-2711-4e9d-87c8-7a0be8531530",
@@ -2335,19 +2335,19 @@
       "related": [
         {
           "dest-uuid": "1065ad69-8969-4ae0-9df6-dc7e7b1129c2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b55c84a0-d045-43f6-a5a9-e8f6edbd275e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d0e64036-83fb-4ff7-b81b-9b67b6c6b9dc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d1ad1b0b-0050-4737-8993-73c2da8d143b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fb640c43-aa6b-431e-a961-a279010424ac",
@@ -2371,7 +2371,7 @@
         },
         {
           "dest-uuid": "5beb62fd-7dac-485f-828c-72cf151124a8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9c36b7a8-22bb-4420-a8ac-8e46ddef5674",
@@ -2387,11 +2387,11 @@
       "related": [
         {
           "dest-uuid": "4192b311-da7a-4ef1-b09a-a03a8c2a1670",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b4cf91ba-a22b-49b4-978e-32c3e1301c74",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ca9d3402-ada3-484d-876a-d717bd6e05f2",
@@ -2399,11 +2399,11 @@
         },
         {
           "dest-uuid": "e031d1a5-92a9-46df-9467-d6899d48f57b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5cb92b6-75b0-4eed-aa1e-4ea529f50fbb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "92203cb2-b7bd-4bc3-ab6f-9859a9856efc",
@@ -2423,7 +2423,7 @@
         },
         {
           "dest-uuid": "b9e42cd6-da26-4e57-b628-aca0fb1bb3f3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bcddd949-40be-40dd-949e-8f69f893360b",
@@ -2439,7 +2439,7 @@
       "related": [
         {
           "dest-uuid": "193f0293-0a53-430f-83c0-a69d0663479a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ca00366b-83a1-4c7b-a0ce-8ff950a7c87f",
@@ -2459,23 +2459,23 @@
       "related": [
         {
           "dest-uuid": "0f9943f2-0e7e-44da-b7dd-e1a7cd52aae0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "284edcb8-0141-4fe6-afb2-9fd8a2b82b49",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e5930bf-6d79-4f75-9b9e-97cad9bf9232",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6b63caad-5d8d-4f23-be77-4e81d8904da6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7e1c7338-11d5-4ab4-aefc-bbd81e26068d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bf176076-b789-408e-8cba-7275e81c0ada",
@@ -2495,7 +2495,7 @@
       "related": [
         {
           "dest-uuid": "1dd7c76f-ff71-4597-8785-f7a730101a00",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7efba77e-3bc4-4ca5-8292-d8201dcd64b5",
@@ -2515,15 +2515,15 @@
       "related": [
         {
           "dest-uuid": "02571f27-8fa6-47cb-9097-0b84016a1dda",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5f1ffd26-01f7-47fc-b544-130fc14c0bd2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ac36f883-9a5b-4796-9f2e-18f1cce8fc0b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f232fa7a-025c-4d43-abc7-318e81a73d65",
@@ -2531,7 +2531,7 @@
         },
         {
           "dest-uuid": "fc507123-4267-4cf8-9e30-a90a89043b20",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a1a9e316-145a-4744-a594-7decc23c543d",
@@ -2547,11 +2547,11 @@
       "related": [
         {
           "dest-uuid": "0c833a56-ca8e-41d8-b79a-3f3c89c63a48",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "222cf26f-e5cc-4b60-a7b2-39118b5c20d6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fb75213f-cfb0-40bf-a02f-3bad93d6601e",
@@ -2571,7 +2571,7 @@
       "related": [
         {
           "dest-uuid": "a7666a4d-ece8-4e5b-ae85-d2987f14b950",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c2e147a9-d1a8-4074-811a-d8789202d916",
@@ -2579,11 +2579,11 @@
         },
         {
           "dest-uuid": "eb5334b4-8a19-4efd-a225-44a2783c6d39",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f884a712-ace6-426c-ab81-8ff33e83be92",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a57c9ffb-8b18-4178-a07f-e596abe389bd",
@@ -2599,11 +2599,11 @@
       "related": [
         {
           "dest-uuid": "170e84e2-fa22-4e8c-b2f3-3cafc0d96d7e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "61e3802a-c95c-43c2-8749-139e0f750169",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9a60a291-8960-4387-8a4a-2ab5c18bb50b",
@@ -2611,15 +2611,15 @@
         },
         {
           "dest-uuid": "9c5ef78d-2e02-4201-ba38-ec858e8b6a6f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e9efdc0-82d3-4046-a4db-e97454f708a6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "befbbdad-a17b-41f2-bb24-5cb477c5cc50",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1fba9af9-8087-4958-90c0-ecdd8c887f6f",
@@ -2639,15 +2639,15 @@
         },
         {
           "dest-uuid": "93918e31-51b1-4d85-8b16-590871c2cc1f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dbc6d9ca-9502-46a0-a59b-15b050bb539c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3c81570-be1b-48c8-b000-b70173c5c226",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a3bdd6e2-92d3-45db-a486-9f051c68672b",
@@ -2667,15 +2667,15 @@
         },
         {
           "dest-uuid": "98d733c2-370b-4cd0-8ec6-226a1ca19604",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c19f8f89-76f9-4345-8bb6-a065fba50bff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e6d04b50-7bdc-480e-9bda-291db9b270f6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b4cdf164-9cb7-4cad-bdc3-81b5574f364a",
@@ -2695,7 +2695,7 @@
         },
         {
           "dest-uuid": "c7172412-6e48-45a0-a1c5-2eae892c1fc7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2556841e-474a-45c0-b827-4f5db6dcca31",
@@ -2715,7 +2715,7 @@
         },
         {
           "dest-uuid": "c061d938-cafa-4e9d-8729-29d63ba633ad",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d32792e2-f927-492b-91bf-ac478cf64868",
@@ -2731,15 +2731,15 @@
       "related": [
         {
           "dest-uuid": "065f2c96-6903-4cd1-a737-99ecf1fdc73e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4aaf0a98-c6a9-4b30-a9d9-3a014473bd0e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b3b58ac5-6b60-4c34-9842-46f5ee517bcb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "be2dcee9-a7a7-4e38-afd6-21b31ecc3d63",
@@ -2759,15 +2759,15 @@
       "related": [
         {
           "dest-uuid": "46630fc8-75de-4b73-b46e-0a4eeb7ad310",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4766bdc0-047a-4250-93c1-6d907178620e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7c28e2f5-c944-4974-810f-81bcfdc8b6cc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9fa07bef-9c81-421e-a8e5-ad4366c5a925",
@@ -2775,19 +2775,19 @@
         },
         {
           "dest-uuid": "b5985d46-1d54-4a6d-81c8-0b577b5d8d17",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c526f8c1-95ec-494f-b7bf-49a95a803f2a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e19cbf11-fabf-4dfd-aeb2-1c62660ebd8f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f0e2baa2-3bb7-4587-8eae-6abddd1cf140",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2f7a5ebd-e025-4822-aed2-46fc3ec1a0a9",
@@ -2803,7 +2803,7 @@
       "related": [
         {
           "dest-uuid": "01f18cc1-2948-4ea7-adaf-017da939b9ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "379809f6-2fac-42c1-bd2e-e9dee70b27f8",
@@ -2827,7 +2827,7 @@
         },
         {
           "dest-uuid": "13a875c4-87d2-448e-a46e-970e1f9ad5da",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d6619253-10cd-4b90-84b5-364c418d2484",
@@ -2847,7 +2847,7 @@
         },
         {
           "dest-uuid": "6ec034ac-289d-48d1-b310-021dfbf7087b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1a8d87f1-48ca-4929-a5cc-2b2a03983f12",
@@ -2863,7 +2863,7 @@
       "related": [
         {
           "dest-uuid": "5028303d-22d6-490c-b053-015e877d5829",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f0589bc3-a6ae-425a-a3d5-5659bfee07f4",
@@ -2883,7 +2883,7 @@
       "related": [
         {
           "dest-uuid": "9696a221-35b9-4576-ae75-714c902c2889",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8ba7d61-11c5-4130-bafd-7c3ff5fbf4b5",
@@ -2903,19 +2903,19 @@
       "related": [
         {
           "dest-uuid": "191d5ea7-ff08-4433-ba1b-1c0ed755ca67",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "80caf81c-0714-4fa5-8b77-8e2144e316b9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e7be37f1-88f9-45e3-91d0-1ff37bc94892",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb6edb6d-9684-4ef7-96b2-13c087276d80",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eec23884-3fa1-4d8a-ac50-6f104d51e235",
@@ -2939,19 +2939,19 @@
         },
         {
           "dest-uuid": "0de81d5a-ffba-4eba-915d-c4f4d8b30f9a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "408b2724-079c-4636-9764-52f435726de7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a82a14f4-6fc9-43b5-b183-68af3cb075a2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a94c1081-d66b-4009-95a9-247721fcd394",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6e1ea095-9f21-4544-8e9b-4fab2668033e",
@@ -2967,23 +2967,23 @@
       "related": [
         {
           "dest-uuid": "04fe83c3-d8d3-4c96-91a4-9167fa8f405a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1f1ed319-a6f9-4f30-9254-e0b1927a6bd9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "38205f16-18da-4d04-ae54-f5143b75c938",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5ff3ae40-d326-4eae-9bc5-c77ddcb6cb6e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cba23232-7fae-47df-bd83-0ca5a5066373",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "df8b2a25-8bdf-4856-953c-a04372b1c161",
@@ -3003,11 +3003,11 @@
       "related": [
         {
           "dest-uuid": "10c89810-d298-42d6-80dd-1228e737e33f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2bbe41df-b8a6-4503-8fb0-028b7387cb1d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4bed873f-0b7d-41d4-b93a-b6905d1f90b0",
@@ -3015,7 +3015,7 @@
         },
         {
           "dest-uuid": "fbbe7372-5d33-4181-a68a-e68f5da94df7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "90b6ef43-3f63-47c5-af59-ed4f95cc9c87",
@@ -3035,11 +3035,11 @@
         },
         {
           "dest-uuid": "59bfb473-611f-4443-9d11-f44e7ace93fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e643c4aa-dc7d-43d9-b36e-f13d733f8e9a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "71a8576b-c9ef-4485-b461-d706fd757a67",
@@ -3059,7 +3059,7 @@
         },
         {
           "dest-uuid": "f27c0482-fbea-47a3-9b19-7302a058a9e5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0602b47a-d37c-4eee-ac4b-b464060945ab",
@@ -3075,7 +3075,7 @@
       "related": [
         {
           "dest-uuid": "63fcb4be-f5c2-47da-951d-cd1b4f1a2cc0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb062747-2193-45de-8fa2-e62549c37ddf",
@@ -3099,7 +3099,7 @@
         },
         {
           "dest-uuid": "ffe7278f-7cd1-402f-a3a7-dcc7a363b031",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b661f959-953f-4329-a43a-f1b060e7626b",
@@ -3115,7 +3115,7 @@
       "related": [
         {
           "dest-uuid": "48a818ac-077b-46ff-b615-bb2958536aef",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea4c2f9c-9df1-477c-8c42-6da1118f2ac4",
@@ -3135,7 +3135,7 @@
       "related": [
         {
           "dest-uuid": "4e5ffb58-75de-4305-a439-98ca3499f45e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79a4052e-1a89-4b09-aea6-51f1d11fe19c",
@@ -3143,15 +3143,15 @@
         },
         {
           "dest-uuid": "bcab4073-2316-4685-be6c-fb5ab92b22be",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d73a1356-7f4f-4f54-afca-437736e5f53c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d8978977-d2c8-4c1c-a6c1-0176330e3446",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5d368ccf-2946-4a01-bfae-c18064b6187a",
@@ -3167,7 +3167,7 @@
       "related": [
         {
           "dest-uuid": "0fbbc547-37a7-4d00-a8a4-5fbcf3d27a1e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2acf44aa-542f-4366-b4eb-55ef5747759c",
@@ -3175,11 +3175,11 @@
         },
         {
           "dest-uuid": "3ea6b02e-47e0-4815-9190-4e95eb51e779",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8a764f0e-4bcd-413d-bbf0-1a10cb98b598",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6bab4067-9bfc-4e7f-b7fc-e578acd81e6a",
@@ -3199,7 +3199,7 @@
         },
         {
           "dest-uuid": "e6037bea-ba25-40bf-b681-361d4f901adb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8d06728f-5b50-4925-a05c-4d56b17ba5d2",
@@ -3219,7 +3219,7 @@
         },
         {
           "dest-uuid": "7aaf568b-bc31-4fb0-8543-12ee281a0b85",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4f95fef5-3b5e-435a-ad00-33d2d9765640",
@@ -3235,19 +3235,19 @@
       "related": [
         {
           "dest-uuid": "041c0b93-fda4-478f-b847-d10619db729c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a0bfcae2-1936-466d-91b4-f72fcae730b6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c8a50f3f-105a-4107-9781-a3d75479e93d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d3e3ed48-7402-40df-a6cc-db9b560bcfd1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e49920b0-6c54-40c1-9571-73723653205f",
@@ -3271,19 +3271,19 @@
         },
         {
           "dest-uuid": "9933242a-f96e-4b3e-896f-e7335f410a4f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cd10c7fd-edef-4f85-aff3-9eaa35906b18",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ddbf61e2-7dad-40ef-90ef-7bec707b50fd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dff59103-f6d4-4580-8316-a0528768b4b3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "08633541-0006-480a-a2d9-e1c81952cc71",
@@ -3299,7 +3299,7 @@
       "related": [
         {
           "dest-uuid": "34c5e959-876b-4851-8ebf-bfaf97e9e609",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "54a649ff-439a-41a4-9856-8d144a2551ba",
@@ -3307,19 +3307,19 @@
         },
         {
           "dest-uuid": "8a534291-3b75-45ba-9f7b-b952251a3f03",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a366262a-ba79-4b74-be16-0b139d546651",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfabf07a-8179-43f5-abf6-699202c10343",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e26778ca-0fd9-4a1b-9d1d-d8ba561b065a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d33ffd4e-6328-4b10-84c0-7ad4a241b02d",
@@ -3335,7 +3335,7 @@
       "related": [
         {
           "dest-uuid": "53dd199d-4f38-4f12-83dd-f2d471d58a1b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c63a348e-ffc2-486a-b9d9-d7f11ec54d99",
@@ -3355,7 +3355,7 @@
       "related": [
         {
           "dest-uuid": "1b6eaec8-141f-44f8-ae1f-387c44635c38",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2db31dcd-54da-405d-acef-b9129b816ed6",
@@ -3363,11 +3363,11 @@
         },
         {
           "dest-uuid": "9c8ba5cd-40db-4214-8db1-b03b2d7b1690",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bcc6bec5-63c7-4084-9d2f-da8b58d0f621",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5367273a-2f30-413e-a961-1dbd323be5b0",
@@ -3383,15 +3383,15 @@
       "related": [
         {
           "dest-uuid": "477fb167-a388-4e85-856b-bdcb36e7fd95",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "759c073c-2c40-484b-af47-8426ec5d5a3e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a65545d7-fa1b-4d6f-b19c-fa03862c6210",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c615231b-f253-4f58-9d47-d5b4cbdb6839",
@@ -3411,19 +3411,19 @@
       "related": [
         {
           "dest-uuid": "1216ae5e-bc5c-4672-a216-2706fb9ba3df",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1fecb6f7-e72f-452e-a078-3298cba8d481",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3327048a-e90c-47e5-9b67-d2ecaa89523c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "38c74fcf-2a4d-45cd-8465-b5d80a605bd8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5372c5fe-f424-4def-bcd5-d3a8e770f07b",
@@ -3431,7 +3431,7 @@
         },
         {
           "dest-uuid": "df0f8f0a-1e92-415d-b15e-63cea928973a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "acb9a314-aa08-4a0f-b3ba-201d87fa4cc8",
@@ -3447,7 +3447,7 @@
       "related": [
         {
           "dest-uuid": "12be6c5f-213a-464f-b780-ac06f20ab763",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8187bd2a-866f-4457-9009-86b0ddedffa3",
@@ -3455,7 +3455,7 @@
         },
         {
           "dest-uuid": "ead38dff-ee26-477d-be5a-69b52dc8bd50",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "653b555a-590f-40e4-9400-f14d0ed92252",
@@ -3471,7 +3471,7 @@
       "related": [
         {
           "dest-uuid": "39d115fc-5e7b-423f-94da-a3b4242e07b8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ffeb0780-356e-4261-b036-cfb6bd234335",
@@ -3495,7 +3495,7 @@
         },
         {
           "dest-uuid": "f2064dd1-8cdb-472e-b187-8d1ef18fb059",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b45310bb-d520-43b3-8758-e9d5a9738429",
@@ -3511,7 +3511,7 @@
       "related": [
         {
           "dest-uuid": "0391c880-fcb3-457f-b625-18f9453659b8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7655ac3b-dfde-49c5-a967-242856174434",
@@ -3535,7 +3535,7 @@
         },
         {
           "dest-uuid": "98b71f96-ae0a-47b4-bec2-156cb6e5bfcb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "dc017318-98a3-450b-b903-fe1e7d988197",
@@ -3551,11 +3551,11 @@
       "related": [
         {
           "dest-uuid": "9eb2a081-e252-4009-a16e-90c9a85f70f1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b88f87d2-4a64-44a2-937e-85a929203843",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ceaeb6d8-95ee-4da2-9d42-dc6aa6ca43ae",
@@ -3579,7 +3579,7 @@
         },
         {
           "dest-uuid": "afb1860a-e29a-4ce8-9524-ab371c5f8d4f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "960d6663-6a7f-4f95-affe-a28d71afc7d9",
@@ -3595,7 +3595,7 @@
       "related": [
         {
           "dest-uuid": "3349af7c-3cea-4424-b2a4-056fedb63831",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bd5b58a4-a52d-4a29-bc0d-3f1d3968eb6b",
@@ -3603,11 +3603,11 @@
         },
         {
           "dest-uuid": "bd8beea8-48c8-41dc-8991-f8c739d10c70",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ec036273-4e90-465e-b115-a69bbb68dde4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c2648552-806d-40ec-8ea7-59f4e44983eb",
@@ -3623,7 +3623,7 @@
       "related": [
         {
           "dest-uuid": "12c748a0-3ce9-4fd2-8a65-f4362b69cafd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3b744087-9945-4a6f-91e8-9dbceda417a4",
@@ -3643,7 +3643,7 @@
       "related": [
         {
           "dest-uuid": "35d9b6e6-aed8-4e9e-b6ee-e683d9c17fd0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b4b7458f-81f2-4d38-84be-1c5ba0167a52",
@@ -3651,7 +3651,7 @@
         },
         {
           "dest-uuid": "bf6b3f42-a7a5-4e6d-840a-e892aa74916c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fbf8f0b2-3587-45c3-be8d-d495384075be",
@@ -3671,11 +3671,11 @@
         },
         {
           "dest-uuid": "3d209345-1676-4170-b1d0-d6538bce06c4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7edc8ff6-0616-4fab-a7b7-1bd3d08cc0b1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "74252ca3-585e-466f-8020-ed77ebda3369",
@@ -3691,11 +3691,11 @@
       "related": [
         {
           "dest-uuid": "273d7b27-6b7d-4017-a7f6-0cd02fd3a128",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e461dab-922c-48cc-aafc-51f20025bf27",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "457c7820-d331-465a-915e-42f85500ccc4",
@@ -3703,7 +3703,7 @@
         },
         {
           "dest-uuid": "865c00d7-fc01-4ce6-8fc8-d7a84f2ded36",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ce0b969a-1411-4b6f-a6aa-c31ef6fe6727",
@@ -3719,7 +3719,7 @@
       "related": [
         {
           "dest-uuid": "0994985d-1d45-478e-9f1c-f407eb297007",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1365fe3b-0f50-455d-b4da-266ce31c23b0",
@@ -3727,7 +3727,7 @@
         },
         {
           "dest-uuid": "8825b589-3a6a-483a-9fc0-a4d00b1183ab",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "31f41970-898c-4c64-b018-e03eabb81916",
@@ -3747,11 +3747,11 @@
         },
         {
           "dest-uuid": "6ffa0db8-a088-4e7a-b8e5-50a204762cca",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b4e2440e-8956-4ae6-94cb-da859f407f27",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "20d79eae-0c09-410a-b99a-f8cb6ec9153c",
@@ -3767,11 +3767,11 @@
       "related": [
         {
           "dest-uuid": "48cc1694-568f-4602-96e4-cbbe099c6dae",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "73ec21b3-5679-44a9-bac3-943060bed786",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a9e2cea0-c805-4bf8-9e31-f5f0513a3634",
@@ -3795,19 +3795,19 @@
         },
         {
           "dest-uuid": "2f4d199c-4d62-4d7d-8c6e-3ec358c22e76",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6bb68520-c27e-435a-86b5-eb2ce7841cb2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e6b92e19-5bc8-414b-b200-96ed6d286388",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f1aae71a-6460-4c08-9aa7-49743f766a71",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "28d6ebc3-3b01-45e1-b48e-6491364d23e9",
@@ -3827,19 +3827,19 @@
         },
         {
           "dest-uuid": "0979e7f1-9d0a-4549-be8f-88979df5c8d7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5d024a50-97d8-4b81-8cc6-3db4fff2712c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "73b31f73-bc47-45c1-9c02-fd8eaacb2f9b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a5cc0eac-af18-4fe2-ac06-88a5cfddf014",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "050d236f-745a-4801-add6-50cb58248615",
@@ -3855,15 +3855,15 @@
       "related": [
         {
           "dest-uuid": "269f36b6-77fa-4959-9e63-e30036c991d7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c53e92a-3659-4137-881a-f4002af9c688",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d6288db6-ff55-4720-b0ee-7aca3e65cc72",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fdc47f44-dd32-4b99-af5f-209f556f63c2",
@@ -3883,7 +3883,7 @@
       "related": [
         {
           "dest-uuid": "602def5b-49e4-4c64-afe6-1476eac13e67",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "70857657-bd0b-4695-ad3e-b13f92cac1b4",
@@ -3903,7 +3903,7 @@
       "related": [
         {
           "dest-uuid": "3af413c2-5b26-4f43-b198-11b4dce97a0a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b4694861-542c-48ea-9eb1-10d356e7140a",
@@ -3911,7 +3911,7 @@
         },
         {
           "dest-uuid": "c42179a8-71c5-41ba-bbfa-d6c1a93e729b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "00a515dc-e3be-4349-9c61-65a5c0ce815d",
@@ -3927,15 +3927,15 @@
       "related": [
         {
           "dest-uuid": "262ce2a7-2c09-4f6d-8e9f-de57b814a2a2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c83f1d8c-ba54-4f2d-91b8-3006a2180497",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eed7a6f2-496d-47c6-bdfd-1b885b58a651",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f6ad61ee-65f3-4bd0-a3f5-2f0accb36317",
@@ -3955,11 +3955,11 @@
       "related": [
         {
           "dest-uuid": "1e9fdc71-d073-403a-9ee9-bab091318454",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4baad14d-46b1-4e96-9e2a-138ae4e3ec75",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c3888c54-775d-4b2f-b759-75a2ececcbfd",
@@ -3967,7 +3967,7 @@
         },
         {
           "dest-uuid": "d0edef63-9a98-4435-9f4b-2c577c7de41d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d96f78ad-21cd-45dc-940a-63b348894728",
@@ -3987,7 +3987,7 @@
         },
         {
           "dest-uuid": "4959f750-78db-4b4c-8d91-23027b386c2b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c7bdd7d7-19dc-4042-8565-5e0cf4656102",
@@ -4007,7 +4007,7 @@
         },
         {
           "dest-uuid": "cda93955-7500-49dd-9150-94bedae91d22",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "78340b60-535e-4f2e-a376-c6fcc53a3c4a",
@@ -4023,7 +4023,7 @@
       "related": [
         {
           "dest-uuid": "17bc7c97-7322-4619-84c5-50e45aa6627d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79a47ad0-fc3b-4821-9f01-a026b1ddba21",
@@ -4031,7 +4031,7 @@
         },
         {
           "dest-uuid": "85b4c967-56bc-4990-b3e2-7e40f3ef1852",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e04f7ddf-6a1e-4731-afd6-5edb74f4c624",
@@ -4047,7 +4047,7 @@
       "related": [
         {
           "dest-uuid": "2ae1dd34-c666-488f-8ad6-752b8a6acae1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "671cd17f-a765-48fd-adc4-dad1941b1ae3",
@@ -4055,11 +4055,11 @@
         },
         {
           "dest-uuid": "f606ec01-15d2-4432-b91b-669411205015",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fcc2b0dc-93c4-49de-abfe-6273c24d1d89",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "206790b2-16bc-46db-a605-8bcff576c161",
@@ -4075,7 +4075,7 @@
       "related": [
         {
           "dest-uuid": "2f39584b-59bd-43ec-bd0a-5c2eba258ae2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fa44a152-ac48-441e-a524-dd7b04b8adcd",
@@ -4099,7 +4099,7 @@
         },
         {
           "dest-uuid": "58e73108-657e-42ce-8dad-4edc968a2b20",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f3bc6ce9-29ad-4ad4-813c-1a4176b5c7a2",
@@ -4115,7 +4115,7 @@
       "related": [
         {
           "dest-uuid": "6482fa33-322b-47e4-a9f7-c2bcc92d132a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6495ae23-3ab4-43c5-a94f-5638a2c31fd2",
@@ -4135,15 +4135,15 @@
       "related": [
         {
           "dest-uuid": "69562961-14e6-42a7-9f8a-24ac00f6404e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "98f8728d-ff74-47cb-b884-25071a21f77e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b053dbd4-ad1e-45e1-a6b7-af2a5d931c82",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dca670cf-eeec-438f-8185-fd959d9ef211",
@@ -4151,7 +4151,7 @@
         },
         {
           "dest-uuid": "e716b209-5b06-4bc4-843f-cbe4c51ddc0d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "be6a466c-40c6-4611-9b68-7cfcbcb35fb0",
@@ -4171,7 +4171,7 @@
         },
         {
           "dest-uuid": "c5544183-4868-4a5c-ad8c-8a9359358298",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ff993025-1f12-486f-936f-6cc563050278",
@@ -4191,7 +4191,7 @@
         },
         {
           "dest-uuid": "b6516e8b-fd18-4c92-8701-1762d8321168",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "62d7a748-dee5-46c7-b61c-77f57f371b4f",
@@ -4211,7 +4211,7 @@
         },
         {
           "dest-uuid": "4eaeffc2-bdfa-427c-a009-daadee39457d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f5ee584b-bbbd-481a-af63-c49166b8b1a8",
@@ -4231,7 +4231,7 @@
         },
         {
           "dest-uuid": "a29288f5-c5d8-4e2d-8370-c4e21a64fc95",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c29886a9-676a-441a-adcd-6f239f8eb6b0",
@@ -4251,23 +4251,23 @@
         },
         {
           "dest-uuid": "466a2102-fcb3-4372-9a8d-ad8fe34e94ec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "61256fb2-d490-4e1d-b308-665a2d68ec64",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "adf3e421-95ec-4b5a-9c00-0262cb888c0a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c9bdc7a6-ff19-46e9-a534-fa2fd3e0a193",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d16be21c-6df4-4648-91cd-36152dafa38d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b667390b-a805-401d-9e02-929204825114",
@@ -4287,15 +4287,15 @@
         },
         {
           "dest-uuid": "66c98f78-2848-43f4-a69d-5562f03712ec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e80763b-5287-451f-b2ab-37168b159387",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5a0bbf3-e5d0-41f1-b757-c67eccece77b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "abb052c6-4edd-4592-9b9b-e53a55ac53b8",
@@ -4311,7 +4311,7 @@
       "related": [
         {
           "dest-uuid": "b8ec766b-cfb9-4ef8-bd46-655f0b820ad3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cf1c2504-433f-4c4e-a1f8-91de45a0318c",
@@ -4335,11 +4335,11 @@
         },
         {
           "dest-uuid": "a2d3072a-0f3a-46a1-a92e-f0d7ae030b48",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c84ed29d-c0bf-465c-9e4a-7685cd4ff444",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9e93c9d8-3e37-45ae-88d5-12914d98ba5a",
@@ -4355,7 +4355,7 @@
       "related": [
         {
           "dest-uuid": "5e4aea30-f04b-4f1e-b68a-f2f3a95e5066",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c45eaa3-8604-4780-8988-b5074dbb9ecd",
@@ -4375,7 +4375,7 @@
       "related": [
         {
           "dest-uuid": "43347e24-50d6-446e-923d-a6fd69805a22",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "54b4c251-1f0e-4eba-ba6b-dbc7a6f6f06b",
@@ -4383,15 +4383,15 @@
         },
         {
           "dest-uuid": "784b7a50-cdc5-4161-8b52-2be5e5de19ac",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a311af7c-2302-4113-8cc3-d5d599fa908a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aef3d563-19f5-4d52-b7ad-4c4abadcb568",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bcb3772f-25d7-4e41-8e37-ec0dc759f44d",
@@ -4407,15 +4407,15 @@
       "related": [
         {
           "dest-uuid": "22ff1717-6ba8-4908-b795-edf0c41a997e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "39da0718-fa22-4f77-8bd2-ea8300087658",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7bf8954f-5028-419d-b93f-9c6bfe6e5086",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8868cb5b-d575-4a60-acb2-07d37389a2fd",
@@ -4423,7 +4423,7 @@
         },
         {
           "dest-uuid": "fe82e2a6-a928-4fe0-a899-fead90eabb29",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "68b7c978-74e4-4f87-a953-2a4e752f56c2",
@@ -4439,7 +4439,7 @@
       "related": [
         {
           "dest-uuid": "2c64ece9-c40f-4d1a-babf-106f587454d0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "35187df2-31ed-43b6-a1f5-2f1d3d58d3f1",
@@ -4447,7 +4447,7 @@
         },
         {
           "dest-uuid": "c94b2c2b-8885-4f5e-abec-e80ab0a24f21",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "90ee8005-5476-422f-abe0-6c231f004cd6",
@@ -4463,7 +4463,7 @@
       "related": [
         {
           "dest-uuid": "d1bcc6a4-e84a-4251-b86b-e8fe2ecc0dd1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e624264c-033a-424d-9fd7-fc9c3bbdb03e",
@@ -4483,7 +4483,7 @@
       "related": [
         {
           "dest-uuid": "54ffc701-eb6c-4e3e-8615-0c6f8b327a34",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7b211ac6-c815-4189-93a9-ab415deca926",
@@ -4503,7 +4503,7 @@
       "related": [
         {
           "dest-uuid": "0929e9c5-2e1a-4cc1-a9c5-df081b180201",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "677569f9-a8b0-459e-ab24-7f18091fa7bf",
@@ -4523,11 +4523,11 @@
       "related": [
         {
           "dest-uuid": "86a87684-5fd5-4778-be36-5dfa07a4246d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b6f88f17-e80f-4c75-99a5-f752880196aa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bd369cd9-abb8-41ce-b5bb-fff23ee86c00",
@@ -4535,7 +4535,7 @@
         },
         {
           "dest-uuid": "e3ddaba3-282b-4bd0-b316-78b724b79acd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "77d3b532-9c4f-4f9f-9581-3009b201435d",
@@ -4551,11 +4551,11 @@
       "related": [
         {
           "dest-uuid": "041812fa-5446-47cc-8ca0-1106f4874c10",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "147c0305-abff-4bc3-ae2a-acd69d0b87fd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "248d3fe1-7fe1-4d71-91c7-8bb7ef35cad3",
@@ -4563,15 +4563,15 @@
         },
         {
           "dest-uuid": "3e87713d-d062-413c-9643-97df331ba651",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "544c832f-4849-4fb7-a851-5f69ec0692a9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d869b672-c3e9-446c-9e7a-c9ce5888794c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "18fe3660-c079-4522-b1d7-7ce7f65f9686",
@@ -4587,7 +4587,7 @@
       "related": [
         {
           "dest-uuid": "6eab700a-548f-48aa-8821-163682fe8bbe",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8cdeb020-e31e-4f88-a582-f53dcfbda819",
@@ -4607,11 +4607,11 @@
       "related": [
         {
           "dest-uuid": "23b9a5cd-9c49-48d8-9d0d-71e35ad78337",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2ec84f0f-1148-4821-acf0-a5527381865f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6fa224c7-5091-4595-bf15-3fc9fe2f2c7c",
@@ -4619,7 +4619,7 @@
         },
         {
           "dest-uuid": "adfcc782-0285-43ef-af18-127dd60d1dff",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "210a0dee-7c4b-4948-80ed-67c3e04886c2",
@@ -4639,11 +4639,11 @@
         },
         {
           "dest-uuid": "99c42b1f-1716-413b-8c23-5f7e1d997ab2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d1d19568-2b59-4d44-9744-22d7304d2200",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "07fb6847-efcb-426e-9344-bfc9dfcdebd4",
@@ -4659,7 +4659,7 @@
       "related": [
         {
           "dest-uuid": "e6f38f76-4e60-4b8a-881c-5d3f206e912c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ffbcfdb0-de22-4106-9ed3-fc23c8a01407",
@@ -4679,15 +4679,15 @@
       "related": [
         {
           "dest-uuid": "1313533a-06c7-44ea-8d75-9a23d3ea23cc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2127b359-24b0-40e2-a202-67e53d5be3b0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "367cfbd9-fcfd-4336-863e-b6917ff71cb4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "51a14c76-dd3b-440b-9c20-2bf91d25a814",
@@ -4695,19 +4695,19 @@
         },
         {
           "dest-uuid": "7fb5fe4f-ecd1-45a1-8a0f-dc913587e650",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "91681b37-7fc7-418c-b4fd-35bebe1d151e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e7ce6bda-a4d3-43a4-afa0-34d57c34ef0d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fbe17895-73cc-432e-8576-f6cab851feb1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2b666abc-e642-4f40-abec-36bd48f1f15c",
@@ -4723,7 +4723,7 @@
       "related": [
         {
           "dest-uuid": "4bb5b68e-1a01-498e-ae39-94f951e01cd9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "573ad264-1371-4ae0-8482-d2673b719dba",
@@ -4743,7 +4743,7 @@
       "related": [
         {
           "dest-uuid": "282d9231-942a-4b97-875c-659aa2c41971",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee7ff928-801c-4f34-8a99-3df965e581a5",
@@ -4767,7 +4767,7 @@
         },
         {
           "dest-uuid": "e886b9c8-2187-4363-9043-1e5c60d75363",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6f59bdfc-8352-4e6f-bef1-cc59b4e9b04d",
@@ -4783,7 +4783,7 @@
       "related": [
         {
           "dest-uuid": "04bcbbb7-bfa9-41a5-9fb8-72a6df9ad50b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "29be378d-262d-4e99-b00d-852d573628e6",
@@ -4791,11 +4791,11 @@
         },
         {
           "dest-uuid": "5a92bf3c-1832-453b-8ac9-24f8688d6faf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7b4b3b54-d992-4f03-922a-6eec96c9342e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5b998fb4-fb3f-4207-ae00-cdf0e1a22b76",
@@ -4811,7 +4811,7 @@
       "related": [
         {
           "dest-uuid": "1a93a610-7389-4ea7-a053-e99d35a5477a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "77e29a47-e263-4f11-8692-e5012f44dbac",
@@ -4819,11 +4819,11 @@
         },
         {
           "dest-uuid": "a0a0f8e9-7a55-4450-8569-7a0e1c0aac0b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3517ec0-f12a-4f64-8d10-e6bc2677f7d7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3efcd3e4-9238-4686-990b-27ac110dccfd",
@@ -4839,15 +4839,15 @@
       "related": [
         {
           "dest-uuid": "089d588f-a6aa-4083-a900-ebcae97b5bfa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0961ff0c-8c36-4820-948d-12855b7f5cc7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3d124174-1e58-44e2-9f5b-f63394fb7a2e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f104855-e5b7-4077-b1f5-bc3103b41abe",
@@ -4855,7 +4855,7 @@
         },
         {
           "dest-uuid": "f74ce996-0982-4e2a-86ee-5bce001ee9fc",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "880c0a88-bbd5-4d71-b8bd-72fbab7d58b2",
@@ -4871,11 +4871,11 @@
       "related": [
         {
           "dest-uuid": "0f996058-7524-4759-9d88-a8997e90ff3c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5ee16525-5e86-4634-aa75-37468c4034c4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cabe189c-a0e3-4965-a473-dcff00f17213",
@@ -4883,7 +4883,7 @@
         },
         {
           "dest-uuid": "dc4a80e3-7670-474f-aaf6-c051d5dda83c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "99758bfb-f638-43aa-a233-d27646452116",
@@ -4899,23 +4899,23 @@
       "related": [
         {
           "dest-uuid": "252e5c07-8ae0-4ef8-9a98-c11b6c6d4d46",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2e51d33e-28d3-4e3f-a68a-38bc2d4abdde",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "99ab1534-79b5-4660-83ed-3604bcb320f2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9f2278c6-2e45-42fb-a1f9-00f02d496c53",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bd34c127-9956-4616-999d-229f30512f74",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f3c544dc-673c-4ef3-accb-53229f1ae077",
@@ -4935,7 +4935,7 @@
       "related": [
         {
           "dest-uuid": "667326a7-1f31-4ef1-92c1-6cb5241dadcf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "77eae145-55db-4519-8ae5-77b0c7215d69",
@@ -4943,11 +4943,11 @@
         },
         {
           "dest-uuid": "7a72f91d-9c16-4724-b87d-3e5448f81b51",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fb330f70-f0f4-4a5b-9b91-37d29a097a4c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c3c32822-80b2-4399-8e82-15cefaa80333",
@@ -4963,7 +4963,7 @@
       "related": [
         {
           "dest-uuid": "03513eb2-6dbd-4160-94dd-25d2bce349be",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7610cada-1499-41a4-b3dd-46467b68d177",
@@ -4971,11 +4971,11 @@
         },
         {
           "dest-uuid": "86103b48-cd6d-447d-aef4-807e10355506",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e86081ab-aad1-48a1-abd8-5a5c8c7c936a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "aae40136-73f7-45e8-a37f-104ae7155bbe",
@@ -4991,15 +4991,15 @@
       "related": [
         {
           "dest-uuid": "45e8fdaf-60cc-46db-a9fd-5dc18c8db6bb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4e4c318b-5da0-46f7-aed2-d37828e4831b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "614594ba-9590-4fa9-871c-3e092882c74c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "635cbe30-392d-4e27-978e-66774357c762",
@@ -5007,15 +5007,15 @@
         },
         {
           "dest-uuid": "ac204e03-5c8c-4e29-929c-780145a98669",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b7a63a7c-e8c2-4a25-becf-299ea45996e5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee065e5f-5a04-49bd-b2b6-33b404ac37c7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2250ba04-1b95-4c72-9373-d87e8c1d7869",
@@ -5031,7 +5031,7 @@
       "related": [
         {
           "dest-uuid": "7bd7f602-0f85-4e96-bd40-ae4a6f490b32",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e0232cb0-ded5-4c2e-9dc7-2893142a5c11",
@@ -5051,15 +5051,15 @@
       "related": [
         {
           "dest-uuid": "70e28077-c8a6-425f-94c7-a74a7140c7ce",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "98ce32fb-1b91-4487-9e5a-951375f2380e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b9f79a81-9fee-47f2-bef8-a9f64fde935e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f3d95a1f-bba2-44ce-9af7-37866cd63fd0",
@@ -5079,11 +5079,11 @@
       "related": [
         {
           "dest-uuid": "3ae99176-ce61-4598-834b-f48d13802dcb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6acf01f9-723e-499b-8774-3fa689a36ded",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b63a34e8-0a61-4c97-a23b-bf8a2ed812e2",
@@ -5103,7 +5103,7 @@
       "related": [
         {
           "dest-uuid": "c4cabd45-86a2-4842-9171-dff93f6ac737",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dcaa092b-7de9-4a21-977f-7fcb77e89c48",
@@ -5123,15 +5123,15 @@
       "related": [
         {
           "dest-uuid": "0677b819-0586-454c-9f4d-c861ccaf1b73",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "70f6482e-e93b-45a5-9b8c-ba7fd0c8220a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "78821450-c84f-498f-abf2-b43211fa4218",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
@@ -5139,11 +5139,11 @@
         },
         {
           "dest-uuid": "a064fdd2-4293-4aff-a91b-e06ac8bf9262",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "da365d5b-c955-46f6-99c2-cd57a3560a57",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "58bdb4c6-510b-4ffc-9703-852614116ac8",
@@ -5163,7 +5163,7 @@
         },
         {
           "dest-uuid": "926f4550-8c47-4882-afb3-1f0832c8d3b9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f40c0c98-76fe-4e2a-970a-0491f52a9a47",
@@ -5179,23 +5179,23 @@
       "related": [
         {
           "dest-uuid": "33d574c3-8e9b-462d-b3d1-09e64c2fa8c7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7947aae5-fd76-403c-8c73-1300dff7d30f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9d70d90c-f318-4318-a18d-e4775ffa229e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d715d148-4d2d-407c-bd83-c471a4163d4e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ddaf8ed8-f6bd-4eac-911c-d9fd243e87e9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e01be9c5-e763-4caf-aeb7-000b416aef67",
@@ -5215,15 +5215,15 @@
       "related": [
         {
           "dest-uuid": "17b82342-cc75-4dcd-ad98-f313cd2a2b69",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "32ef36a3-3112-40a1-84d0-323b7b86cb5b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "70e3066e-6ba3-444b-8e88-dfc3575f2706",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9db0cf3a-a3c9-4012-8268-123b9db6fd82",
@@ -5231,7 +5231,7 @@
         },
         {
           "dest-uuid": "f8c99f4f-f61e-436c-a093-c97969c9b038",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ee73dd97-cf1a-4220-a7cf-52d864811bb4",
@@ -5247,15 +5247,15 @@
       "related": [
         {
           "dest-uuid": "097ce8cb-9a38-4c8a-836c-cee15ccdf258",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1c3cb010-1c22-40c8-92d3-52e31353ad92",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "475a8817-1ace-4bef-baaa-0f56979eb85a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "47f2d673-ca62-47e9-929b-1b0be9657611",
@@ -5263,7 +5263,7 @@
         },
         {
           "dest-uuid": "632f7aef-f848-4147-95fa-2052bd373576",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f9d25557-f87b-4920-a98b-8a3c9df4bfce",
@@ -5279,11 +5279,11 @@
       "related": [
         {
           "dest-uuid": "773188c7-6191-4ba4-ad39-b67ed8578dd9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "778e2c18-2b26-4dd4-b4b2-3f8310d57a07",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e51137a5-1cdc-499e-911a-abaedaa5ac86",
@@ -5307,7 +5307,7 @@
         },
         {
           "dest-uuid": "670462e3-6c3e-4779-af75-2a0424a5d221",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b376d299-69ef-444a-8ba1-15a6c7049605",
@@ -5323,7 +5323,7 @@
       "related": [
         {
           "dest-uuid": "84e969fd-a0ee-425f-a7dd-ae10e170d45a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f6fe9070-7a65-49ea-ae72-76292f42cebe",
@@ -5347,19 +5347,19 @@
         },
         {
           "dest-uuid": "2faaefb9-7816-4eb5-a9f5-b4006c99c20b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4f15b707-9b44-4716-bfcd-e3f28659077b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ae581308-5c1f-40b9-ae6e-51c375821476",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ba43428d-b5d2-4815-a614-42ff1ea816a9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2470975e-6748-42a5-9a48-74dc7b687fe9",
@@ -5375,7 +5375,7 @@
       "related": [
         {
           "dest-uuid": "2e039fd4-a1f6-4c4b-b47a-56c257335298",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f9e9365a-9ca2-4d9c-8e7c-050d73d1101a",
@@ -5383,7 +5383,7 @@
         },
         {
           "dest-uuid": "f9fb1a46-02f0-4d89-a3d9-6bed04bd47be",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "101bde37-6150-45c6-bf88-3a8cda39b2f0",
@@ -5403,7 +5403,7 @@
         },
         {
           "dest-uuid": "89e3509c-d732-4826-ac78-baea8fbf0834",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f3cd8bda-d509-4452-a119-3feebb8f05b6",
@@ -5423,7 +5423,7 @@
         },
         {
           "dest-uuid": "298d1a46-ec12-4cd2-acce-7e0f849c384d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f31ad178-1f54-41a6-b286-8040e7eb7158",
@@ -5439,7 +5439,7 @@
       "related": [
         {
           "dest-uuid": "248be939-35f5-4c8a-9e21-b6de514da577",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aedfca76-3b30-4866-b2aa-0f1d7fd1e4b6",
@@ -5447,11 +5447,11 @@
         },
         {
           "dest-uuid": "e21542c4-8df8-4c9e-8b1d-2c9bbe058386",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e8fc16bf-6654-4912-96c9-208e4c5bbaa6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "07669925-383b-455b-a3e2-3a79e18eed27",
@@ -5471,15 +5471,15 @@
         },
         {
           "dest-uuid": "23b6aee9-90fc-46b8-bf8b-36043218f393",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "425a3e89-ac22-4ff3-bc1e-ca1672113075",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e08eb9fa-4a45-434b-9776-277bd545f1f7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e3776b4e-00b0-44cd-9e77-5df960a979d7",
@@ -5495,7 +5495,7 @@
       "related": [
         {
           "dest-uuid": "0faa41a3-0d4c-42d1-885a-12436fbee9c1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "118f61a5-eb3e-4fb6-931f-2096647f4ecd",
@@ -5503,15 +5503,15 @@
         },
         {
           "dest-uuid": "5a652a8f-a8e1-4010-bc2b-2ffaa2838333",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "63de336c-105c-4e8f-aefc-420a3eac32e9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee7499f8-4262-47cf-8fff-5344f60bf2cf",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "263a0357-5f6d-4066-bfda-afeb883e51d7",
@@ -5527,7 +5527,7 @@
       "related": [
         {
           "dest-uuid": "23e84bf6-70d1-4c49-97b8-0fff9c6efa8f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a6937325-9321-4e2e-bb2b-3ed2d40b2a9d",
@@ -5551,19 +5551,19 @@
         },
         {
           "dest-uuid": "34560ac3-2e05-4394-8145-0cd6071c1680",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "538707d4-df45-489b-97f5-0115802a701f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "575a9c01-6dac-4513-86ca-e80b6e485212",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d970c6c7-82d0-4977-9e2e-4b27af383ca5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1dd8a02b-b447-48ed-a146-ad955c9b2dc1",
@@ -5583,7 +5583,7 @@
         },
         {
           "dest-uuid": "9f3aea30-e100-432a-8aa0-959bd7f4e069",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f3cc2f0f-c657-4453-90a8-d7c9a59d6e37",
@@ -5599,7 +5599,7 @@
       "related": [
         {
           "dest-uuid": "11d8dd9d-e8f3-40cd-b9fe-cc82b6c2e790",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1996eef1-ced3-4d7f-bf94-33298cabbf72",
@@ -5607,19 +5607,19 @@
         },
         {
           "dest-uuid": "407bb9c9-0c31-4172-8dd3-bdd0547f2d1e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "42a8c7a7-2773-4892-b647-40d3542ae4d2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc8183e1-9de4-469a-9117-79bf2e986e31",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fe648823-66c8-4cc3-8a8e-38616194464c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c2721658-fa76-4b6f-9f84-50618de81ae0",
@@ -5635,7 +5635,7 @@
       "related": [
         {
           "dest-uuid": "7d4732f8-989c-4425-81c4-aa3e1bcb8d0e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8861073d-d1b8-4941-82ce-dce621d398f0",
@@ -5643,15 +5643,15 @@
         },
         {
           "dest-uuid": "c85d0aea-06c4-4b0f-8552-0d0873394ffa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ecb9db5c-55ef-48df-8ccb-f57db8c32a08",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fb23f9ee-cdc8-46be-8f40-3631afbaff5a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f6e514c0-120a-4ab1-ae3d-aa2de14e4324",
@@ -5667,19 +5667,19 @@
       "related": [
         {
           "dest-uuid": "0519edaf-6485-40b2-8b91-13db29fb8cb8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e852bb9-785d-4bc4-9f7e-b7e43a5d8bc8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4c7d92bb-4b46-44e4-b070-43c46d3193c4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d3bad85b-9e86-4de8-9e4a-1666133af782",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f7c0689c-4dbd-489b-81be-7cb7c7079ade",
@@ -5703,7 +5703,7 @@
         },
         {
           "dest-uuid": "d845dc30-6950-4f0c-9342-29b7a7315bd2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "65c18137-cad3-4fd3-8b24-22a61850c8a1",
@@ -5719,7 +5719,7 @@
       "related": [
         {
           "dest-uuid": "868abb22-3d6c-4172-bf38-9e3c1aba4dae",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ae7f3575-0a5e-427e-991b-fe03ad44c754",
@@ -5739,7 +5739,7 @@
       "related": [
         {
           "dest-uuid": "3e9734aa-b9b4-4716-927c-27c2c2aa972e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "562e9b64-7239-493d-80f4-2bff900d9054",
@@ -5759,23 +5759,23 @@
       "related": [
         {
           "dest-uuid": "3102edb4-6947-4cef-9660-4a35d582a716",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "472f81b1-99ba-406a-b2ef-d70b2af5b527",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5f2cc434-5edc-4f36-927a-eb48ee72aa6e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7027622a-7a33-4189-a500-c54eef3467b6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b7e4a6de-8ff3-4711-aa83-97533adec211",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c675646d-e204-4aa8-978d-e3d6d65885c4",
@@ -5795,7 +5795,7 @@
       "related": [
         {
           "dest-uuid": "108a10d2-4a9e-4c11-8a6f-42c8b60f0f52",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7decb26c-715c-40cf-b7e0-026f7d7cc215",
@@ -5803,7 +5803,7 @@
         },
         {
           "dest-uuid": "d5dc64ab-bb69-4893-a155-84d403040e1a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bbeacdc8-c14c-44f1-9ace-fc8282a05c67",
@@ -5819,11 +5819,11 @@
       "related": [
         {
           "dest-uuid": "42683860-d6df-4585-af65-31f783269f8f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "69d9d158-aa43-4b73-b9a4-f1a2dc6c13c1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7bc57495-ea59-4380-be31-a64af124ef18",
@@ -5831,15 +5831,15 @@
         },
         {
           "dest-uuid": "aaddc766-52bb-428b-98c4-3a742d10befa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b50bf863-644a-48c2-85a3-2c633f135650",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "be6e5f23-0e29-430f-83f7-d76c58de3a2d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "33ab9d0c-5671-48e6-8465-f80560909c65",
@@ -5855,7 +5855,7 @@
       "related": [
         {
           "dest-uuid": "092689c7-be8a-4d11-99d8-7dd96afa938d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a1b52199-c8c5-438a-9ded-656f1d0888c6",
@@ -5863,7 +5863,7 @@
         },
         {
           "dest-uuid": "c221d379-1dcb-4ca7-908e-59f6ed7afaed",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "df1da8e4-cabf-42f0-8f5f-2fa8086b1423",
@@ -5879,23 +5879,23 @@
       "related": [
         {
           "dest-uuid": "1b3bbeab-2000-47d6-88f9-8ed519f9bed6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "23c7fff8-de08-49dd-a101-0c35ad40bd7e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "24e6cefb-6e1c-4676-9bb8-74f6a731703c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4a930e8d-75eb-469d-82d8-1e1d5764a6d4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "95d381e5-f2d6-4164-9917-57f9b070333b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b2d03cea-aec1-45ca-9744-9ee583c1e1cc",
@@ -5903,19 +5903,19 @@
         },
         {
           "dest-uuid": "cfff571f-eb6b-41e2-a447-f69bc07aa77a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "de41a23b-b07d-411b-80f7-d1a8f55ba459",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e2f104ac-b21a-4c48-8987-3e0ad73997df",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3e2d59b-220f-43b0-9891-7b299be27c50",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "630ea167-088b-4958-ac19-0fc59310e262",
@@ -5931,15 +5931,15 @@
       "related": [
         {
           "dest-uuid": "126cff4b-4ba7-4464-bfc8-4daabed5e05b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "32ace35c-66c4-48d7-a8bc-d81c65f4451b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8d43ac43-de80-4815-b992-6f49519ed340",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c3c8c916-2f3c-4e71-94b2-240bdfc996f0",
@@ -5959,7 +5959,7 @@
       "related": [
         {
           "dest-uuid": "616bc2d5-5c4d-4efa-9490-c77213be1de1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbfbb096-6561-4d7d-aa2c-a5ee8e44c696",
@@ -5983,11 +5983,11 @@
         },
         {
           "dest-uuid": "94628b16-2443-4e66-9f7b-a61a39012a9c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e0af3ac-dfeb-48c3-8d15-5f9edd69be69",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f07cfa67-8a83-4a62-ae18-bee29bfc7569",
@@ -6007,15 +6007,15 @@
         },
         {
           "dest-uuid": "557d1a5d-31ae-4600-b4ed-a456d9964a83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a31400ee-ac3e-408e-aa4d-fb2b470142ab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c76d69b2-f1d4-4867-965b-886b6caf95be",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d2daf569-4fc9-46a3-97b7-4d3d76c04a64",
@@ -6031,11 +6031,11 @@
       "related": [
         {
           "dest-uuid": "66923fbc-1d4d-4945-89dd-102a8e2c6122",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "78f4f0fe-55ef-4598-85ac-865cba1920d3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a01bf75f-00b2-4568-a58f-565ff9bf202b",
@@ -6043,7 +6043,7 @@
         },
         {
           "dest-uuid": "a62a2b36-00e9-481c-9a3a-14c14cd42dae",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "de120f6a-c19b-4346-b62f-c8cd95fcb291",
@@ -6063,15 +6063,15 @@
         },
         {
           "dest-uuid": "4385bff9-e730-48cd-bdfc-43de56c302aa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5312ddd0-dd58-4bcb-afc0-7a05a6b2df42",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9abfb75c-2051-4549-b458-f09c4e6f4ad3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a5800f15-f024-4701-912a-20d7e1cb465a",
@@ -6091,7 +6091,7 @@
         },
         {
           "dest-uuid": "a80f58c9-deb2-45ed-a8fb-4f3df5082874",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7578b2e3-2b9c-491d-9157-699a4bd6a136",
@@ -6107,19 +6107,19 @@
       "related": [
         {
           "dest-uuid": "0ec40b2f-4969-443f-bad5-4bc6239fec29",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1a68a39c-c4e3-4ff1-88f5-db78575ce15e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "27213df4-c761-4745-b8ef-f91a46966eb9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e30007c-fc51-447f-850a-c8378427be3d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "435dfb86-2697-4867-85b5-2fef496c0517",
@@ -6127,15 +6127,15 @@
         },
         {
           "dest-uuid": "49897e8e-8d14-4fcb-b305-328d44e58f35",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "badcc199-683b-41f5-9522-9710969cff15",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d76081f4-26cd-4e62-91e8-4e4a3992dd90",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d1912fbc-aaac-4bb1-82f1-0713280ca9a1",
@@ -6151,11 +6151,11 @@
       "related": [
         {
           "dest-uuid": "29988e3f-2f65-4fe5-9bf7-dae0cb869fc6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4d8e89c0-fbde-43fc-adc4-d2f50bec3193",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6b57dc31-b814-4a03-8706-28bc20d739c4",
@@ -6163,15 +6163,15 @@
         },
         {
           "dest-uuid": "72dd4fd9-b6cb-4704-b845-0632fe224995",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d613771b-087c-43c4-8430-2a0bf6ebb314",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5b0d0ab-a464-4e9f-a1c0-dfb08a6ef53f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cf33849d-67f4-418e-9a41-6a6c082e576a",
@@ -6187,7 +6187,7 @@
       "related": [
         {
           "dest-uuid": "00bf6b2e-444a-4a83-aafd-43bc8eea4594",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "38eb0c22-6caf-46ce-8869-5964bd735858",
@@ -6195,15 +6195,15 @@
         },
         {
           "dest-uuid": "7dbd928f-da93-4cbf-af73-ac5987a7858a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c03988c-3387-48e4-8013-7b9d223b8911",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c7752951-1077-478d-9511-df852cba6b28",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1a45b10a-c410-4212-8018-7c00bb292dab",
@@ -6219,11 +6219,11 @@
       "related": [
         {
           "dest-uuid": "24af9441-602e-4202-a2e7-04a46c008406",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "34d6af16-fe37-458c-b15c-413ff2d5b2f7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bf90d72c-c00b-45e3-b3aa-68560560d4c5",
@@ -6231,11 +6231,11 @@
         },
         {
           "dest-uuid": "ce0f284b-f8d9-4cb0-84ad-97e1e8390d0c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8857048-181f-4883-a50b-65aca5204228",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "156ddd81-b3ae-4a79-8c4e-7a75b6fd994c",
@@ -6251,7 +6251,7 @@
       "related": [
         {
           "dest-uuid": "01967eb2-5169-4113-aff0-ac2180fd14d9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "924d273c-be0d-4d8d-af58-2dddb15ef1e2",
@@ -6275,15 +6275,15 @@
         },
         {
           "dest-uuid": "479e5749-a746-4b17-9543-ca4b9d41576a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a986c8fd-6779-4769-895a-e6d167d9f1a9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c8d9ad93-e4ce-4b00-89cb-8f0f6452923d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f273ee4a-e468-4a01-bb1a-f3a687518ded",
@@ -6303,19 +6303,19 @@
         },
         {
           "dest-uuid": "52ee5593-7db2-4ad0-b5f4-630ebcf2ce0f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9a65f8bc-1b81-4e05-8e8b-bfdb0d581213",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9a73d14c-ce3c-47c5-a6c2-3d6b49c4d009",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f315abd4-7115-45ac-9466-64c23367cd41",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "dab6c58b-2f44-4539-93e1-b03990fc1649",
@@ -6331,19 +6331,19 @@
       "related": [
         {
           "dest-uuid": "39d675d5-548d-4b35-8a8f-a6605ae3835d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5b1514b3-e35b-4ea8-bcc1-b8e492d6d3cd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a0ecdd41-a051-4ada-9ec1-c29dc0c4ac61",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "df32865a-79b2-4faa-abd4-3ecfa27c8a77",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f5bb433e-bdf6-4781-84bc-35e97e43be89",
@@ -6363,19 +6363,19 @@
       "related": [
         {
           "dest-uuid": "1a7052d7-84f1-4116-bdb1-49bbe8709e3d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "478e6298-d012-4337-b2ed-0f8d4909ee05",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ffd3332-fcc0-440d-b717-ef98e140c543",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a98fc9c5-9c4c-47c5-a773-d68b523c7304",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f2514ae4-4e9b-4f26-a5ba-c4ae85fe93c3",
@@ -6399,11 +6399,11 @@
         },
         {
           "dest-uuid": "cd91348f-296f-4007-a853-6d06d8175210",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e0ad2e3d-c109-4af0-ac44-0d4cd45407c2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e2f961bd-ddc5-4940-bc62-e2b0bd3405f8",
@@ -6419,7 +6419,7 @@
       "related": [
         {
           "dest-uuid": "05af7b9b-ec1a-4d6c-a944-64a7ad0eb2f5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ed2e45f9-d338-4eb2-8ce5-3a2e03323bc1",
@@ -6443,15 +6443,15 @@
         },
         {
           "dest-uuid": "29370f2b-0877-458c-8ade-a9a23b8fb7b2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5a5d5ff5-e2bb-4ba9-9f95-504c86b1a1cf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "82cdec5a-52af-4489-b002-b0256e5ba60e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8b8cfd0f-bbe2-417b-b1d2-eebf84d3f008",
@@ -6467,7 +6467,7 @@
       "related": [
         {
           "dest-uuid": "0c8a9540-51d7-4ba3-8594-8860b3fa8485",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "69b8fd78-40e8-4600-ae4d-662c9d7afdb3",
@@ -6475,19 +6475,19 @@
         },
         {
           "dest-uuid": "99b2296f-dc1c-4b0e-a05a-883a0dbb1535",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9a0c2390-f8e9-4f03-ae21-0e1e876fed89",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bca44b88-4615-45b8-8fb9-ce934c65c8be",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cd7fee55-79e6-42f4-9c68-e653cc8a1d24",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bfb5cb12-7025-44c3-9a2d-79cfe42ecf54",
@@ -6503,7 +6503,7 @@
       "related": [
         {
           "dest-uuid": "4da5660a-3b1c-4b4d-ad79-991bef456b20",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfefe2ed-4389-4318-8762-f0272b350a1b",
@@ -6527,7 +6527,7 @@
         },
         {
           "dest-uuid": "abe61118-51b2-45ad-93bc-9215dad25b25",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3de93376-739e-4842-875d-d6e9948db8d4",
@@ -6543,11 +6543,11 @@
       "related": [
         {
           "dest-uuid": "0e7e1861-14be-4862-8cba-6344e6e196f2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3258db60-8500-4935-837c-78b23f2d83d1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5909f20f-3c39-4795-be06-ef1ea40d350b",
@@ -6555,15 +6555,15 @@
         },
         {
           "dest-uuid": "7b95ffd7-165d-4435-97b6-4508b9328d89",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bd893675-a17e-4c3b-bec4-ffbad6986c73",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d02dbf1d-b6e9-4c3c-84a2-f70fec797504",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2d5f2445-a395-4012-b378-c953f2df7353",
@@ -6583,7 +6583,7 @@
         },
         {
           "dest-uuid": "b4a380ed-cc16-47cd-8fe1-44ccf4cad097",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6b47bf45-a3f2-4d4b-884a-3cec3ef3f994",
@@ -6603,11 +6603,11 @@
         },
         {
           "dest-uuid": "126a43e3-7b39-4312-ba15-aab0f7ce78f9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "892f06ae-6a95-438b-8219-49b3384a4d24",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ee674b38-f59a-4f21-860a-19d065e13aaf",
@@ -6623,7 +6623,7 @@
       "related": [
         {
           "dest-uuid": "0029e7e7-d42c-4a91-8d00-6bf6fd72962f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3ccef7ae-cb5e-48f6-8302-897105fbf55c",
@@ -6631,11 +6631,11 @@
         },
         {
           "dest-uuid": "75f05a04-103c-432a-afd6-8a8987b4370e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c4866ad5-310c-4a72-89b5-1e5a8683d286",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5b3bf2de-d91e-4272-97a8-5df6f4071e45",
@@ -6651,7 +6651,7 @@
       "related": [
         {
           "dest-uuid": "441bfb28-3fe5-410b-93a5-2280a7f19dad",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d10cbd34-42e3-45c0-84d2-535a09849584",
@@ -6671,11 +6671,11 @@
       "related": [
         {
           "dest-uuid": "048adb6e-49a1-463e-bc0d-0a9a543cf0ce",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5907bfc2-a5d6-4ff1-bba8-8b94c9835ed6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "633a100c-b2c9-41bf-9be5-905c1b16c825",
@@ -6699,7 +6699,7 @@
         },
         {
           "dest-uuid": "17687fa0-bfbf-4ff2-9eb0-520538e6af31",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8374a5e5-6d9f-4896-9546-a4d998188ac5",
@@ -6715,7 +6715,7 @@
       "related": [
         {
           "dest-uuid": "20879a60-f16c-4a90-bd71-2c8865c99481",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "322bad5a-1c49-4d23-ab79-76d641794afa",
@@ -6723,11 +6723,11 @@
         },
         {
           "dest-uuid": "475313b7-c26f-44f6-a8f3-09b57f03fcd8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f654b08-222f-4fc0-83cc-ab871e290d1e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d8e8768e-34c1-45f4-95d2-fa7ba317b63a",
@@ -6743,7 +6743,7 @@
       "related": [
         {
           "dest-uuid": "5523b4ab-42b1-480a-854b-819879905f8d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5bfccc3f-2326-4112-86cc-c1ece9d8a2b5",
@@ -6751,11 +6751,11 @@
         },
         {
           "dest-uuid": "d27caeb7-7af2-4a55-9dcb-734730c0ccf1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f9079cb0-76ff-4b4a-a73c-4f6572e7eef5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9c2a1b83-eec8-4d0c-a0b5-e5b561dbd68f",
@@ -6771,19 +6771,19 @@
       "related": [
         {
           "dest-uuid": "287661d0-714e-4bb4-a9f7-c272ad0018b1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "28fbe1b0-9663-4997-9d4e-ef43803be114",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5d7b1be3-1c8a-40bf-a4d2-85e26dd82d76",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "84299e85-2a7e-4f78-9767-3d29aa58857a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3a12395-188d-4051-9a16-ea8e14d07b88",
@@ -6803,7 +6803,7 @@
       "related": [
         {
           "dest-uuid": "11ac52fe-f8e0-4748-9fbc-2f85c43ad506",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4eeaf8a9-c86b-4954-a663-9555fb406466",
@@ -6811,11 +6811,11 @@
         },
         {
           "dest-uuid": "79600919-afe8-4ac9-946c-147d85af6cfe",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "837bd639-c291-4e42-b737-6a21d6bf8fd5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3ec6ad13-f3d6-4eb2-91fe-6ee5266d1447",
@@ -6835,19 +6835,19 @@
         },
         {
           "dest-uuid": "908aa2d1-f1c0-456b-9c9f-b984b309e51c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "989a524f-cf9a-4fcc-a21f-ac5aac46f0ed",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c2b959ca-75f4-4291-9812-0b065e7bb395",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c5117811-b262-4920-90d9-001d25b6305b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "155cab5b-c70b-4cfb-ba52-f62a21836b19",
@@ -6863,7 +6863,7 @@
       "related": [
         {
           "dest-uuid": "22d28e80-ecae-4fa4-8901-ef9125c99e9f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "29ba5a15-3b7b-4732-b817-65ea8f6468e6",
@@ -6871,15 +6871,15 @@
         },
         {
           "dest-uuid": "7e6e9c0e-737e-43ac-8cdd-5edbff4d6424",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8a226737-e2a7-4b70-8964-98c47444a638",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f9534b4a-57ef-40a0-801a-d56a217304f0",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4556646a-39df-48bf-9df3-623d4da7a859",
@@ -6895,7 +6895,7 @@
       "related": [
         {
           "dest-uuid": "9a68f1a7-65f0-4eef-a711-888bccbeb0d5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f303a39a-6255-4b89-aecc-18c4d8ca7163",
@@ -6915,7 +6915,7 @@
       "related": [
         {
           "dest-uuid": "bf64c48c-5834-426c-be21-6db0efbc7909",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d245808a-7086-4310-984a-a84aaaa43f8f",
@@ -6935,19 +6935,19 @@
       "related": [
         {
           "dest-uuid": "0527196a-1551-445c-bdd7-943dfda9b718",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2b751817-3de2-4388-b8b9-d43b5ecda671",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "36c2c2fb-0bea-40fe-9032-c0758d381de5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5ef73ed0-313e-4b9b-b616-8c2d02f4151a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "692074ae-bb62-4a5e-a735-02cb6bde458c",
@@ -6955,19 +6955,19 @@
         },
         {
           "dest-uuid": "70500794-7d3d-4538-8e88-ed6d5e998a8a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c35bd9de-acd9-41f9-9e4f-2a3aad461de6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c4a0d95a-2dfc-4b03-830e-d0dafca0be6f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cfffc717-79f1-4aea-9e68-475ef52db11d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "84dfca59-e541-48a8-bb95-d7581a8f48d2",
@@ -6983,7 +6983,7 @@
       "related": [
         {
           "dest-uuid": "370daadc-e640-4487-8ba0-c897f46459bc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fc74ba38-dc98-461f-8611-b3dbf9978e3d",
@@ -7007,11 +7007,11 @@
         },
         {
           "dest-uuid": "7853421f-8eb4-49c3-9943-077430b97037",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "83067587-4426-44cb-89de-f2b948c91104",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "eec6a137-c506-4654-8780-8e3028f3fd28",
@@ -7027,19 +7027,19 @@
       "related": [
         {
           "dest-uuid": "230a55ce-4584-4588-a006-5532a9efdbd8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3154acf3-a5df-40bd-b4bc-3a210b6e5e0e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "32b5b330-2a40-4117-8999-395c23490614",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "35701083-a327-4f68-a426-13751b9743c3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d742a578-d70e-4d0e-96a6-02a9c30204e6",
@@ -7059,7 +7059,7 @@
       "related": [
         {
           "dest-uuid": "04e9470e-676f-4af0-add4-8103300ebd19",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a9fb6b3f-4a3c-4703-a4f1-f55f83d1e017",
@@ -7067,11 +7067,11 @@
         },
         {
           "dest-uuid": "e1e76ffd-b452-429e-8ea0-a25ba877a2b5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fc3e13fd-cbee-4bb0-aae7-ce1e8af7d768",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4a11abbc-9637-4d2e-a8ac-39fef2c0256d",
@@ -7087,11 +7087,11 @@
       "related": [
         {
           "dest-uuid": "05985fc7-44cf-4b28-8d4f-14c1662bc5ea",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "223a39c8-d194-456e-be99-2db9e97ab7da",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "73b24a10-6bf4-4af1-a81e-67b8bcb6c4e6",
@@ -7099,7 +7099,7 @@
         },
         {
           "dest-uuid": "98f18ad5-0def-4ac3-8822-7538f0a8d64d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "09caebdc-2ce4-4698-a40c-d91cb65f9720",
@@ -7115,7 +7115,7 @@
       "related": [
         {
           "dest-uuid": "c1167779-9df4-4387-b777-4da097c6b033",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f4c3f644-ab33-433d-8648-75cc03a95792",
@@ -7135,15 +7135,15 @@
       "related": [
         {
           "dest-uuid": "2c0df764-d9bd-4a91-808a-aa13df13511a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "801a3652-8772-4b69-8a13-d870be653ef0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "824db63f-2a2c-4e3e-8e7d-49110cc63173",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "954a1639-f2d6-407d-aef3-4917622ca493",
@@ -7151,15 +7151,15 @@
         },
         {
           "dest-uuid": "e36b2d32-05a8-4bcf-b7cf-58dc3ad4c0d3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e96b0210-f7d5-43ac-bf73-893f243f6015",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f51edea3-e0e8-4090-8e81-a01c3394ba53",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5dab1bc7-89e2-4fe4-ae30-40b550d0daf4",
@@ -7179,7 +7179,7 @@
         },
         {
           "dest-uuid": "e4dd4100-2387-4029-a478-35aefd37c288",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "26580351-9bc3-4e03-b5ad-139d38303707",
@@ -7199,7 +7199,7 @@
         },
         {
           "dest-uuid": "5f9fdff8-55ed-4b1e-8889-46b376ce7149",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "300931b1-bd28-4e91-ba6e-585f3563e8e4",
@@ -7215,11 +7215,11 @@
       "related": [
         {
           "dest-uuid": "2a9d296d-6b36-42de-870c-9d851c0471ed",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3651d7d0-dfc7-4b36-aaf2-4eb0eb39167d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "394220d9-8efc-4252-9040-664f7b115be6",
@@ -7239,7 +7239,7 @@
       "related": [
         {
           "dest-uuid": "dba3fe8d-6080-4efe-9b93-6eda138ac771",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f2857333-11d4-45bf-b064-2c28d8525be5",
@@ -7263,7 +7263,7 @@
         },
         {
           "dest-uuid": "f4af0b1b-db51-4266-8b02-2cdfcb191f60",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6182825d-f41f-4d87-ac93-937f7894ab1d",
@@ -7279,7 +7279,7 @@
       "related": [
         {
           "dest-uuid": "0f4789c9-7946-473f-967b-e8ca59fa3c8c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "53ac20cd-aca3-406e-9aa0-9fc7fdc60a5a",
@@ -7287,11 +7287,11 @@
         },
         {
           "dest-uuid": "8018e3a6-ab64-4fe2-9771-ca129091bc17",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eaeb2a44-eebe-41f3-875a-a34abdc03252",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "043bc738-1f07-4d28-9f5c-1b1f81525e7c",
@@ -7307,7 +7307,7 @@
       "related": [
         {
           "dest-uuid": "67d1900f-9e02-4290-a14c-6d32be508d19",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5cc9e7a-e61a-46a1-b869-55fb6eab058e",
@@ -7327,7 +7327,7 @@
       "related": [
         {
           "dest-uuid": "40882c73-344f-4138-894e-049b9bb1f460",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d4b96d2c-1032-4b22-9235-2b5b649d0605",
@@ -7347,11 +7347,11 @@
       "related": [
         {
           "dest-uuid": "11f18771-dd49-45f7-8ef5-05d3426d82d5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6385ccc0-f1a9-4198-997e-dec943e88db7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "67720091-eee3-4d2d-ae16-8264567f6f5b",
@@ -7359,15 +7359,15 @@
         },
         {
           "dest-uuid": "90a8d89c-f54a-49dd-8734-6f85e5e3a2a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9465ea54-a81a-4d00-a75d-e0b7f3392bb8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d8b422b3-50e7-48cc-bfa1-a6e0cecf5761",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9646aa18-4ebf-43c8-bf4c-670063bc5ef8",
@@ -7383,7 +7383,7 @@
       "related": [
         {
           "dest-uuid": "04cd1c76-d01d-482c-83e2-4bb5109e9764",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "06c00069-771a-4d57-8ef5-d3718c1a8771",
@@ -7391,7 +7391,7 @@
         },
         {
           "dest-uuid": "d9c7e50d-4b13-4634-80f9-e8032a043414",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9af47d08-fbb3-4122-8af4-74105cc23b62",
@@ -7407,11 +7407,11 @@
       "related": [
         {
           "dest-uuid": "05d8ce15-eaeb-47f5-abb7-8f8868dd8aaa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4f2bc468-a57d-44e9-b9cd-d491df6b0daf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "59ff91cd-1430-4075-8563-e6f15f4f9ff5",
@@ -7419,7 +7419,7 @@
         },
         {
           "dest-uuid": "780021a3-d3e6-4c5b-a976-1c3715b990e2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9f227978-8d56-406f-9d50-ef10aae1bf77",
@@ -7435,7 +7435,7 @@
       "related": [
         {
           "dest-uuid": "01c969ef-7057-44bd-bced-9b64a98234ec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0a5231ec-41af-4a35-83d0-6bdf11f28c65",
@@ -7443,11 +7443,11 @@
         },
         {
           "dest-uuid": "52a5dffb-f3a3-45fc-97b3-2c09fed8e0b4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc5f309c-6eb0-4f96-ba1a-0f4fd3bc1b79",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "928a6ce6-fca0-4d66-aba3-1121431b953e",
@@ -7463,7 +7463,7 @@
       "related": [
         {
           "dest-uuid": "171803bb-8aa7-42df-861a-18d6d694f909",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6faf650d-bf31-4eb4-802d-1000cf38efaf",
@@ -7471,11 +7471,11 @@
         },
         {
           "dest-uuid": "db3263c7-0abc-47be-a9f3-434d255b1e0e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f3c5c71a-da1b-4d09-bda7-ec07b0b7c05d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e9ee6ab5-333b-4cea-8637-23360d904472",
@@ -7491,23 +7491,23 @@
       "related": [
         {
           "dest-uuid": "42ba4dcf-0354-4d70-8c29-d0c3a8c90c23",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7f269271-6800-4d20-b9f7-6c38cecac6f0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c1fd84b0-953d-463b-a293-3d6aa81e4589",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c62026a7-3332-489f-bb86-30626c1b3cc8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ca56c2df-0338-4325-964a-0f775d986277",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f6dacc85-b37d-458e-b58d-74fc4bbf5755",
@@ -7527,11 +7527,11 @@
       "related": [
         {
           "dest-uuid": "28e26a6a-e470-4f1c-845f-f2cbd816a1f7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "94871740-e9ae-458a-9d09-ef0f58c05905",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a1df809c-7d0e-459f-8fe5-25474bab770b",
@@ -7539,7 +7539,7 @@
         },
         {
           "dest-uuid": "dcc422d4-90fc-4e2a-afd5-b4fbc3d6c4a1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e98d37af-727b-44a7-a72b-cdcf8a481a12",
@@ -7555,7 +7555,7 @@
       "related": [
         {
           "dest-uuid": "0f94823c-ac95-48d8-9716-58f59d39974c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "68a0c5ed-bee2-4513-830d-5b0d650139bd",
@@ -7575,7 +7575,7 @@
       "related": [
         {
           "dest-uuid": "09ef4725-8e20-452d-b08c-f7db3cbee174",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b46a801b-fd98-491c-a25a-bca25d6e3001",
@@ -7599,11 +7599,11 @@
         },
         {
           "dest-uuid": "59d44906-a35e-4b0f-ab84-df3bfa6df8f9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ceb2c722-f9ec-41de-980e-d8848b1cb20c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e90ab093-47a3-4c05-80b1-1919d2362ea9",
@@ -7619,11 +7619,11 @@
       "related": [
         {
           "dest-uuid": "062580eb-eb79-4b31-b3fd-e500ebcfc128",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6f2fdf37-f603-4264-aed1-24fe2d1aa094",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "791481f8-e96a-41be-b089-a088763083d4",
@@ -7631,7 +7631,7 @@
         },
         {
           "dest-uuid": "c89e4f72-a563-4665-9934-14b9efe88a06",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a53d62ae-b269-45e8-9937-17def4e28663",
@@ -7651,7 +7651,7 @@
         },
         {
           "dest-uuid": "92004715-82f0-409d-a520-fc49720e4f3d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8f6ddd50-aeb8-48ae-8f4a-83b314829ca3",
@@ -7671,7 +7671,7 @@
         },
         {
           "dest-uuid": "eb031858-bf91-476e-8248-2c54ef0f0864",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2db51eaa-3407-4ad0-a45e-86ebf5f2abac",
@@ -7687,23 +7687,23 @@
       "related": [
         {
           "dest-uuid": "135452f6-c760-42a6-8a3f-d09c33f05369",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "55a0743e-cdc1-44d1-94c7-cf3837e3ef2f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "decb2be7-1a0a-46dd-ab48-cf6258c0185e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e2fb4be5-bd70-45d6-89ad-e687bc475285",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e50f8247-73da-4461-a560-745ed84f1209",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f5d8eed6-48a9-4cdf-a3d7-d1ffa99c3d2a",
@@ -7723,11 +7723,11 @@
       "related": [
         {
           "dest-uuid": "55b8622a-795b-41d8-9b11-5576a0fb8f0f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "65f89c21-d42a-4028-9865-122ea1079a77",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d456de47-a16f-4e46-8980-e67478a12dcb",
@@ -7735,11 +7735,11 @@
         },
         {
           "dest-uuid": "d5af4c93-632c-41c3-a101-6e9e534d7d01",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea250997-091b-4c5e-8827-a41f03e34caf",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "27b606f9-dde4-456c-8d90-51289313994f",
@@ -7755,7 +7755,7 @@
       "related": [
         {
           "dest-uuid": "d9bcfaee-d2d1-4673-b834-5c219f8dba9b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea016b56-ae0e-47fe-967a-cc0ad51af67f",
@@ -7775,7 +7775,7 @@
       "related": [
         {
           "dest-uuid": "1a18402e-efb1-49c7-8615-dc907f838320",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4f9ca633-15c5-463c-9724-bdcd54fde541",
@@ -7795,15 +7795,15 @@
       "related": [
         {
           "dest-uuid": "20ecf7be-864a-4ae0-be66-cf26ffa9a217",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "46585379-5be9-4ce0-9178-c3492f539e11",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6869578d-d3e8-4a3c-9717-0a188dc0bafe",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8e350c1d-ac79-4b5c-bd4e-7476d7e84ec5",
@@ -7811,7 +7811,7 @@
         },
         {
           "dest-uuid": "a2309590-988e-4116-85e6-59bfc5357726",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d187b646-5fb3-4d65-a190-e25e2131f802",
@@ -7831,11 +7831,11 @@
         },
         {
           "dest-uuid": "2d21fb1f-f9c3-4e72-a6dd-3d7872be3294",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "971ddd36-1ecd-46bf-b94c-22e8f05c1462",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3243e976-0cf8-4f18-8b50-38b9ee5bfc4c",
@@ -7851,7 +7851,7 @@
       "related": [
         {
           "dest-uuid": "86dbac4c-1cba-4056-84a1-604eefbb11ac",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ce4b7013-640e-48a9-b501-d0025a95f4bf",
@@ -7871,11 +7871,11 @@
       "related": [
         {
           "dest-uuid": "0669b8b5-8888-45aa-acf8-819dfb7d00a2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "13a1653f-3d4e-4a4f-9619-f8e8a97ec60d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "65917ae0-b854-4139-83fe-bf2441cf0196",
@@ -7883,11 +7883,11 @@
         },
         {
           "dest-uuid": "e268a6cb-2264-473e-9683-fb0f33ecd793",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e564e2b8-542b-4003-a8b7-df9d3396f5b9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "682ddf59-6de3-4765-a1c0-09b539fa5d4f",
@@ -7903,11 +7903,11 @@
       "related": [
         {
           "dest-uuid": "72bf9819-b0b5-43ab-9c2d-195abe8165b8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a1436a64-ffc4-4e39-a7c8-140e78336ffa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a93494bb-4b80-4ea1-8695-3236a49916fd",
@@ -7915,15 +7915,15 @@
         },
         {
           "dest-uuid": "b31fc018-6fbc-4de7-9bf2-f545b5f8f0c2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cba73580-034b-4cdd-84a2-22704d520e9c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "db50537c-9234-4350-9bf0-838d4cffbd34",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1439efe8-4d10-4ce8-8727-458db69bae85",
@@ -7939,15 +7939,15 @@
       "related": [
         {
           "dest-uuid": "383dda28-1d76-4605-a53d-07829f3d7ef8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "60b2d6f4-1bf0-4c52-8923-ac8e3b8088d4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d1ef9a86-7781-4b9e-9178-c2e5b1782c1f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d4bdbdea-eaec-4071-b4f9-5105e12ea4b6",
@@ -7967,15 +7967,15 @@
       "related": [
         {
           "dest-uuid": "63d21290-b858-4c4e-9447-31d623048048",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "65691cb3-a2b3-4c48-91d2-7088a047ebef",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "667c21d2-2f92-42d6-aaea-b46974f63c8d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d157f9d2-d09a-4efa-bb2a-64963f94e253",
@@ -7995,7 +7995,7 @@
       "related": [
         {
           "dest-uuid": "359ab8ab-f306-4e67-8ff4-f8e1c8ec7db3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4fe28b27-b13c-453e-a386-c2ef362a573b",
@@ -8003,15 +8003,15 @@
         },
         {
           "dest-uuid": "5acd81f3-466a-472d-bb1f-9bda231ac4c0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "64c6aa46-a824-4c8e-8462-d0a58b78acfb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7f128f2c-5b38-4088-9026-e251237f8add",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fff8e15e-f7eb-4c07-8b77-8e7ef2eb01b6",
@@ -8027,7 +8027,7 @@
       "related": [
         {
           "dest-uuid": "1c715030-9564-482d-98b7-22072bf28c97",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "edf91964-b26e-4b4a-9600-ccacd7d7df24",
@@ -8047,7 +8047,7 @@
       "related": [
         {
           "dest-uuid": "be773ad4-9e5f-4063-910a-99a3cab90582",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e0033c16-a07e-48aa-8204-7c3ca669998c",
@@ -8067,7 +8067,7 @@
       "related": [
         {
           "dest-uuid": "7a9088cb-cfe8-4a4a-979c-1ef7678179f2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8a2f40cf-8325-47f9-96e4-b1ca4c7389bd",
@@ -8075,11 +8075,11 @@
         },
         {
           "dest-uuid": "b31afcb5-1690-43f1-acbb-3e2936e48616",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e95d8309-8435-4c32-9ac3-38e350c170c5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cd0c92f4-2345-40ae-aa73-ccc1eb78eb14",
@@ -8095,7 +8095,7 @@
       "related": [
         {
           "dest-uuid": "131d3f89-e10d-4ac9-a9d0-fcb4e8e8760a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "241f9ea8-f6ae-4f38-92f5-cef5b7e539dd",
@@ -8103,15 +8103,15 @@
         },
         {
           "dest-uuid": "3ecc4ba2-bf4f-481c-b813-69c169c28c83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "748f457a-5dfa-431b-b5a0-3d5e1d56ebbb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee4e3e61-e138-498b-93bf-3a5f8fea691c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "16495e17-03ec-4e11-ab80-f76ed6386329",
@@ -8127,7 +8127,7 @@
       "related": [
         {
           "dest-uuid": "3a57e109-235d-497a-9c90-952ab8b749b6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d201d4cc-214d-4a74-a1ba-b3fa09fd4591",
@@ -8147,11 +8147,11 @@
       "related": [
         {
           "dest-uuid": "4dff3c9a-4730-46de-af2f-dfa86b249167",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "539a4182-ab9e-4abf-a83b-f30cf2dec770",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "66b34be7-6915-4b83-8d5a-b0f0592b5e41",
@@ -8159,7 +8159,7 @@
         },
         {
           "dest-uuid": "77d3146f-2066-40a9-872e-ec05d7a4d6d1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "434d1a09-6a53-43ae-8f8c-e0eb853c4a25",
@@ -8175,23 +8175,23 @@
       "related": [
         {
           "dest-uuid": "0fb1d87b-e993-447e-8a2f-e9d42f6859c0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "636b1cca-1fc4-4909-ac33-c2b2a7d69e02",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "92d182e9-6723-43e4-9eab-f00aa6d53153",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9418d7e2-666f-4f73-9ac7-96b32005e9b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "982100e1-6d38-4d0e-b36d-7e2d2cf5a424",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b6301b64-ef57-4cce-bb0b-77026f14a8db",
@@ -8199,7 +8199,7 @@
         },
         {
           "dest-uuid": "d8e18081-2670-4a88-9246-59a1dc52c51c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c5e3823f-5ee0-43db-b6fa-b63d6587b24c",
@@ -8215,19 +8215,19 @@
       "related": [
         {
           "dest-uuid": "5882d2ff-289e-454d-9146-81306c154be3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "81d64cae-ddd2-4512-9c8a-9a574b968c52",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "83a2f3c2-24c5-466d-8453-aa52802c2991",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c6ae166f-f2ac-405a-85c2-b7f9349a1b99",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d2c4e5ea-dbdf-4113-805a-b1e2a337fb33",
@@ -8247,11 +8247,11 @@
       "related": [
         {
           "dest-uuid": "2bf1ce64-970b-4d0d-bf5f-a854fc6d7235",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cb428c22-0a5a-44c9-ae63-6b1bedb34fee",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc7b8c4e-9be0-47ca-b0bb-83915ec3ee2f",
@@ -8259,11 +8259,11 @@
         },
         {
           "dest-uuid": "d32cc2a4-60ed-4761-809e-a59cde2a1881",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f979bacd-580c-4948-b501-c42dd4a8cb92",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d7106707-eee8-443f-b106-e7eff58a739e",
@@ -8283,7 +8283,7 @@
         },
         {
           "dest-uuid": "448ecbfb-2b38-4ecc-9c63-f7dd87339271",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bd33de0c-1ed7-42ea-b77d-1fd5d33acd3b",
@@ -8299,11 +8299,11 @@
       "related": [
         {
           "dest-uuid": "353e902d-b33c-466b-9276-5f224a259934",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4a5abd9c-b4f3-4c29-9406-82aa3401c049",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5e4a2073-9643-44cb-a0b5-e7f4048446c7",
@@ -8311,7 +8311,7 @@
         },
         {
           "dest-uuid": "c233a50c-0fdb-412b-85f6-8ff71a3539b9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3e5e2bda-40c0-4aea-90f1-8fc52096ad5e",
@@ -8327,7 +8327,7 @@
       "related": [
         {
           "dest-uuid": "90eca5d7-c330-4b86-bde6-de04019cbba7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cfb525cc-5494-401d-a82b-2539ca46a561",
@@ -8347,15 +8347,15 @@
       "related": [
         {
           "dest-uuid": "2d1d5482-b82b-45ff-9563-959766d373ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "67ca77c9-074f-4c93-9592-cabe9ba8a831",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "72ba4979-f786-4205-a5da-90874e12813f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ae676644-d2d2-41b7-af7e-9bed1b55898c",
@@ -8375,15 +8375,15 @@
       "related": [
         {
           "dest-uuid": "0e2094fe-6912-4bde-9e5a-9d95c640646a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "14ac0f26-e5db-42da-b730-9e115027f8e9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2891bd53-5a81-4330-bb05-ffd731868d06",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "359b00ad-9425-420b-bba5-6de8d600cbc0",
@@ -8391,11 +8391,11 @@
         },
         {
           "dest-uuid": "696b98e8-10fd-4c7a-bb80-302baca34e60",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7efd6a7b-d7c0-4922-a1df-c492c0a2d3f8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "20f11806-1639-49c5-ae0b-84633a142870",
@@ -8411,11 +8411,11 @@
       "related": [
         {
           "dest-uuid": "10dcfce8-70df-4682-ab04-90279d7292f9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "635f834e-ee46-496f-aec4-23dbef04451b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7e150503-88e7-4861-866b-ff1ac82c4475",
@@ -8423,19 +8423,19 @@
         },
         {
           "dest-uuid": "914a5b13-5977-4e62-abab-9ee03e72624f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c6208aa1-fa6e-4d9d-a284-dd0aab1ee31c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d42c2a80-bf02-460f-b279-147940ece3a9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d78b4bb3-bd0a-4e43-bc19-0a7b72f6a9d3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7c45d09a-030e-4b30-b2d9-41fee3daa293",
@@ -8451,11 +8451,11 @@
       "related": [
         {
           "dest-uuid": "27cbe2a7-25a0-4f6d-b2b0-dff50b2c0883",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "62285936-d8a3-4b18-b3b4-a521fbef10ec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7de1f7ac-5d0c-4c9c-8873-627202205331",
@@ -8463,11 +8463,11 @@
         },
         {
           "dest-uuid": "af8d3a12-dafb-4e40-8017-7d20d9e77d55",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c448cbb5-1256-4a00-8582-1759fb5a6e56",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7b0ea292-22f5-4963-b1c2-0d396fb17619",
@@ -8487,7 +8487,7 @@
         },
         {
           "dest-uuid": "f313053f-5898-4f47-b263-a60098f5c963",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4994627c-216b-4832-90cf-074d3e9013e4",
@@ -8503,15 +8503,15 @@
       "related": [
         {
           "dest-uuid": "01d19202-019e-43c9-a5e9-e1e2a38eb738",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0277e29a-af6d-4242-a187-32673328664a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7ff5d08a-5d4d-4260-85ee-fdb6a244f258",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "837f9164-50af-4ac0-8219-379d8a74cefc",
@@ -8519,11 +8519,11 @@
         },
         {
           "dest-uuid": "9c5d279c-eb09-4592-91a4-8cf6436522b6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "df289d0f-0f31-487e-b213-9a492d903f2c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b34a9911-8261-45b4-af09-3885f9b82cc6",
@@ -8539,7 +8539,7 @@
       "related": [
         {
           "dest-uuid": "0abb4122-0795-46ef-b162-7570db42596a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3c4a2599-71ee-4405-ba1e-0e28414b4bc5",
@@ -8547,19 +8547,19 @@
         },
         {
           "dest-uuid": "4f5f64b3-bc1b-4573-b790-42b8adfdd609",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79ecfad5-3439-4a04-919a-236d47652ba0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a48f36c7-e946-4270-ae23-1a2e52ae2e24",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfe1b67a-a1c1-43f4-a043-5784a315d018",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "36bb5edf-e7b6-4d36-8ccc-1a18ddc573da",
@@ -8575,15 +8575,15 @@
       "related": [
         {
           "dest-uuid": "00112bcc-174f-4201-ac81-fe3edd1292e6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3166927d-91e4-4e08-bfec-abda2783be8c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5e225927-bf50-4261-b1ae-d65e803da0b8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7bd9c723-2f78-4309-82c5-47cad406572b",
@@ -8591,7 +8591,7 @@
         },
         {
           "dest-uuid": "7cf1b4ad-95e8-4bf0-8b2f-fc3c14938656",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "98d6523f-54c5-4a24-a758-333caa833967",
@@ -8607,7 +8607,7 @@
       "related": [
         {
           "dest-uuid": "84ad99e5-4e6e-4d07-93ae-9e55e6f99707",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ffe59ad3-ad9b-4b9f-b74f-5beb3c309dc1",
@@ -8631,11 +8631,11 @@
         },
         {
           "dest-uuid": "7a209f60-7f43-407f-b5bd-7877e10222ee",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ffcee6e2-02dd-4053-92a3-8600dd70445e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c2133628-efa0-4bb0-9f9a-a475ec6a52e7",
@@ -8651,15 +8651,15 @@
       "related": [
         {
           "dest-uuid": "4f33b538-1370-4df1-934f-fe3a609453fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5233d621-6658-4338-b183-01bd73e52861",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "564071d9-44b1-44b8-92c0-348e22e544b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "69e5226d-05dc-4f15-95d7-44f5ed78d06e",
@@ -8679,7 +8679,7 @@
       "related": [
         {
           "dest-uuid": "0bd02555-3b54-4425-84c8-118b95857df1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3975dbb5-0e1e-4f5b-bae1-cf2ab84b46dc",
@@ -8687,15 +8687,15 @@
         },
         {
           "dest-uuid": "5258feec-def7-43e0-bbe9-459ba53d3e28",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d01951d8-aae8-48b6-afd3-68c86fc167b1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d71c4839-8d23-41f4-b59a-8bd2c3517d1e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "45ac24cf-b8f4-44d5-97e1-3efe2bf28abc",
@@ -8715,7 +8715,7 @@
         },
         {
           "dest-uuid": "bf5772b8-86b4-4d73-bbff-6abb5da9edac",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e5eff2eb-4a41-44d1-9c79-4977fb73f569",
@@ -8731,19 +8731,19 @@
       "related": [
         {
           "dest-uuid": "55ec66de-8146-4fd0-a423-0954d6ba33ef",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "671050c7-7e86-4be7-9ab4-aa9c763fad44",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aae03a6c-b308-49cb-bb85-7be4a5c2a4bb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dc4096a9-b89d-4bef-b20d-58cf5e87f6bf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f7827069-0bf2-4764-af4f-23fae0d181b7",
@@ -8767,7 +8767,7 @@
         },
         {
           "dest-uuid": "c94f0795-ef0b-4e22-8395-bbba4f28346f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "552a7d85-4ac4-48cd-9072-61a4c6b2c682",
@@ -8787,19 +8787,19 @@
         },
         {
           "dest-uuid": "1affb8e9-25b4-49c1-b290-687e9696fa83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "67febd8b-36fe-4f72-8647-95fe449ecb5d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "afd585f3-20fa-4bd8-8930-243cb5dbe5f8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c9b3d194-843a-4f65-ad8b-4b3192571fc5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "33bbfada-99c8-4cac-8b21-fa013959001d",
@@ -8815,19 +8815,19 @@
       "related": [
         {
           "dest-uuid": "1543bc4a-7614-417a-85b9-d67e3da0350c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3810988a-78be-4628-a9a5-500020f9c075",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7402eb3b-9349-478a-a8e9-7ee72c4b67c5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8dbd751b-a2cf-418a-b409-daae78a250f8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a19e86f8-1c0a-4fea-8407-23b73d615776",
@@ -8835,7 +8835,7 @@
         },
         {
           "dest-uuid": "c545f39e-d1a2-4b0e-bdf1-6a84226557e9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ed9ef930-ec1f-4e57-a110-9b647e2ca195",
@@ -8851,7 +8851,7 @@
       "related": [
         {
           "dest-uuid": "0f4ec296-008e-42aa-95b2-6e4e351d730c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bef8aaee-961d-4359-a308-4c2182bcedff",
@@ -8859,11 +8859,11 @@
         },
         {
           "dest-uuid": "d1feb97f-3683-49f5-b5a8-b54d58de3444",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d9eb3056-115b-496a-89f7-be38470ff022",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fecfb9f9-645e-4e09-ba21-05bc60722688",
@@ -8883,7 +8883,7 @@
         },
         {
           "dest-uuid": "c223f997-8323-40c2-98c9-38a8a1779db4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9c4b0b07-df7f-4697-8cd1-0b95ff6a6361",
@@ -8903,11 +8903,11 @@
         },
         {
           "dest-uuid": "7845facb-50f2-4d32-ae00-6766b9410681",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "de0a1136-1476-4c28-bf49-004ac3ef97f7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c08df366-fa5a-4f34-a27e-b28e756f09f0",
@@ -8923,7 +8923,7 @@
       "related": [
         {
           "dest-uuid": "3dc28690-699a-4f6d-ad4b-278aa2dd8c59",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "818302b2-d640-477b-bf88-873120ce85c4",
@@ -8943,7 +8943,7 @@
       "related": [
         {
           "dest-uuid": "a1e502e2-d940-4c71-9eac-893e7a3025e3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fc742192-19e3-466c-9eb5-964a97b29490",
@@ -8963,7 +8963,7 @@
       "related": [
         {
           "dest-uuid": "01a3cc24-df78-4ff7-8a25-67545d830229",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1c34f7aa-9341-4a48-bfab-af22e51aca6c",
@@ -8971,15 +8971,15 @@
         },
         {
           "dest-uuid": "27caeb90-1cf0-4650-a3f3-c8a1edaecbab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "561fb700-686a-4583-96a9-77a55358d357",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c5e7b8a9-72f6-40db-be4a-ec17386d884f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e91165c5-e850-465e-9042-6ba82478b522",
@@ -8995,15 +8995,15 @@
       "related": [
         {
           "dest-uuid": "18253101-bce9-453e-ab03-603bbd174552",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "55083ce8-b00e-4501-97db-829082bdbb48",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "62afd8a1-550d-43a6-a56a-7d5ae5abbcf6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fbd91bfc-75c2-4f0c-8116-3b4e722906b3",
@@ -9023,11 +9023,11 @@
       "related": [
         {
           "dest-uuid": "80be1bd7-b4e8-4d1b-b294-56b1c073bbe0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a677cebe-06e8-4993-bd4c-6a6884862444",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ed7efd4d-ce28-4a19-a8e6-c58011eb2c7a",
@@ -9051,23 +9051,23 @@
         },
         {
           "dest-uuid": "3f36a861-3be2-4f6d-bfad-f044cdc01b15",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "49e91c60-9b73-4a0a-9510-f94152a8ba5e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7518f788-43dd-440a-955c-870cdb7dea26",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a0554596-7100-4f8b-a4dd-165f528fe6a1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bc143cf2-d6fb-4ea4-98a5-a2db81fc3f84",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cdfe6166-43e9-434a-a961-139edd58ca0c",
@@ -9083,15 +9083,15 @@
       "related": [
         {
           "dest-uuid": "3b02d81a-8684-4fc8-8364-127f30359282",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4a32d0e6-9486-4bbb-8807-7f913f96f448",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "533d13df-5317-45dd-a544-c26d0192d6b2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7385dfaf-6886-4229-9ecd-6fd678040830",
@@ -9099,11 +9099,11 @@
         },
         {
           "dest-uuid": "9e03886b-155c-4483-9d92-dad6a7d8543b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fee823fd-f31e-4898-820e-322e49574438",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8582f5e6-44a5-4950-b7e8-a3e1b6d58d63",
@@ -9119,11 +9119,11 @@
       "related": [
         {
           "dest-uuid": "00b2801f-752e-4b70-95fd-c2644ccef671",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "29433de9-360e-4189-9f6d-fb00c9a57e41",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "30208d3e-0d6b-43c8-883e-44462a514619",
@@ -9131,11 +9131,11 @@
         },
         {
           "dest-uuid": "70df3731-9576-4450-bd32-0f52cc8f0ec3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f6ad51e5-b869-455d-acb1-ef725acb27cb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5e9a51b5-7e4a-4e78-a1ba-215ce937c877",
@@ -9155,15 +9155,15 @@
         },
         {
           "dest-uuid": "7c91d6c7-4591-41b1-9c08-0c0660b07d24",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9032a591-de05-44c2-b1f6-3d711f417cce",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b88251d3-6406-4512-a55f-a6bc3493e2ad",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bb431f45-c3fe-4b98-8dd7-70346b56c880",
@@ -9179,7 +9179,7 @@
       "related": [
         {
           "dest-uuid": "2d054232-8968-4d11-b742-536b70bbb1ba",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8ef3a62-3f44-40a4-abca-761ab235c436",
@@ -9199,7 +9199,7 @@
       "related": [
         {
           "dest-uuid": "50658b7e-57c5-4e31-b156-1b294574a9f2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b97f1d35-4249-4486-a6b5-ee60ccf24fab",
@@ -9219,15 +9219,15 @@
       "related": [
         {
           "dest-uuid": "2e6218d1-1f84-4dc5-8ab5-c24835aafbab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "39ec0aa6-935a-44d3-b206-211981dec3bd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "82acd5d4-70e1-4f3e-b059-15bdc55cf4bf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "92a78814-b191-47ca-909c-1ccfe3777414",
@@ -9235,11 +9235,11 @@
         },
         {
           "dest-uuid": "94e3c24f-01ee-45bc-89c0-7024ada7cc66",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbb8adb2-434a-483e-af3c-4843241e2158",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ea1f5423-64b9-44eb-824f-251aa0faccd2",
@@ -9255,7 +9255,7 @@
       "related": [
         {
           "dest-uuid": "18c20664-b820-4a14-a7bf-5a75ac2fae92",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "83a766f8-1501-4b3a-a2de-2e2849e8dfc1",
@@ -9263,15 +9263,15 @@
         },
         {
           "dest-uuid": "98f5c157-17c8-4ab8-943d-8d4c54dc3d6d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e95ed4e2-d6bc-4a6f-acbc-bdbfcbaca158",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f47f256d-686f-4553-85e2-bd4d156da1e7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "510a02c8-4341-40ab-8b57-bd678c411ac0",
@@ -9291,15 +9291,15 @@
         },
         {
           "dest-uuid": "2bce7f8d-90c1-4835-9ce9-832e5e3a37d6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "557e1f6e-5eeb-46ea-bcd2-5d858eea314c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e9ba7101-369f-48c6-8e6d-075ddd5744ba",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e2d84c66-3647-4aab-962b-c1ad89455a18",
@@ -9315,15 +9315,15 @@
       "related": [
         {
           "dest-uuid": "6ed3efbf-c060-4c7f-8d8b-0e93f65a0790",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "786c54fa-8a9f-41bc-aa22-c4a4f6a93bd7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8fba0b53-2aca-4cca-8856-714e0f05665b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b577dfc1-0177-4522-8d5a-782127c8592b",
@@ -9343,7 +9343,7 @@
       "related": [
         {
           "dest-uuid": "02309791-384c-4ca9-b25c-6a6bc754795f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2e34237d-8574-43f6-aace-ae2915de8597",
@@ -9351,11 +9351,11 @@
         },
         {
           "dest-uuid": "7a6192b4-997a-4526-bb3d-76664bc31274",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "db6995d9-68ab-4638-a430-c0a8d2daf306",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8d904004-e492-4f76-9f84-be75fc61e5c5",
@@ -9371,15 +9371,15 @@
       "related": [
         {
           "dest-uuid": "29a00bef-79bd-4eb9-bf92-01651cffe9b0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "80c5c2fd-eb3a-4678-9d3b-6147a90284de",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "81233639-a08b-4a56-a5d4-ac2f9ae94a2b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b8902400-e6c5-4ba2-95aa-2d35b442b118",
@@ -9387,11 +9387,11 @@
         },
         {
           "dest-uuid": "b94bb114-7532-4934-9955-9c7031109b9e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f0dacfba-bcc0-43cb-bad5-0cd3fe3a7f5f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "08861418-398c-4972-8850-5e11f2d32944",
@@ -9411,7 +9411,7 @@
         },
         {
           "dest-uuid": "ee7c904b-144f-4dc4-87af-7eee4655899c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1221d0cb-6404-4fe7-837e-6057a96e7acb",
@@ -9431,7 +9431,7 @@
         },
         {
           "dest-uuid": "7a424183-94ca-4dc1-a03b-610d174aa973",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6aa65bd1-4c0c-4bf7-ba74-ba0d8edd9cb9",
@@ -9447,11 +9447,11 @@
       "related": [
         {
           "dest-uuid": "345af006-d658-4f22-aef6-b1cfc0058875",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "756214e0-660d-4f32-a4f1-f8ff24a7852f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bb5e59c4-abe7-40c7-8196-e373cb1e5974",
@@ -9459,11 +9459,11 @@
         },
         {
           "dest-uuid": "c5134555-561a-4905-8601-a6ba307fc121",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "caa11058-4906-48b4-ab3f-a650aab6968d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ec33e12c-e0f1-426d-a453-fa5ae4d3cf9a",
@@ -9479,11 +9479,11 @@
       "related": [
         {
           "dest-uuid": "4e8da615-4d12-4b53-8c7b-06d7c41e22a9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "58a609cb-b266-4a1a-a40f-9e4cd5d591ce",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ba04e672-da86-4e69-aa15-0eca5db25f43",
@@ -9491,11 +9491,11 @@
         },
         {
           "dest-uuid": "cf74f802-0080-41ff-8745-9c42af313462",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dd202a3f-c73b-47cf-9689-f14a8def816e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6ab41bc0-2d89-4173-8149-728fbc2698b6",
@@ -9511,15 +9511,15 @@
       "related": [
         {
           "dest-uuid": "3e682b33-5064-4202-aad7-ca1900fde1a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5e7eea18-14f5-4d76-b5cc-bc63a0e5ce65",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a50c90f1-51b1-4948-8945-4b89735d4750",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f24faf46-3b26-4dbb-98f2-63460498e433",
@@ -9527,7 +9527,7 @@
         },
         {
           "dest-uuid": "fcb2ed1a-2f39-47e8-9524-95ceac0ff383",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ee1c44c9-c5aa-4a9c-9e68-49854ed4d602",
@@ -9543,7 +9543,7 @@
       "related": [
         {
           "dest-uuid": "04412d94-62ac-4484-9408-c4ca1c206f1b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2dbbdcd5-92cf-44c0-aea2-fe24783a6bc3",
@@ -9551,11 +9551,11 @@
         },
         {
           "dest-uuid": "8601dbfa-8767-4328-8809-1930b53b5e31",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a52321d0-5961-497b-8212-61602e05420b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "264a9ce0-b26f-4cc6-bdf4-384b0d188a95",
@@ -9571,15 +9571,15 @@
       "related": [
         {
           "dest-uuid": "8e0f5333-9fc0-4f03-ae12-cf98903e08ea",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "967f7636-1547-4db7-921a-1b84f312a2cd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a788e3ed-8faf-4443-bb26-fd530ca930d1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cacc40da-4c9e-462c-80d5-fd70a178b12d",
@@ -9587,7 +9587,7 @@
         },
         {
           "dest-uuid": "e42656e7-6a0e-492e-82b6-90d0d5667993",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f0190654-2eda-42a7-9a4d-6edc95aada02",
@@ -9603,11 +9603,11 @@
       "related": [
         {
           "dest-uuid": "25bd8222-a9c0-4771-8250-7d6ce7b2d176",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "42d5a9d5-f897-4c45-b577-9b2c776c6c0d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e74de37c-a829-446c-937d-56a44f0e9306",
@@ -9627,15 +9627,15 @@
       "related": [
         {
           "dest-uuid": "0252a0ff-a4fb-4196-9b43-d759af950d55",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5f584d00-63b5-44c5-b629-ff238f5b9931",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c3a43bc-dd07-4e72-a987-a2dc36e162fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d349c66e-18e1-4d8b-a2d7-65af7cbd2ba0",
@@ -9643,7 +9643,7 @@
         },
         {
           "dest-uuid": "fb767270-25ad-4fea-a8e7-8f9c57ac1fa8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f1f9b6fc-a261-4bcf-a0c0-3ae42cdc28fc",
@@ -9663,7 +9663,7 @@
         },
         {
           "dest-uuid": "b192336c-4a85-4322-9ae8-fd6eb6b7747b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "de98fda3-10f9-4013-a163-fb9b6c117a9b",
@@ -9679,7 +9679,7 @@
       "related": [
         {
           "dest-uuid": "269ab5e4-4c45-4f7a-8d82-c235492ff83a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "34a80bc4-80f2-46e6-94ff-f3265a4b657c",
@@ -9687,7 +9687,7 @@
         },
         {
           "dest-uuid": "d4a29d94-bce4-4069-a0b5-9e0e731cff97",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "eccdd5b4-e19e-4254-909e-4a9c2e3ac27e",
@@ -9703,7 +9703,7 @@
       "related": [
         {
           "dest-uuid": "c0766f2c-e282-44a1-8dcf-1575d77658da",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e8a0a025-3601-4755-abfb-8d08283329fb",
@@ -9727,15 +9727,15 @@
         },
         {
           "dest-uuid": "121a5310-3157-47b1-925e-998767c0ec06",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "20e00aff-6389-4c8a-8e38-3b63924e1612",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5f1a4795-74e5-49b9-85bb-e186ca699648",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a9de0990-69e9-4b1a-9754-1c7fb4102ac9",
@@ -9751,19 +9751,19 @@
       "related": [
         {
           "dest-uuid": "143f3057-237e-427f-911a-2aa7d64721f0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "39aa9168-6f3b-4179-84f9-a6b8dcf90900",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6b8a97fe-4e51-4409-9eab-f2795eb2ec74",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "72540cd1-3ba6-4a4a-8866-a3113094196a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc36eeae-2209-4e63-89d3-c97e19edf280",
@@ -9787,15 +9787,15 @@
         },
         {
           "dest-uuid": "4db0f97c-a0c4-4c96-af56-86c6b227ea42",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cecfe3bc-525a-431e-8ee1-5133ab8ce79c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fde025ac-a180-472c-a9b5-b4fa1e97cc75",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bdf67026-8adb-41da-9a58-c9acba4da1f3",
@@ -9811,7 +9811,7 @@
       "related": [
         {
           "dest-uuid": "015260e0-432e-4eaf-978e-b1a32fa6af6a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1eaebf46-e361-4437-bc23-d5d65a3b92e3",
@@ -9831,7 +9831,7 @@
       "related": [
         {
           "dest-uuid": "a06e9154-5584-4f5d-be47-b420d79674c7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f4599aa0-4f85-4a32-80ea-fc39dc965945",
@@ -9851,7 +9851,7 @@
       "related": [
         {
           "dest-uuid": "0e9add05-93bd-47b2-acf5-1817f03e804a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "731f4f55-b6d0-41d1-a7a9-072a66389aea",
@@ -9859,19 +9859,19 @@
         },
         {
           "dest-uuid": "a79ae1d1-1a8d-427d-aa6d-261ea63d5650",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aace8c0e-4534-432b-9a84-6e01c19570b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b95a3fbf-3d6c-4ead-8421-ff9c07ca4019",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d8cc8663-020b-4fde-a8de-a92ecf97aea4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5c44619a-da36-4bbd-9730-efceacf2409f",
@@ -9887,15 +9887,15 @@
       "related": [
         {
           "dest-uuid": "06e0501e-a87e-452d-9ab5-93ed9a5eade5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "24aa5ee9-ba7f-4991-b32a-27d40ee2d010",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5d7158ce-17f5-4643-bde2-c0a4f2ba0b73",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "72b74d71-8169-42aa-92e0-e7b04b9f5a08",
@@ -9903,23 +9903,23 @@
         },
         {
           "dest-uuid": "7b0d80c0-807e-46b1-b3f7-fd3e4f3aceba",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c4973f27-c8db-4478-aaf8-eb73580fceec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cb177f89-c8a4-4233-a2e4-3fdd02dccba1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d85db7b4-5eb1-4781-b92c-a18102a568dc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e576eaeb-2158-40f9-8edb-c119eac56442",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fdda430c-e4f6-43ce-95d6-0f97253ff6a2",
@@ -9935,7 +9935,7 @@
       "related": [
         {
           "dest-uuid": "105ca36e-c3e0-48c4-ada3-7f8c4aa4430f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d50955c2-272d-4ac8-95da-10c29dda1c48",
@@ -9959,7 +9959,7 @@
         },
         {
           "dest-uuid": "7975ae39-8c6b-45cc-9280-98e94b666c85",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a948dd3c-a8f3-4bc0-aec3-4c5264e7a012",
@@ -9979,15 +9979,15 @@
         },
         {
           "dest-uuid": "97f27df6-5041-437b-9aeb-58a9bc33a376",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ba2056ee-77d7-49d4-a993-5806506964df",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d90a4f16-b5e1-4daa-bf65-91112fe02761",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ec412019-109f-4f84-aa2f-d623f40254e0",
@@ -10003,7 +10003,7 @@
       "related": [
         {
           "dest-uuid": "0fff438f-1aa9-4424-be94-a08b400adcb0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1bae753e-8e52-4055-a66d-2ead90303ca9",
@@ -10023,7 +10023,7 @@
       "related": [
         {
           "dest-uuid": "08c69003-044c-46a5-b17a-7cb5b25f2d50",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "36b2a1d7-e09e-49bf-b45e-477076c2ec01",
@@ -10031,15 +10031,15 @@
         },
         {
           "dest-uuid": "44c2e32e-bd34-4ba9-8105-28c14309207c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb7692b0-5592-4d23-ba06-fdded48a2a0d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fdf11d76-3bd7-41c4-b117-7b0f17b31b17",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "20f5a44b-e9bb-48e9-9bea-e7a3d757005f",
@@ -10059,7 +10059,7 @@
         },
         {
           "dest-uuid": "d9383849-c91c-4eef-88a0-97c2454ca1af",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3f3ebc58-fff0-4083-bc5c-ee7308026a20",
@@ -10079,7 +10079,7 @@
         },
         {
           "dest-uuid": "8a7a7e80-c28e-42b2-a222-c1d75932c986",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "96c3e267-9dde-45cb-b700-e27c1a672cf8",
@@ -10095,15 +10095,15 @@
       "related": [
         {
           "dest-uuid": "08318de4-1327-48ac-a686-403162d3891f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0fe7a1db-759d-4d27-8ef1-a71509643594",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "668bc76f-04cc-4274-8a66-cfa00e83ef14",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfd7cc1d-e1d8-4394-a198-97c4cab8aa67",
@@ -10123,15 +10123,15 @@
       "related": [
         {
           "dest-uuid": "5bbe0089-4927-4415-bff7-14a3ba5543c0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "61d89912-f74e-4fde-ae7a-591e8c7c5739",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "81cd2610-bc6c-46bf-8d3c-d6e30c7f51c8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d40239b3-05ff-46d8-9bdd-b46d13463ef9",
@@ -10151,7 +10151,7 @@
       "related": [
         {
           "dest-uuid": "481966ed-de78-42e4-9c51-c69281a21650",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d20fff9-8751-404e-badd-ccd71bda0236",
@@ -10175,15 +10175,15 @@
         },
         {
           "dest-uuid": "685b05a6-92a3-417d-a917-8e7689e43237",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c08ad617-cc0d-4435-9168-08c762048503",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c101374a-ce7a-46d7-b7d4-c64fbdf1f685",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3638f523-dc38-4ff0-8682-d2027af5bd77",
@@ -10203,7 +10203,7 @@
         },
         {
           "dest-uuid": "e863e865-8ecc-47ce-b736-eec54b6399d6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8febbfe8-91ae-4625-8fc7-656639b90a11",
@@ -10223,19 +10223,19 @@
         },
         {
           "dest-uuid": "3cdef7d3-4ca6-4d4a-933b-656af73f8433",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7535f2e7-d7bb-4e92-8a63-36cd9ccc01be",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bb3daf14-f237-4688-a319-a4d7570e407e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c15f60a8-6e58-460f-8dcf-1bce272b5eaf",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0eb48c77-9056-4178-900b-7ac23fd1c7cd",
@@ -10251,19 +10251,19 @@
       "related": [
         {
           "dest-uuid": "0b0d50a0-d07b-4cf1-9cb0-23c95e8321b2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "12f9a28b-126d-48b1-bc93-5bc3c1635905",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4f71c7bd-dd25-43c7-ac5c-7a85c7588759",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ae82099a-0baf-4887-953c-67ef5e2d4470",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b6075259-dba3-44e9-87c7-e954f37ec0d5",
@@ -10271,15 +10271,15 @@
         },
         {
           "dest-uuid": "bcf6e9cb-fee9-4efd-8998-03de4908448b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d71a1e3e-6507-438b-9ee2-f80dc1f938d2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d93312e3-210a-4757-b638-4ed19fca8621",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "72742281-7457-4124-a277-7f3cf5e23f4e",
@@ -10295,15 +10295,15 @@
       "related": [
         {
           "dest-uuid": "1fd68bec-86cb-4457-b0cd-56fc724fd578",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8cd02c43-f3f5-4623-a816-cefe1f586288",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c24eb4e0-f23a-4d93-b2e0-7f5e7cae44f6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f244b8dd-af6c-4391-a497-fc03627ce995",
@@ -10327,7 +10327,7 @@
         },
         {
           "dest-uuid": "ca649f9b-2a1f-4d45-b61b-33ac38d6a4ee",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c3924c07-255d-4df9-8357-a47e68c04bbb",
@@ -10343,7 +10343,7 @@
       "related": [
         {
           "dest-uuid": "3374a404-06f9-4b32-bf94-5ac688fb9dad",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "35dd844a-b219-4e2b-a6bb-efa9a75995a9",
@@ -10351,19 +10351,19 @@
         },
         {
           "dest-uuid": "8cbda989-39e6-4f9e-8e23-213f92b3479d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a0714b4d-5dbf-499e-a737-7b00478267ee",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d20d7cf8-ecac-4011-96e0-3ec862223c11",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5adcc7e-5d68-4080-bb87-e901f297485d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "df11466a-27a2-4cb1-bf73-2a3a4aaee0d9",
@@ -10379,11 +10379,11 @@
       "related": [
         {
           "dest-uuid": "0248d3dc-266e-45c3-89e4-4865f9174cfd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "03f2259d-45c2-4422-83ad-58955f89350c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0f20e3cb-245b-4a61-8a91-2d93f7cb0e9b",
@@ -10391,7 +10391,7 @@
         },
         {
           "dest-uuid": "62cf396f-01d6-4ab0-a3f5-bf75d90c2c40",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "00a4e92b-8164-4342-a71c-013ecc777ad0",
@@ -10407,7 +10407,7 @@
       "related": [
         {
           "dest-uuid": "111bf5b3-ce1c-4f60-b1b0-deef85fc6a0a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "37047267-3e56-453c-833e-d92b68118120",
@@ -10415,7 +10415,7 @@
         },
         {
           "dest-uuid": "ece5746f-194b-4564-9f5f-7ebf3b23542e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c1ca9729-d9a0-47fd-98bf-8355ee9fc8e2",
@@ -10431,23 +10431,23 @@
       "related": [
         {
           "dest-uuid": "2c5d3103-2b9c-4b56-b415-c01e055fff64",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d0595b9-eca7-488d-bbc2-ed02ff4ced9b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a941dd04-5626-4091-9eed-300d7d7f0a1f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "adbe8ef2-15e5-4fb9-83d8-4c67b7b1be78",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "af7bff30-45c5-4baf-9ced-68208b7ae836",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b24e2a20-3b3d-4bf0-823b-1ed765398fb0",
@@ -10455,7 +10455,7 @@
         },
         {
           "dest-uuid": "ba6c8c55-ee38-4219-a426-a3f1e04c7a8a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "655a8556-c82d-4148-b52a-7bc48fe7ce20",
@@ -10471,7 +10471,7 @@
       "related": [
         {
           "dest-uuid": "1282f497-ce04-4151-9bd0-4eedbf4530b6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "49fca0d2-685d-41eb-8bd4-05451cc3a742",
@@ -10479,11 +10479,11 @@
         },
         {
           "dest-uuid": "4ab12b3f-5c6a-42a6-8d9c-c10b7e814986",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7c0e4ffa-7f95-41de-9e3b-de2ad4a7a9ae",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d22f1848-fc32-4fdb-999b-9c0845fb6552",
@@ -10499,23 +10499,23 @@
       "related": [
         {
           "dest-uuid": "611778c2-9de4-4066-b7d1-78752891c32e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "82f3feb5-f17e-4c1c-b67d-c8331d220905",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ad5fb8d4-7f1c-4442-a4e5-96592364c4cc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b608c89f-ce2c-4993-8522-7b2731851606",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d265376d-3cdc-4e95-a8ea-4c4278860218",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fb8d023d-45be-47e9-bc51-f56bcae6435b",
@@ -10535,23 +10535,23 @@
       "related": [
         {
           "dest-uuid": "1155df11-eee4-4fdf-a354-15eda0e90d4c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "203586e5-e178-4d41-bbae-93a86f04977b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3b18d20b-94c7-41e7-8f82-99148945a74f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "57d8fd27-9af5-4d01-9d1a-fdde8ec0c902",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b2f444b1-e434-40e1-9501-6b66a05a0201",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b80d107d-fa0d-4b60-9684-b0433e8bdba0",
@@ -10575,27 +10575,27 @@
         },
         {
           "dest-uuid": "13556e3f-80f0-4aac-83f0-0d6c706e76ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "14390641-6cba-4351-a488-bf97c6eee8a7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1d8bc80f-8719-41f0-a73e-127d6830f516",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "52dfd8de-910a-4caa-98a7-6dcf44ef903e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "53336c8f-a218-462a-b97c-aac07cf96077",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f525a464-a4e5-40fb-831a-162af2f232e7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b3ce3826-401f-4549-92ce-c825b4ddafb0",
@@ -10611,19 +10611,19 @@
       "related": [
         {
           "dest-uuid": "4412fb07-9a44-49de-80af-8746b0be3865",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4742e058-a301-47e1-b594-8daa8eabfc79",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "688ed638-d3ba-47dc-baa7-16b16a9fe9c8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d0a3871-8cee-47bd-8829-637e132c98f7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c21d5a77-d422-4a69-acd7-2c53c1faa34b",
@@ -10631,7 +10631,7 @@
         },
         {
           "dest-uuid": "cae917e6-7542-41d0-8b03-ad2b7ab1eb01",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2cb544af-ef54-4376-9608-b399ad67d3d6",
@@ -10647,19 +10647,19 @@
       "related": [
         {
           "dest-uuid": "1cd8c844-575a-44be-9fee-80cd988dc781",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "31027842-f02c-4bc3-8cd6-3e4b533da5ac",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "65abf5f4-ddb9-4eac-a926-1bef5d6b5c63",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8089daf3-72b0-4714-b800-2856f27dc21c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "853c4192-4311-43e1-bfbb-b11b14911852",
@@ -10679,7 +10679,7 @@
       "related": [
         {
           "dest-uuid": "a5e9fb06-ab75-415d-beff-206aa059e096",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c48a67ee-b657-45c1-91bf-6cdbe27205f8",
@@ -10699,7 +10699,7 @@
       "related": [
         {
           "dest-uuid": "a59042de-ecac-45bf-a852-af3df41b86d8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e6f19759-dde3-47fc-99cc-d9f5fa4ade60",
@@ -10723,7 +10723,7 @@
         },
         {
           "dest-uuid": "f3478623-5b5c-482e-96f1-6b225ff8fa70",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7f7679d8-c2eb-4fcc-be46-27055ef491a6",
@@ -10743,7 +10743,7 @@
         },
         {
           "dest-uuid": "ae250934-772b-43a5-9a29-9cbd92972858",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c254ecff-c728-4de8-a0f8-e5ad5015aa32",
@@ -10763,7 +10763,7 @@
         },
         {
           "dest-uuid": "e7444be7-3c0a-4ff2-927d-f623af05936d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4e2e06c5-a7bd-40d9-af9b-99fdfe725360",
@@ -10783,7 +10783,7 @@
         },
         {
           "dest-uuid": "d6166e3d-2e29-4097-9fb4-c66ce0616897",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "17c97a51-74c2-449c-bc95-cf6a7647fb83",
@@ -10799,15 +10799,15 @@
       "related": [
         {
           "dest-uuid": "56552a3e-9934-4809-97a4-67d62f29478c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "62d55c57-54a3-4c6f-8d0d-2684fa26c347",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c93951a7-7f78-40cf-a891-30d6c6a9bee6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
@@ -10815,11 +10815,11 @@
         },
         {
           "dest-uuid": "f20d9241-84cc-4393-b2fb-798241da73fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fac5b2df-a58d-424e-a351-7d7ca05260e8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "67677c4c-5778-49eb-ae74-1920645b8554",
@@ -10835,15 +10835,15 @@
       "related": [
         {
           "dest-uuid": "13f8fd10-3982-4a10-85c1-4641712c7286",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6db136be-4e41-4cb7-8237-eee81ee6a3cd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79f3bf7a-cf35-442c-b707-ba4dabd6ed62",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bb5a00de-e086-4859-a231-fa793f6797e2",
@@ -10851,7 +10851,7 @@
         },
         {
           "dest-uuid": "dd283114-84d8-4b1a-a765-f3a7f378c2d1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c922d994-74bd-4847-a870-c0ae216318c9",
@@ -10867,7 +10867,7 @@
       "related": [
         {
           "dest-uuid": "00449d4c-48c7-4977-bf38-86fbc4e79285",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "20fb2507-d71c-455d-9b6d-6104461cf26b",
@@ -10875,15 +10875,15 @@
         },
         {
           "dest-uuid": "86ea7b9c-c017-463d-b5d5-377f6dbfae1e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e12e1f0-1547-4008-8755-2b3bc1c00279",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea793457-89e6-47d2-8ae1-7fd2bd814f82",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ae37afa8-87d5-4091-ac33-010e78eefe97",
@@ -10899,7 +10899,7 @@
       "related": [
         {
           "dest-uuid": "03b0d93e-955a-49f6-83ad-8cf72b678367",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e6831b2-bf4c-4ae6-b328-2e7c6633b291",
@@ -10907,11 +10907,11 @@
         },
         {
           "dest-uuid": "58bed5f5-6ef5-4558-9ac9-b58f8aa9888c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ff692121-8bbd-4d22-8192-fe6a7dd94f57",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "13233865-3b73-4065-a056-43fcd6eb6ed5",
@@ -10927,23 +10927,23 @@
       "related": [
         {
           "dest-uuid": "20b6d23a-d1cc-494c-ac67-e7358835c674",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "776b9173-cbe0-4d1e-8ac9-af19b3db9dd7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "818b46ce-9c93-47c9-a649-8bc5d3b734a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbaa7fb3-974c-41ef-9cec-a0789a66445c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee0f60f3-2fb3-4857-b02e-58c69b5aab52",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f4c1826f-a322-41cd-9557-562100848c84",
@@ -10963,11 +10963,11 @@
       "related": [
         {
           "dest-uuid": "313de6ca-629b-4f77-b58f-5cf7b490a62e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7cb2010a-e502-4117-94f3-fa3bd8d64a34",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7dd95ff6-712e-4056-9626-312ea4ab4c5e",
@@ -10975,15 +10975,15 @@
         },
         {
           "dest-uuid": "e59e2d8c-20cb-4a77-9d8b-1d838b01bd87",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e622500c-4217-466c-955c-82ef3217653a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e9ee76c8-e959-4925-8f93-4b8fb66bc9f1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "11f7fa69-2da4-4280-90d2-abc2f0722683",
@@ -10999,27 +10999,27 @@
       "related": [
         {
           "dest-uuid": "1193139d-0032-4d0b-88f1-c140abe2c964",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3090db89-83c0-44bc-a17d-7cb2a6aecb87",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "33b7f7b2-b79c-4893-bd5c-2d5638bf5786",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3a19d0ff-833f-47ae-81a0-2516e91c7b25",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "81c940cd-633b-4f88-9f8f-f6837a7026bc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "97cb8df9-f100-4a64-802a-1aa2f45c26eb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b4409cd8-0da9-46e1-a401-a241afd4d1cc",
@@ -11027,7 +11027,7 @@
         },
         {
           "dest-uuid": "d0a9cbc4-d190-44fb-b067-27153e35dc49",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "eccad822-4f5b-4337-8c8b-825cf617f853",
@@ -11043,7 +11043,7 @@
       "related": [
         {
           "dest-uuid": "1b5b9ee8-69e6-41d4-a529-aa18afcdf453",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2f41939b-54c3-41d6-8f8b-35f1ec18ed97",
@@ -11051,15 +11051,15 @@
         },
         {
           "dest-uuid": "52d150da-36f4-43b4-96c4-b4fe33b012a2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a53e2979-2c41-44bc-b46e-13a19305e00d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e7b2c8da-d54d-446a-a7f6-062fe234a8cc",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e4040d30-1f5a-4f80-9f06-f1c1d2a8c238",
@@ -11075,7 +11075,7 @@
       "related": [
         {
           "dest-uuid": "60d70569-0d28-4d98-957c-4676b2411685",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d1fcf083-a721-4223-aedf-bf8960798d62",
@@ -11095,11 +11095,11 @@
       "related": [
         {
           "dest-uuid": "07deb060-c373-4059-b73b-736688a25c80",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79c7d394-e772-479c-acf9-ddd05b8a68b9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ad255bfe-a9e6-4b52-a258-8d3462abe842",
@@ -11107,7 +11107,7 @@
         },
         {
           "dest-uuid": "dc87f086-1764-43c2-a7bf-1a5ba2ea8191",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e17b2809-7534-4749-9bd8-95fdb24e4891",
@@ -11127,11 +11127,11 @@
         },
         {
           "dest-uuid": "969bd6a3-b89f-4279-9bd2-3fc461880308",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b5d77678-fff4-41cd-9e77-d3f82243240a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "01cc085c-7d7d-49fc-9d15-bc5b2226026a",
@@ -11147,11 +11147,11 @@
       "related": [
         {
           "dest-uuid": "003c2ca3-a9a8-4a56-9163-f6733f19b41d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3cb4d3f4-df71-474c-a9f0-438dbf26bf66",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "deb98323-e13f-4b0c-8d94-175379069062",
@@ -11159,7 +11159,7 @@
         },
         {
           "dest-uuid": "e6a7eeb3-0652-460c-b68b-f17d2ed82822",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7a182af0-a7e1-41a1-ae5e-ac76ff7f5948",
@@ -11175,15 +11175,15 @@
       "related": [
         {
           "dest-uuid": "4ea80ec4-bfcc-4bd6-b986-aa2c9fe2d8d6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "73931643-7fae-409c-98b3-00bd88e246e0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c4108797-7eb4-4ef8-8dee-c2db00695ab4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ec8fc7e2-b356-455c-8db5-2e37be158e7d",
@@ -11207,15 +11207,15 @@
         },
         {
           "dest-uuid": "8129e7b8-eaa1-4459-ba70-ebf6d68ca16c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dc0bf4ca-1d65-46ee-b4b1-d8f73a6e0cda",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f2c91a4c-1e79-4350-8a7e-94bc7b7b9a4c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d41df11d-b2cd-4afc-89a5-9c77e7f31985",
@@ -11235,23 +11235,23 @@
         },
         {
           "dest-uuid": "2c3ec402-b9e9-4091-a04d-3b73f260e669",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8963772e-2ee5-421e-aec0-b952d05d4efc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a3c087a6-b7dc-464f-9e84-278bf3076ed1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a6299804-cf50-4496-a242-1394ff89c147",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e01b29cd-2369-4ad5-bd91-98994f36cd1e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bd2348f8-acef-4310-bd03-cf7b866d2592",
@@ -11271,7 +11271,7 @@
         },
         {
           "dest-uuid": "4c744ac0-ba25-4b42-8397-9b398ba55eb8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6c9e1f65-7d75-4091-b97d-e5f88ed12812",
@@ -11287,7 +11287,7 @@
       "related": [
         {
           "dest-uuid": "8986f2ab-2e6d-4c68-99ac-6a1c5f29fb7b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c32f7008-9fea-41f7-8366-5eb9b74bd896",
@@ -11311,15 +11311,15 @@
         },
         {
           "dest-uuid": "560f859b-2174-4655-b927-b274ad0bda3f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ce76c289-b810-44cf-b71e-afc76a70f7bf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d8f9ab20-4c82-42fc-9316-91781fa9e5e1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "eaa0f0da-bee7-4ce3-97e5-46d5ac2a9257",
@@ -11335,7 +11335,7 @@
       "related": [
         {
           "dest-uuid": "1a068df0-67d4-4521-aeda-75fa8e9f8d98",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "58a3e6aa-4453-4cc8-a51f-4befe80b31a8",
@@ -11343,11 +11343,11 @@
         },
         {
           "dest-uuid": "c4eb93f1-0288-4884-bdbc-800e7a8e87c3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e11709c9-0203-4f76-bbfb-379ed36723ce",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "90123c20-ff3d-4034-9a5f-905444bb0311",
@@ -11367,7 +11367,7 @@
         },
         {
           "dest-uuid": "c9be9fb3-460f-42bc-9b56-3bb88839aeab",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "af0d25b2-1912-4821-85db-305abe318535",
@@ -11387,7 +11387,7 @@
         },
         {
           "dest-uuid": "3947e311-cada-4eab-b4fd-1ea1f3fc3485",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2f4449cb-0eec-4871-bff3-f846f12bec15",
@@ -11403,11 +11403,11 @@
       "related": [
         {
           "dest-uuid": "6cf46787-028d-4ac8-9dfa-58682edb3625",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aa255cdc-0b49-4ad3-951d-eab5582da56f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b17a1a56-e99c-403c-8948-561df0cffe81",
@@ -11415,15 +11415,15 @@
         },
         {
           "dest-uuid": "d059a437-bf45-4b10-a36c-7e42e183d3c7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dc062a09-572e-41fc-bfff-f654751a6a0f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f9c3a686-2894-498d-9d04-7ac510752e1f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a6245075-b59f-46cf-8b76-e8d95c378a22",
@@ -11443,7 +11443,7 @@
         },
         {
           "dest-uuid": "ab1122c5-f459-4097-8ba7-f5a7960d2da5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e9a74ecb-cc65-4c21-ae40-850e3317c248",
@@ -11459,19 +11459,19 @@
       "related": [
         {
           "dest-uuid": "5012d2b2-bd36-431c-91d3-4c10b7d3a9d6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "535e9bc8-b033-4aee-88e1-bd48699b7856",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "682f84f1-5571-4d41-b071-53c8f72a88f1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a74c34c2-f4bf-4bd0-9f23-7c04c45b93ca",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bf1b6176-597c-4600-bfcd-ac989670f96b",
@@ -11491,7 +11491,7 @@
       "related": [
         {
           "dest-uuid": "337976cc-5fd5-49e8-abcb-79f27d19382c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "43e7dc91-05b2-474c-b9ac-2ed4fe101f4d",
@@ -11499,11 +11499,11 @@
         },
         {
           "dest-uuid": "5439d083-91d6-4369-9406-8cfb2cf5cbde",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "61282e0a-3eae-4358-8821-6c8318961e24",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9833b57b-4c83-4f58-b4cf-76f041b29273",
@@ -11523,11 +11523,11 @@
         },
         {
           "dest-uuid": "155b0dfd-15d5-45bd-a8c4-249adc52f20d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f5e4bee-0677-41dd-89ad-8a467ae08eec",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "91b70fb4-8e86-4dd2-a988-33d64cc46d4e",
@@ -11547,15 +11547,15 @@
         },
         {
           "dest-uuid": "5a05483c-fb3b-4240-bf90-c1873b6bd392",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5b9f2d26-e84c-49a3-8586-a7367580b802",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cf404364-1397-4f0f-9c21-cd534880722a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9280a84d-bf77-4a86-a052-ce6ea0d50e72",
@@ -11575,7 +11575,7 @@
         },
         {
           "dest-uuid": "fb933fd5-5dd8-4879-b2bb-e68bc26ff60d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e7bd0f37-f2cf-4e3c-a9c1-c41f63b67e1c",
@@ -11595,15 +11595,15 @@
         },
         {
           "dest-uuid": "0e832ea1-a261-4bdd-8fc8-ae049468c347",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4f985435-9144-4a8f-aca0-598f788855b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e9de9003-46e9-438f-929a-94a33c2eb5bd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d70b8fdd-de14-4143-a350-56e3b885b37b",
@@ -11623,19 +11623,19 @@
         },
         {
           "dest-uuid": "0c122a8e-bcb0-4756-8a63-193c52d61d90",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "63a1b615-8389-4776-a79c-6db04037a7b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7924d1b1-a512-425f-b397-9e9b9887b21b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "da140e65-e30c-4cf2-8961-82fb200a7f0b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fe0d7d82-1575-4685-9a4f-4bf83e0227a0",
@@ -11651,7 +11651,7 @@
       "related": [
         {
           "dest-uuid": "631da3e4-5ecd-4dc9-966a-1c2633f8f24c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9664ad0e-789e-40ac-82e2-d7b17fbe8fb3",
@@ -11659,7 +11659,7 @@
         },
         {
           "dest-uuid": "bafd38ad-aebd-40f1-9f17-bd63a1c74ba9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a9b4dd72-07f2-4fd5-b46b-2fe9f6945f14",
@@ -11679,23 +11679,23 @@
         },
         {
           "dest-uuid": "0f8a0af6-7544-4f29-8e08-6b07dda1337e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "32199f21-430f-4c91-b2d7-a0b7409cd5f0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3b218f49-59ce-44a5-a10b-889c99e78934",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "416b5616-a16d-4ccc-b214-5873f96e5b1f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "682bd971-c540-4c16-a25a-b928201a320d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6928b108-f04e-4a9b-bda5-53bb0c64ec9b",
@@ -11715,7 +11715,7 @@
         },
         {
           "dest-uuid": "d7a82fc6-047b-47a8-8b3c-d6dcab00d56b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8c92a33f-ac2f-4ae9-9258-7a6a67922ad4",
@@ -11731,7 +11731,7 @@
       "related": [
         {
           "dest-uuid": "0be2ac94-5f56-4bdc-bf07-ec9ea08c8bb7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "22522668-ddf6-470b-a027-9d6866679f67",
@@ -11751,15 +11751,15 @@
       "related": [
         {
           "dest-uuid": "198d4196-25f0-4e28-a95b-c89709f452ab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4e288214-93b3-48a7-b51e-2b0136db8540",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "acaabb0b-6cfc-45cd-8bd9-08ad49e1096c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e6415f09-df0e-48de-9aba-928c902b7549",
@@ -11779,11 +11779,11 @@
       "related": [
         {
           "dest-uuid": "4d76bcf2-0935-4f61-8dd9-57ee3713b840",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79ba9430-eeb0-4fce-9757-bb81fc2a43d5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b5327dd1-6bf9-4785-a199-25bcbd1f4a9d",
@@ -11791,11 +11791,11 @@
         },
         {
           "dest-uuid": "d677a72d-db0e-4332-a467-95b19836ef16",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f94e2ae3-7c79-4796-96a1-e462828f9c13",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "55321f9d-1646-45b9-b23e-e3c0fe105400",
@@ -11815,7 +11815,7 @@
         },
         {
           "dest-uuid": "fedc5a7d-4ea9-4dd7-b2e0-3f10549d90db",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ef1996dc-b6e9-4d8b-a216-77d14323b3e5",
@@ -11831,7 +11831,7 @@
       "related": [
         {
           "dest-uuid": "3b327a8f-0ea3-4848-b34a-58029e5edf57",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a2029942-0a85-4947-b23c-ca434698171d",
@@ -11839,11 +11839,11 @@
         },
         {
           "dest-uuid": "c4ff3b74-bba1-4129-b246-50213e77336d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea127140-2f66-4c3d-93ab-215c210ad6c5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "909c86ca-ddd0-4e96-8464-39f5f80ef20e",
@@ -11859,7 +11859,7 @@
       "related": [
         {
           "dest-uuid": "217128c5-144d-492b-ab72-bd0704348221",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb2cb5cb-ae87-4de0-8c35-da2a17aafb99",
@@ -11879,15 +11879,15 @@
       "related": [
         {
           "dest-uuid": "3655f892-ed0d-4b76-9173-ecb7eebacd8a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "59faf79f-831d-436b-9ce3-e5c1d338da6c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7dce56f3-43db-4787-ae13-bd2ce6851088",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d28ef391-8ed4-45dc-bc4a-2f43abf54416",
@@ -11895,7 +11895,7 @@
         },
         {
           "dest-uuid": "eac7b88d-0ee2-4fbf-9e0b-ea73c376ccb3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "48e8d8b1-0117-48bd-a32d-f4e43b665bf3",
@@ -11911,7 +11911,7 @@
       "related": [
         {
           "dest-uuid": "207b58a9-7e3b-41ca-bb5a-c66b24210a83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d336b553-5da9-46ca-98a8-0b23f49fb447",
@@ -11931,15 +11931,15 @@
       "related": [
         {
           "dest-uuid": "01ef3337-0585-4eaa-acb2-df363f7d5463",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "25403649-ce66-4fb0-9957-8c319b10e9d7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "31098e90-e2a0-477f-80ca-e969430d54c2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3257eb21-f9a7-4430-8de1-d8b6e288f529",
@@ -11947,11 +11947,11 @@
         },
         {
           "dest-uuid": "4c4941eb-b087-4710-8c88-ff537c2309ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b3579b0f-7daf-40bd-af1c-f5cd020942e6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "49505f6d-b778-4a84-a072-9236b700e7b5",
@@ -11971,7 +11971,7 @@
         },
         {
           "dest-uuid": "72033f2d-a943-40be-862c-051317ec541c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "218a24ca-9534-44e2-9282-fb08373e7845",
@@ -11987,15 +11987,15 @@
       "related": [
         {
           "dest-uuid": "003dd2ae-b156-4ebd-8a59-76f993056552",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0ba25127-85e4-46ef-8173-96aa9df90c22",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2a4f23d7-3f80-45b7-90ec-b13fdd7f8d70",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3d333250-30e4-4a82-9edc-756c68afc529",
@@ -12003,27 +12003,27 @@
         },
         {
           "dest-uuid": "a807fb55-1c4f-4353-90d6-1a05aa05f2c9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ac692681-2851-41b4-aff9-4b5efc4c40c8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d2762796-1dea-448a-970a-7aeb176aa668",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dc5bfda5-057d-4bec-b3e6-a6b2117a4134",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fb51dd4c-b751-4282-a447-d9f5f257b435",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "febc685b-997f-4095-b60b-5dfeefe01ae3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e8e88bcd-0294-48d2-bd3c-0408814f4a69",
@@ -12039,15 +12039,15 @@
       "related": [
         {
           "dest-uuid": "70b2ab8e-f18e-4cb5-8149-4ba2c334df69",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7c7f0049-96af-4acc-9c58-9f8e661adb63",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8049e0b4-961b-499f-9204-45fa9b7117be",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "86a96bf6-cf8b-411c-aaeb-8959944d64f7",
@@ -12055,7 +12055,7 @@
         },
         {
           "dest-uuid": "e18f0682-6610-4ba8-8159-a4afea3b7974",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ac9c6b7c-bf94-4eeb-926c-f576673c0a14",
@@ -12071,15 +12071,15 @@
       "related": [
         {
           "dest-uuid": "89e3c3a3-249e-4af3-8885-92c228d88b02",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b8141218-1f71-4b65-a611-7c9c55038c4c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c031c27b-4d05-406a-8538-04ce1df41d35",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f5946b5e-9408-485f-a7f7-b5efc88909b6",
@@ -12099,19 +12099,19 @@
       "related": [
         {
           "dest-uuid": "0066bac9-599a-4f7b-a667-9cb1dca94347",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1327b96f-73db-4a5e-8e71-e515fc030bf3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2a93100f-6332-4c91-bad9-fd371d638309",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b01d212c-112a-47fb-8883-78bb623ee34b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b21c3b2d-02e6-45b1-980b-e69051040839",
@@ -12131,15 +12131,15 @@
       "related": [
         {
           "dest-uuid": "35300a0c-e135-4865-9fe5-9d65a1c77dda",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "82908b5f-fa84-4420-bb1c-cc77e12e9d3c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8d7fb300-189d-4654-ba66-3612a8a4cf65",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfebc3b7-d19d-450b-81c7-6dafe4184c04",
@@ -12159,7 +12159,7 @@
       "related": [
         {
           "dest-uuid": "10d8886b-6cf6-45af-b187-04541e2ffaa4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "514dc7b3-0b80-4382-80a9-2e2d294f5019",
@@ -12179,15 +12179,15 @@
       "related": [
         {
           "dest-uuid": "0b8b8557-0393-4c63-963f-e5a3b5cc6ad8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2d4a40e4-359f-49ac-9e3f-58e29497aa41",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f3ae0da-3005-42d7-afa3-8eaa8da3f700",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c306d8d-cde7-4b4c-b6e8-d0bb16caca36",
@@ -12195,7 +12195,7 @@
         },
         {
           "dest-uuid": "bb339113-e807-45fe-99c4-ed8348e51b36",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "13a856f3-66b2-4ab7-b73f-2a26e712e77f",
@@ -12215,7 +12215,7 @@
         },
         {
           "dest-uuid": "7e4ac594-c46c-4c7e-ba6d-9a457ab1e767",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a1b25828-57bf-470c-8f47-8ad4e1f6bbdb",
@@ -12231,15 +12231,15 @@
       "related": [
         {
           "dest-uuid": "1fbe9da1-a760-4ac9-8ab0-59203a50fb82",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2f0f5c7a-18ee-462e-b364-b1d8df3b2c02",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4416c78b-902b-4baa-9a5d-26f0b7e5d78d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "799ace7f-e227-4411-baa0-8868704f2a69",
@@ -12247,15 +12247,15 @@
         },
         {
           "dest-uuid": "b3d533fc-010a-4ee8-b234-80f98e2443a0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c15d6b5e-bbb7-4dc7-8b59-8ce2c0663c05",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f9b13a61-0110-4882-9384-3468d22ac221",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7225a3bd-f235-4c13-a236-3c6b9a3d445c",
@@ -12275,7 +12275,7 @@
         },
         {
           "dest-uuid": "e246212e-aca3-489d-a2d9-7e24f7c3516c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fdcd77fc-d6da-4692-a978-461a7f7dba61",
@@ -12291,7 +12291,7 @@
       "related": [
         {
           "dest-uuid": "6a57daad-9d2c-4851-a46e-b6ebac607a4c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
@@ -12299,19 +12299,19 @@
         },
         {
           "dest-uuid": "79c196d7-abb8-4766-a875-4acafc6f059d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cb70ad2f-7c96-4669-baed-3007246b0630",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e7debe02-4326-48ae-aa22-59c2a847d3e7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "edfec58e-e591-4057-a906-1baf3674d80b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "172cff54-a89b-4207-abc2-8d0c9601025e",
@@ -12331,11 +12331,11 @@
         },
         {
           "dest-uuid": "7b4c77fd-f350-48ec-abce-aac3e35c939f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b6d9d5a1-5966-4888-b4ce-30b125043c4d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "996f14f4-3419-45f6-af22-edc15f5d5d19",
@@ -12351,11 +12351,11 @@
       "related": [
         {
           "dest-uuid": "5ce49e4b-a67f-46ea-b48d-f08f7b942fb4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "616755c6-e83d-46ce-ad76-ac706074a575",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bf147104-abf9-4221-95d1-e81585859441",
@@ -12375,11 +12375,11 @@
       "related": [
         {
           "dest-uuid": "5a10a19a-035e-469e-8ec5-fafb1f0f0fe6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6e053521-1d6d-493f-8cd5-34f9a5992fc7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "830c9528-df21-472c-8c14-a036bf17d665",
@@ -12387,11 +12387,11 @@
         },
         {
           "dest-uuid": "900bc498-4b81-43b6-bec2-3b55edc5c0ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aff88199-cad0-47f8-b065-0ad7a86ec8a7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "769615c5-08d5-4f51-8f3b-7ac2f1febce8",
@@ -12407,7 +12407,7 @@
       "related": [
         {
           "dest-uuid": "3e5b15b0-e6b2-402a-9c4f-e483c968a38e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6d4a7fb3-5a24-42be-ae61-6728a2b581f6",
@@ -12427,11 +12427,11 @@
       "related": [
         {
           "dest-uuid": "28c16139-9ce1-4dd7-b26a-e257f37e246c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6914dd62-46a6-4de4-9c0b-afe1cb5b075d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "92d7da27-2d91-488e-a00c-059dc162766d",
@@ -12439,11 +12439,11 @@
         },
         {
           "dest-uuid": "deb57305-6324-404d-a9d0-00aa0c285920",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8998263-e55f-428f-b8d0-46d9e31277d2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "beb3a98c-f1a4-434a-81e7-29d178b14db2",
@@ -12463,7 +12463,7 @@
         },
         {
           "dest-uuid": "bcb01d01-66f6-47bb-9ca1-46b4ce686ad4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8e003575-5a6f-458d-be35-a8606c9b7dea",
@@ -12479,7 +12479,7 @@
       "related": [
         {
           "dest-uuid": "63e17792-17f5-48ae-8002-da6b62b4bcaa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "74d2a63f-3c7b-4852-92da-02d8fbab16da",
@@ -12487,15 +12487,15 @@
         },
         {
           "dest-uuid": "9274294a-dfc3-4084-b228-dfb36448f077",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "945f8192-6f4f-4183-b457-40b5c6d9b4ca",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b3828af6-912b-493b-b621-3448a8f07972",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0596d971-9552-4cd0-a5aa-4385cf707371",
@@ -12511,7 +12511,7 @@
       "related": [
         {
           "dest-uuid": "156387d6-9b9a-49f8-834a-cf3cd5ede09c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1ecb2399-e8ba-4f6b-8ba7-5c27d49405cf",
@@ -12519,11 +12519,11 @@
         },
         {
           "dest-uuid": "aa12f037-f724-43a6-97ca-e2e706859c1a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb0d78b0-f35d-49db-a8a5-d3cf840db6fd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a9796458-df5d-467f-b037-acad6c261f25",
@@ -12543,7 +12543,7 @@
         },
         {
           "dest-uuid": "d5c81e57-37c4-4393-a202-0955af560983",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b79f47ca-4c42-4658-ba71-a6374778eb98",
@@ -12563,7 +12563,7 @@
         },
         {
           "dest-uuid": "ffaa281c-dd99-486d-bc7f-225580f784f4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c7d19c6f-a7f8-4323-af57-c626ccb74d88",
@@ -12579,7 +12579,7 @@
       "related": [
         {
           "dest-uuid": "164a04c5-db61-477f-b3fa-8bf806631fbb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "354a7f88-63fb-41b5-a801-ce3b377b36f1",
@@ -12587,23 +12587,23 @@
         },
         {
           "dest-uuid": "3ff23082-b5c6-47c0-8d76-a2d6fa88e622",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "54bfcc92-e04c-4eac-9aa2-c10b7574088c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "85a20f4b-4171-4450-a34f-17725d44aad9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d664b158-5035-4e0b-a069-7a5b27ce0936",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eca769c3-9497-4c87-b624-4003fd1b0304",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "75161d5e-2b6d-4112-ab4d-338f70ea97f0",
@@ -12623,7 +12623,7 @@
         },
         {
           "dest-uuid": "b721ae18-79fc-4b82-8991-93980b14ded5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7c27cb31-4806-479f-a07b-900450236a57",
@@ -12639,11 +12639,11 @@
       "related": [
         {
           "dest-uuid": "1d46bf4d-a090-4865-9205-e271d223da42",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "77769a6d-f3f4-42f1-a9a7-0d1096563115",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d4287702-e2f7-4946-bdfa-2c7f5aaa5032",
@@ -12651,7 +12651,7 @@
         },
         {
           "dest-uuid": "fe1e10ae-ddd2-40f0-8e62-3db88c0c8c68",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "834e853c-479d-4ddd-a1a3-349b09466b8d",
@@ -12667,7 +12667,7 @@
       "related": [
         {
           "dest-uuid": "62f43db8-4701-49b9-bb0e-a8fde37e5d07",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7ad38ef1-381a-406d-872a-38b136eb5ecc",
@@ -12691,7 +12691,7 @@
         },
         {
           "dest-uuid": "6eab694d-ea06-4487-99c4-0e21279530e8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "92ce4302-72cb-4b7b-9184-1fc14900d0e1",
@@ -12707,19 +12707,19 @@
       "related": [
         {
           "dest-uuid": "1c2e527f-b9ff-4e1d-896d-0c1257f0abc1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1dee558e-720e-4f3b-9414-192a63eb8909",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e7ff1f9-57e2-44f4-8dc1-20d1a1652f73",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "97a188cf-5851-4cb7-9bb5-17702707d52b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b3d682b6-98f2-4fb0-aa3b-b4df007ca70a",
@@ -12727,7 +12727,7 @@
         },
         {
           "dest-uuid": "f1ec63bc-294c-471c-ae9f-4dd70f3c036a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e3758cbb-5dd9-4aad-b848-0539a8c56307",
@@ -12743,7 +12743,7 @@
       "related": [
         {
           "dest-uuid": "37d6450b-6c90-48dd-b69d-161099913851",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7007935a-a8a7-4c0b-bd98-4e85be8ed197",
@@ -12767,7 +12767,7 @@
         },
         {
           "dest-uuid": "bfc7e981-ca7e-4b1b-a692-65a8867a7a89",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b511a320-18a6-46ff-9588-85065c44312f",
@@ -12783,7 +12783,7 @@
       "related": [
         {
           "dest-uuid": "305b6a70-6d5b-4b32-a40b-ae0cae342e62",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6151cbea-819b-455a-9fa6-99a1cc58797d",
@@ -12791,19 +12791,19 @@
         },
         {
           "dest-uuid": "7a3dd710-39a7-4327-8d3b-150c50b2c680",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "96fe3582-b1a3-40e4-9e9d-bab764f2af7e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a8ed4e86-c79a-40db-84e5-1b4cf0e917d3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c804a181-f0be-41dd-81ce-95e0a3e5245d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cff5ca37-cc4a-431c-b481-d0ccabbf6980",
@@ -12819,7 +12819,7 @@
       "related": [
         {
           "dest-uuid": "007a370c-be77-49c9-9ca3-25d50de35864",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "46d818a5-67fa-4585-a7fc-ecf15376c8d5",
@@ -12827,7 +12827,7 @@
         },
         {
           "dest-uuid": "e8bfbaf2-cfa8-41fd-a5ee-48b57026ac7c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0677c510-fa4d-4a39-a14b-b91f9cde1e23",
@@ -12843,19 +12843,19 @@
       "related": [
         {
           "dest-uuid": "498eb889-4468-4c55-9337-df219d5f142b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "80c7f835-116d-4fa1-817a-08965efef16c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "88041144-900d-4968-9e8a-8f1f63ae8417",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aad71d3e-93b0-4cb6-8240-274369f8ad34",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e358d692-23c0-4a31-9eb6-ecc13a8d7735",
@@ -12863,7 +12863,7 @@
         },
         {
           "dest-uuid": "f794d2f4-ad8e-4e11-b374-2c35f8ca38e9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9ec6dafe-3e93-4ebb-943e-26b84136f6a9",
@@ -12879,7 +12879,7 @@
       "related": [
         {
           "dest-uuid": "177bb119-93cc-4319-b9a7-e8d308d958c4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "40597f16-0963-4249-bf4c-ac93b7fb9807",
@@ -12887,19 +12887,19 @@
         },
         {
           "dest-uuid": "81b1e9a7-b6f4-4cca-b07a-3498ab4abd4a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8a5a1b1e-336f-41af-8f30-2fa7e8e10fab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d49c13ed-df07-4bb3-a2dc-43411e5d402a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f1f23910-7ecd-498b-92e8-7b5aa0d53ac8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1753ab98-4530-4284-9bc3-5d4813abfb9e",
@@ -12915,7 +12915,7 @@
       "related": [
         {
           "dest-uuid": "619804e7-5ae7-4c6e-b1bb-e1d10a22cc87",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b22e5153-ac28-4cc6-865c-2054e36285cb",
@@ -12939,7 +12939,7 @@
         },
         {
           "dest-uuid": "f568a973-fb34-41aa-950f-f46457544564",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "62b445ed-7d9d-4c1a-8d4e-6c742ec1b0e2",
@@ -12955,7 +12955,7 @@
       "related": [
         {
           "dest-uuid": "6c0a2e08-debd-46e6-bb5f-5159ad8f12ad",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6e3bd510-6b33-41a4-af80-2d80f3ee0071",
@@ -12975,7 +12975,7 @@
       "related": [
         {
           "dest-uuid": "2fa4d134-8583-4cbe-bc84-bfc799205116",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d2d642da-61ff-4211-b4df-7923c9ca220c",
@@ -12995,23 +12995,23 @@
       "related": [
         {
           "dest-uuid": "458038e6-60a2-47d2-bd55-675e77f0e279",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "77c3b78a-fb34-4040-9dda-057e8eca3362",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "88d9dbea-cc85-4c94-a368-e5c1a603854b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5b0fcab-05e5-4687-a1a9-dd382a19980b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ecf26d05-48ef-43b2-bfc3-4ea331be735b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fe926152-f431-4baf-956c-4ad3cb0bf23b",
@@ -13031,11 +13031,11 @@
       "related": [
         {
           "dest-uuid": "22e6f5f4-e4cc-449c-9dba-280788935ce5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "710aa303-3e9f-4170-95a4-b2caf5f827fd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d77a07d-02fe-4e88-8bd9-e9c008c01bf0",
@@ -13043,11 +13043,11 @@
         },
         {
           "dest-uuid": "c93edcb2-385a-4472-a9db-ace5371250eb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fe489775-b01e-4da2-a0e2-962d1572ba09",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f66a9e86-49fb-4de6-963d-0e357a77f679",
@@ -13067,7 +13067,7 @@
         },
         {
           "dest-uuid": "be55aa59-62b5-40cd-bab2-dbc4de80da0e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c4f5335d-8e85-4b45-86b1-1d5a8cc6523d",
@@ -13083,11 +13083,11 @@
       "related": [
         {
           "dest-uuid": "0c6a8e7a-f9d0-479a-88c1-4ce26edba81c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f42390d-2a44-4094-9cea-429f1286f8aa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "acd0ba37-7ba9-4cc5-ac61-796586cd856d",
@@ -13095,7 +13095,7 @@
         },
         {
           "dest-uuid": "ae8e028c-2c3a-4ac0-964f-d0b59533190d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b38e114c-f00f-4c70-9623-267da801625a",
@@ -13115,15 +13115,15 @@
         },
         {
           "dest-uuid": "1a39005f-28e7-4b07-85e2-14ffa0f6ea3b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "32ca8e2c-9c1e-4883-aa98-439efbfc76e4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f47f3e9-2856-4830-9762-7ca0c3924f6d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "edf894b7-052a-4baf-8984-f01ec773c80c",
@@ -13143,7 +13143,7 @@
         },
         {
           "dest-uuid": "fd614a66-7e99-4a69-9070-3c11036f0335",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cbf5f016-0801-4861-93d8-d372645778d5",
@@ -13159,7 +13159,7 @@
       "related": [
         {
           "dest-uuid": "88ece783-08bc-41e6-a000-a63f540768cc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d273434a-448e-4598-8e14-607f4a0d5e27",
@@ -13179,7 +13179,7 @@
       "related": [
         {
           "dest-uuid": "17ce541a-23fa-4b33-affc-c6ba906e9956",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a0f84e1d-d25c-4dd1-bb26-3c0e68471530",
@@ -13203,7 +13203,7 @@
         },
         {
           "dest-uuid": "a8284241-0d8e-42da-b86d-48f0d660df6c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a92f4b5f-9d0d-461f-8581-a50975f5e07a",
@@ -13219,15 +13219,15 @@
       "related": [
         {
           "dest-uuid": "c78d2e09-07d7-48ef-add1-bde622e502a2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d5f0b652-3699-45af-97e6-81e7426558bd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e4a9dd91-3354-40c8-a55c-941d53f2ddec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e4dc8c01-417f-458d-9ee0-bb0617c1b391",
@@ -13247,7 +13247,7 @@
       "related": [
         {
           "dest-uuid": "8708dc0b-8eeb-4a3d-8770-2fab30f46682",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e848506b-8484-4410-8017-3d235a52f5b3",
@@ -13255,11 +13255,11 @@
         },
         {
           "dest-uuid": "ecf190d1-5311-466f-a361-a33820b3c7b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8787a86-552b-4e03-8d68-7177001a215d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7a848f8f-4bdc-426c-989e-bc1abfaeb7fa",
@@ -13279,15 +13279,15 @@
         },
         {
           "dest-uuid": "6f8fdb88-56d1-454e-9a35-3b7170011ca2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b355ae5d-3cd6-4594-8bd9-8fed59e02326",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bb687663-4b26-46ef-a176-e188f538d399",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2cbbc0b5-2c4b-4861-91d3-1f64a47ef191",
@@ -13307,11 +13307,11 @@
         },
         {
           "dest-uuid": "7263a8a8-a06f-4bdc-a021-3529ad683f9d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ad4670e-f336-454f-960e-4f2f611f3657",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "53144b02-d6b1-42de-b5cf-e785a59c43bd",
@@ -13331,7 +13331,7 @@
         },
         {
           "dest-uuid": "de8d67d4-9d2a-4379-be8b-3ae3f3b3ac75",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cf6a38ec-4c16-4c7f-8730-6e04f6dd6e67",
@@ -13347,15 +13347,15 @@
       "related": [
         {
           "dest-uuid": "59354e08-ed82-4b95-99c5-aed3996473e1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aff39b79-72c6-4cf9-8ddf-1332252580d5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bcac4672-778d-4b35-8b75-eaaf84b91853",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc3502b5-30cc-4473-ad48-42d51a6ef6d1",
@@ -13363,7 +13363,7 @@
         },
         {
           "dest-uuid": "f392a2cb-dd4b-4585-84d5-1fa4bd65ff60",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "195e8d37-dfe6-4dc8-8012-dc80984872aa",
@@ -13379,23 +13379,23 @@
       "related": [
         {
           "dest-uuid": "45a34d76-16aa-45ac-9419-ffbc5d2e090d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "57595eb2-4d20-4d99-86b3-82064b3566cf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7a5e5aff-8395-4b4e-9072-dd765dae7d19",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7ac026eb-9a3b-49fe-b7ec-7261cb6d6191",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "92157361-c2f8-45e6-9624-38a3cdb44598",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a718a0c8-5768-41a1-9958-a1cc3f995e99",
@@ -13415,11 +13415,11 @@
       "related": [
         {
           "dest-uuid": "08dd2c3b-e07c-4b47-bae6-aa09c2a86d87",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "43834e1c-533a-4f08-b508-8632d35b10ad",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7f0ca133-88c4-40c6-a62f-b3083a7fbc2e",
@@ -13427,11 +13427,11 @@
         },
         {
           "dest-uuid": "e2ca60b5-82df-4e7e-8528-dd24d9a79750",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e64aebfd-8343-45ec-bdce-6681a8255637",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "abf6c96c-09f3-4bea-a5b7-1177f99881bc",
@@ -13451,7 +13451,7 @@
         },
         {
           "dest-uuid": "a67ac8ec-2748-4fe6-8dd7-bd570af1e104",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "af66dc57-77fc-42a7-9e84-7a588c3ab516",
@@ -13467,11 +13467,11 @@
       "related": [
         {
           "dest-uuid": "5ce50294-f89c-4158-b5f2-7ca257a88837",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8626f553-efed-4418-bbc6-b9fa83b0b315",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c99724c-a483-4d60-ad9d-7f004e42e8e8",
@@ -13479,11 +13479,11 @@
         },
         {
           "dest-uuid": "d49f06ba-7a81-440b-bc16-c583ba918a3d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e83afa89-0ec1-49e7-b351-eef67b085480",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e3718a7a-77b3-4790-99ba-aba7703815fd",
@@ -13499,7 +13499,7 @@
       "related": [
         {
           "dest-uuid": "53ba6028-13cd-449e-aab4-d2f9fea458a4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "84e02621-8fdf-470f-bd58-993bb6a89d91",
@@ -13507,15 +13507,15 @@
         },
         {
           "dest-uuid": "e5fcc815-0ab4-4da9-aade-659b87d079da",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e8c91885-736e-4348-ba09-2acfbdd8b176",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f13ff1ad-5c7b-4136-b5cb-7a5663c3c54f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6368178a-04c5-490b-96d5-f12dcccd0497",
@@ -13535,15 +13535,15 @@
         },
         {
           "dest-uuid": "26520d1c-1e0a-443b-817e-7ec1846a0476",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f257014-01d4-487d-980c-77d4d2130315",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "af3dff40-40be-40dd-9a0e-a47cf052880b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6dd441e4-d264-4f7f-b145-9c122955c532",
@@ -13559,7 +13559,7 @@
       "related": [
         {
           "dest-uuid": "1f3a6d61-9658-4c9b-92af-5c711206e3fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "494ab9f0-36e0-4b06-b10d-57285b040a06",
@@ -13567,11 +13567,11 @@
         },
         {
           "dest-uuid": "8d58973f-7fd7-435e-86b8-58f9b399f89f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ce2233bb-9715-4e7b-8603-7218f8bae326",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "baea10fc-7921-4ae2-bfe6-572c3f107303",
@@ -13591,15 +13591,15 @@
         },
         {
           "dest-uuid": "4eca5ae6-797c-41cb-bacd-dc7a6da58fb0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8226ce94-1f5b-4ab0-b0bc-92f1d225eaa4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d9a1ace1-6307-4db7-925f-67057361e66a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1177cbb7-bc00-4a36-8774-d51b7b3c66e9",
@@ -13619,7 +13619,7 @@
         },
         {
           "dest-uuid": "9dab17bf-62c7-4187-90f4-7335790df7c0",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7ff1f384-2373-4ea9-9311-1587b520a5c4",
@@ -13639,7 +13639,7 @@
         },
         {
           "dest-uuid": "e9f451b7-1b9e-420e-983a-3442547b7180",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1d738832-3de4-45f0-98e5-ac37642619e8",
@@ -13655,23 +13655,23 @@
       "related": [
         {
           "dest-uuid": "09df0b88-e1ae-4a1e-86c4-8bb00e79baed",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2a0cc1a9-db3b-4f05-8c85-29d69507418b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "46ecb875-0842-4171-bb36-9b361453a89f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4da63d13-d9bb-41c6-88c8-31bc9f2579fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5ea048cd-f1d5-4da2-9128-10c53ee337c8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a62a8db3-f23a-4d8f-afd6-9dbc77e7813b",
@@ -13679,7 +13679,7 @@
         },
         {
           "dest-uuid": "c5fe5b29-c56f-4c40-b880-051ec6644600",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7ee73f2e-76b2-4f00-bcc0-7fb79d31d344",
@@ -13699,7 +13699,7 @@
         },
         {
           "dest-uuid": "2cb33f68-48f8-4ffe-86e1-bc857a300398",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a51d4d34-78fc-49b7-9071-348905dd33c2",
@@ -13719,15 +13719,15 @@
         },
         {
           "dest-uuid": "a9c30b9d-6810-47d3-8bf5-ca787836e7ef",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c07e8730-b5cf-4a74-be3a-938184af42df",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e2e39b7e-02e4-4e7a-966c-6b05721da8f7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "41107d12-dd2e-439f-af29-1a10dcfcb6ce",
@@ -13743,11 +13743,11 @@
       "related": [
         {
           "dest-uuid": "412b76ec-d44e-4064-9dc1-32cf793f0176",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "55808d73-7aa9-4f2c-8122-8e60bf14f4c6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "82caa33e-d11a-433a-94ea-9b5a5fbef81d",
@@ -13755,7 +13755,7 @@
         },
         {
           "dest-uuid": "b12639b9-5daa-46aa-a21f-521f6962f042",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7f5dde79-7872-48dd-8718-cd2e10d7cbfc",
@@ -13771,7 +13771,7 @@
       "related": [
         {
           "dest-uuid": "2432f5a3-ddae-4138-9981-f916ad23a1e1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4933e63b-9b77-476e-ab29-761bc5b7d15a",
@@ -13779,11 +13779,11 @@
         },
         {
           "dest-uuid": "cfdd2422-7e68-417a-9298-062bac59df0c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "da7cf744-fc04-4b17-8a96-3140a4b349d6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "dc415caf-2f8f-4208-8aa8-7db10729cbfb",
@@ -13799,7 +13799,7 @@
       "related": [
         {
           "dest-uuid": "32d56b42-ff83-46d2-aeea-57a6958d3e83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b8017880-4b1e-42de-ad10-ae7ac6705166",
@@ -13819,11 +13819,11 @@
       "related": [
         {
           "dest-uuid": "4b53b71f-16b4-483b-b64a-eacf6c9db077",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "755fb4b5-903f-4694-b591-04078afa27aa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "afddee82-3385-4682-ad90-eeced33f2d07",
@@ -13831,11 +13831,11 @@
         },
         {
           "dest-uuid": "b3ea7945-a7ef-421c-be84-af86b2b95ae5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8e77c9a-2b8c-47d2-b44a-23857d246016",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "be7a4dda-a46a-4245-8837-e69946a79d3f",
@@ -13851,19 +13851,19 @@
       "related": [
         {
           "dest-uuid": "175bf607-fca6-4555-a30b-3d6cd4cfe876",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3f53ca22-5efe-43b3-8225-5fdd4b8a8194",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "874f0437-1aab-4cfe-a30a-7586c0602b6f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b1ee9791-91f8-4788-9e08-c40eedbcf08b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d63a3fb8-9452-4e9d-a60a-54be68d5998c",
@@ -13883,11 +13883,11 @@
       "related": [
         {
           "dest-uuid": "19b6de3a-032f-4dc8-aa72-7cd952dfed59",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a0730d9f-0a05-4153-8c6a-6f04f9f7346c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e24fcba8-2557-4442-a139-1ee2f2e784db",
@@ -13895,11 +13895,11 @@
         },
         {
           "dest-uuid": "e2dd9fee-91b7-4e32-8031-69ed4d7b927c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fe8c1ef5-59ed-40c3-b7f6-eb560555ee22",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a9351ea0-8379-47cd-a5c5-c5cf424249ef",
@@ -13915,11 +13915,11 @@
       "related": [
         {
           "dest-uuid": "75d43d9f-7b54-4cd4-a6d9-523f8f9a60ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "789849fe-7e94-4fd0-904b-02f8c9c0a696",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "94cb00a4-b295-4d06-aa2b-5653b9c1be9c",
@@ -13927,23 +13927,23 @@
         },
         {
           "dest-uuid": "9735a0b1-df29-49fe-b0f7-973c0b513e8d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b2569010-23c0-4dd8-9e53-3537c1e89efc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d1eafedb-ac64-46b0-972d-8f8759fc11b3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fca70138-f183-4deb-b2a4-59908c76070b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ff0d2f8d-1fff-4bda-94e6-c0cd50abe6ed",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "44f32d03-50ce-480f-b531-481bcc6dc0a8",
@@ -13963,7 +13963,7 @@
         },
         {
           "dest-uuid": "f2c03ef0-cd36-42b8-9c2d-e25a3b1b8b1c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a1e17bbb-73d6-48d5-b0ab-1350189b0ecd",
@@ -13979,11 +13979,11 @@
       "related": [
         {
           "dest-uuid": "40066e48-f70c-4fbb-a2cf-d7a385171edb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6e3a93db-d2a6-43b7-9aa6-4dcf972f5e53",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ef05e3d-52db-4c12-be4f-519214bbe91f",
@@ -14003,7 +14003,7 @@
       "related": [
         {
           "dest-uuid": "6dae9309-90a7-4b4e-b764-9486a7ba4390",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb125d40-0b2d-41ac-a71a-3229241c2cd3",
@@ -14023,11 +14023,11 @@
       "related": [
         {
           "dest-uuid": "6fb4668b-9c70-44d2-87a3-43ff2dc699f2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "739bd746-e98b-45cb-8bc6-3c8876745b4a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d13fa042-8f26-44e1-a2a8-af0bf8e2ac9a",
@@ -14051,19 +14051,19 @@
         },
         {
           "dest-uuid": "6ffbdad6-3d60-452b-9e04-a8292d0125e9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7b87b63c-0936-48b5-8017-47bf5561e6f9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "be680af0-8d5f-482c-9042-f5d4921e65f8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d2bca034-2f97-4c64-ac30-e75d24886be7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "21ad7ddc-77f6-422b-8e0c-c82e184e0ad0",
@@ -14079,19 +14079,19 @@
       "related": [
         {
           "dest-uuid": "59aedd87-8373-45d3-93e3-5697e4cc7a48",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "625983e7-9736-44f4-98ba-f372b3a3d236",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7e029a7f-beb5-4da9-9d75-8fcfc812103b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "80939714-6d17-4cc0-accd-3e1d634846bc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f4a33ec-8b1f-4b80-a2f6-642b2e479580",
@@ -14099,7 +14099,7 @@
         },
         {
           "dest-uuid": "f6985c70-6de1-4600-aba0-5b3324184dce",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "309ca3cd-d3f0-4aea-8932-558550aa89f4",
@@ -14115,11 +14115,11 @@
       "related": [
         {
           "dest-uuid": "2bec56a7-957c-44b4-b730-00dd55ff99f8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2c8326bd-dd59-4715-87ef-dc3bdef919fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3fc9b85a-2862-4363-a64d-d692e3ffbee0",
@@ -14127,11 +14127,11 @@
         },
         {
           "dest-uuid": "571b10ce-fb7d-492e-b05a-23649ae14148",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "de4fe01d-96d7-4258-a1d6-6958fe50a4ed",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1a273fde-f4fc-4ca0-94d4-7df285167b5e",
@@ -14147,11 +14147,11 @@
       "related": [
         {
           "dest-uuid": "0521835b-bc02-41ed-8e6a-153e6422ee9c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5b41efa6-7410-403b-ac07-89e262fa17ca",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c877e33f-1df6-40d6-b1e7-ce70f16f4979",
@@ -14159,11 +14159,11 @@
         },
         {
           "dest-uuid": "cd4d2b49-6a27-41a7-ab20-d2a3791142bd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d053d033-b587-4ed0-bdbc-0c6a9bdd7c82",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9daf5067-79c3-477c-bf41-813aada4770d",
@@ -14179,11 +14179,11 @@
       "related": [
         {
           "dest-uuid": "2385f397-5d17-4b37-ba07-bb52a52ff66c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "23fa40ac-79d0-400a-a017-8e06cfc67e6c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2aed01ad-3df3-4410-a8cb-11ea4ded587c",
@@ -14191,7 +14191,7 @@
         },
         {
           "dest-uuid": "3415a6fa-a447-42f3-8155-68cf5d7cbcb3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "69f22425-2ebb-4f3c-ab4d-fb9c6645f2f7",
@@ -14211,7 +14211,7 @@
         },
         {
           "dest-uuid": "756d5795-ef61-4115-80d2-f2e7440dff56",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8a9b730a-b290-40ce-b182-dbcb06fbad3d",
@@ -14231,15 +14231,15 @@
         },
         {
           "dest-uuid": "41153f33-d415-4e1d-b3c8-7333b2f1915e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b5020e23-475e-4f74-a943-787e090d3e2f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "db45c19b-d9d6-4794-8b49-ba232cca34b0",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "101e19ca-f902-4c2d-8ceb-ddd07a43f1a7",
@@ -14255,7 +14255,7 @@
       "related": [
         {
           "dest-uuid": "11dd0dbf-e880-43d2-99f7-4b6bf9d821fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "887274fc-2d63-4bdc-82f3-fae56d1d5fdc",
@@ -14279,11 +14279,11 @@
         },
         {
           "dest-uuid": "f398e8ff-8c61-4672-8ace-118b11a38515",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f5a0dc9d-3dda-4e31-ad4d-0560b918b6b1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e32dbff1-9d06-4495-b815-48463481581b",
@@ -14299,11 +14299,11 @@
       "related": [
         {
           "dest-uuid": "53491f5a-7062-41f0-a51d-07b52dc8192c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e2b0e14-eabd-4eb7-93b0-da238e3786db",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c08366bb-8d11-4921-853f-f0a3b6a2a1da",
@@ -14323,7 +14323,7 @@
       "related": [
         {
           "dest-uuid": "22cba5f6-b3d5-4a1a-9275-ed7db0bd4c7c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3d1b9d7e-3921-4d25-845a-7d9f15c0da44",
@@ -14331,7 +14331,7 @@
         },
         {
           "dest-uuid": "8c0c52d0-7357-4073-84fc-d262632d268f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "83a814c2-73ac-4942-84ad-704a272cd864",
@@ -14351,15 +14351,15 @@
         },
         {
           "dest-uuid": "80e9341d-7ea4-4684-8f27-54566e996ce6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8d75d4b3-6748-4d1c-936c-129ee56a12a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c9079261-caa7-4cfe-8be6-1359db599d27",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "29d1e77a-a05e-4ead-8272-b254992cd2ba",
@@ -14375,7 +14375,7 @@
       "related": [
         {
           "dest-uuid": "3ee2fdaa-358a-4f65-9d15-c9096628bc7e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "55fc4df0-b42c-479a-b860-7a6761bcaad0",
@@ -14395,7 +14395,7 @@
       "related": [
         {
           "dest-uuid": "5c280910-f7cf-4e7a-9b99-a592115dbc8b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a8e971b8-8dc7-4514-8249-ae95427ec467",
@@ -14403,7 +14403,7 @@
         },
         {
           "dest-uuid": "ccb42e9d-557f-4dc5-b313-75fb6b212821",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "12414f0e-85ca-4403-873a-6d415c2020f4",
@@ -14419,7 +14419,7 @@
       "related": [
         {
           "dest-uuid": "3c320df0-2a99-4bc4-b0f4-7af1675ccdb9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5b0ad6f8-6a16-4966-a4ef-d09ea6e2a9f5",
@@ -14427,11 +14427,11 @@
         },
         {
           "dest-uuid": "81889314-3404-4cfb-a650-52a5898b6f31",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fba8a3f5-74d0-47d2-a688-1bdcc99dae6b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5d244477-26e2-4b3a-b882-fd74e366e07d",
@@ -14447,7 +14447,7 @@
       "related": [
         {
           "dest-uuid": "7726e542-666b-4eeb-8998-cddb45a41605",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "937e4772-8441-4e4a-8bf0-8d447d667e23",
@@ -14467,15 +14467,15 @@
       "related": [
         {
           "dest-uuid": "27a0146c-0af8-4323-9c41-fbd3df9af1fa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "305c684a-2b36-4209-9d00-778ed16de763",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7b981ab1-eb5f-4ad0-a819-90db819a4431",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "861b8fd2-57f3-4ee1-ab5d-c19c3b8c7a4a",
@@ -14483,11 +14483,11 @@
         },
         {
           "dest-uuid": "9a6089cc-92a7-48ea-b4a4-4d4d2b6489e3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f8c255ac-8ba5-4971-9e11-420a10e688ad",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e1854c9f-2b70-4311-9a46-a420f6c0b6d0",
@@ -14507,11 +14507,11 @@
         },
         {
           "dest-uuid": "413bdb56-913d-42e0-978e-5a48c60f562e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6a60d1be-ab95-46d2-91a7-01703553090e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3ead6ecd-8ecb-40c9-8a73-ee3272bf0deb",
@@ -14531,11 +14531,11 @@
         },
         {
           "dest-uuid": "98b0a8a6-881d-4f00-84c3-3f70d368067e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fdb6acce-e069-4e35-8a4b-f4517924f092",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7c7aa84d-8425-42cc-b0bc-5d384b04d99a",
@@ -14555,11 +14555,11 @@
         },
         {
           "dest-uuid": "b95bc556-c98c-459e-9327-49830ce9c77c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c8eb9196-3134-4954-9331-838556db9aa1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1098f1d3-7dfa-4dc0-b524-98af5588f6f7",
@@ -14579,19 +14579,19 @@
         },
         {
           "dest-uuid": "487d9ddf-a790-4adc-9be4-ec5651e790f1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "747a2974-0c77-4c47-9c02-2775025327c6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "863a9028-6b2a-46c6-b696-dd310937fbf9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a09ed72b-be04-475f-8c0a-11ed47b40bd1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "54aaab69-62fb-4d40-b2e0-0d07594353ed",
@@ -14607,7 +14607,7 @@
       "related": [
         {
           "dest-uuid": "0021ecae-778a-4726-aa66-1cf4ca01943e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4a5b7ade-8bb5-4853-84ed-23f262002665",
@@ -14615,15 +14615,15 @@
         },
         {
           "dest-uuid": "81e2b983-2159-47d1-9ec1-a5c863faa1a7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9f5f193f-6aef-4586-a047-492b0c651001",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fc9161ef-3cab-45f5-a585-d78778d72f2b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8796c5cc-7e5a-402f-8252-f083aafc5cc9",
@@ -14643,15 +14643,15 @@
         },
         {
           "dest-uuid": "38252d77-0b46-4e00-8732-3ce1f8491472",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "48e4aceb-38dd-4bf2-8074-9fee8436985b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ab9a4c72-f7ce-4721-8c9f-c5d9c966b600",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "461e3a2b-2315-4550-abb4-0bd73b0ceaa6",
@@ -14667,11 +14667,11 @@
       "related": [
         {
           "dest-uuid": "053dd0c5-9746-46ea-bdeb-b385bf5cbbf8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "37166782-8770-4812-b70c-27f3c705489b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "43f2776f-b4bd-4118-94b8-fee47e69676d",
@@ -14679,15 +14679,15 @@
         },
         {
           "dest-uuid": "4b72b349-f810-4e34-9185-b5550147147e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "98bd8e15-68ea-43a3-982b-66fcd1142c9a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d7f9b07f-401c-4685-a014-6a824f95f866",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "dcc26ef4-3ecd-4b37-b4b4-66faee084352",
@@ -14703,11 +14703,11 @@
       "related": [
         {
           "dest-uuid": "983ae9ea-a125-498a-862d-00d5bed2087a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b7b70725-f1d8-4fad-8fc4-fc1b9cbf77ef",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e1c912a9-e305-434b-9172-8a6ce3ec9c4a",
@@ -14727,7 +14727,7 @@
       "related": [
         {
           "dest-uuid": "0b514d96-12ce-41e2-b870-b35933d7faa6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "18cffc21-3260-437e-80e4-4ab8bf2ba5e9",
@@ -14735,15 +14735,15 @@
         },
         {
           "dest-uuid": "35c7be24-c1c0-4ddc-9356-dec5e39414be",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "867239cd-7939-446c-9efb-b2a7a5bd5403",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ade844ef-f156-4db2-bc11-9dbdc006c8d6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "430abda8-2a2c-4ab8-bbd6-eb205a189362",
@@ -14759,15 +14759,15 @@
       "related": [
         {
           "dest-uuid": "101d4e7f-4282-4fea-89be-e17d97ca0b91",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3234a537-0ad5-449f-87f4-25fd949c97e7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3bbe2c4-615d-4847-93dc-b5857fc1b384",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea071aa0-8f17-416f-ab0d-2bab7e79003d",
@@ -14791,23 +14791,23 @@
         },
         {
           "dest-uuid": "3cb835e5-ded1-42c4-a5cc-38911078b0a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5c6e9102-b3ef-4eaa-85c1-bb5702df0f45",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5d2820b1-af59-4ca2-9f9e-b5bc76f55395",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8359e4ed-c4a1-4734-a3dd-e2d3eb33bc90",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "93c97a07-283e-46c5-b2ac-560db0382ea9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b6d7d7cb-b56f-4095-b3ac-21147b0123e5",
@@ -14827,7 +14827,7 @@
         },
         {
           "dest-uuid": "dc58724a-18a9-4bb9-a901-f5630963095b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b5ec4351-ee04-4beb-a019-b1f6d0e00894",
@@ -14843,11 +14843,11 @@
       "related": [
         {
           "dest-uuid": "01b79770-a269-4b4d-bf09-a4760bae9c94",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0ebcdeba-7b02-4f1c-96c9-a602b3663446",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3aef9463-9a7a-43ba-8957-a867e07c1e6a",
@@ -14855,15 +14855,15 @@
         },
         {
           "dest-uuid": "7879313f-abf1-487a-b4d3-813f385ddce3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9199891a-1543-4f51-be59-4fffb03dfd43",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d17e0719-d338-47eb-a5b4-8616749584cf",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "dcc65927-b113-4f42-b7bd-adb6caebf24a",
@@ -14883,11 +14883,11 @@
         },
         {
           "dest-uuid": "4773bc29-5272-45d5-92bd-b24a34b16df6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "50e52979-5f21-4a02-99f3-fc1858b73369",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1f04ccee-f8b2-4af3-bc34-e5b54d2c883e",
@@ -14907,7 +14907,7 @@
         },
         {
           "dest-uuid": "a9372c6a-8d3b-420a-ad9d-8ef8d284205f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "22331b2d-e8a1-4820-ae6b-7d04f24f7df7",
@@ -14923,11 +14923,11 @@
       "related": [
         {
           "dest-uuid": "04fbc0f1-82f0-4311-9c39-6b519b48e7d8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8e20de5b-1b9c-4443-a095-bcdd52ed161e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fcb11f06-ce0e-490b-bcc1-04a1623579f0",
@@ -14951,11 +14951,11 @@
         },
         {
           "dest-uuid": "a69cefd7-02e8-4840-a26e-2ea0b6a95812",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a8133527-5402-49e0-a9f1-14ee4fb2dd3f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3b8a3713-0f0a-433c-82bd-13b2f9224206",
@@ -14975,15 +14975,15 @@
         },
         {
           "dest-uuid": "56a17328-c6b0-4e3d-9404-d4b8ba967a14",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d14cc347-9e27-479d-8347-1a5950cdd70c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ef8fa56d-882e-42da-990e-2adc3a771041",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "685546e7-2ec3-4bfa-9109-86df9fb196ee",
@@ -14999,7 +14999,7 @@
       "related": [
         {
           "dest-uuid": "44bb0cf8-12ee-4a8f-8701-6c787a008bd8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6bc7f9aa-b91f-4b23-84b8-5e756eba68eb",
@@ -15007,15 +15007,15 @@
         },
         {
           "dest-uuid": "753ec5a6-9327-452e-ab9c-62b7206c24aa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "86bb41b4-5c8a-4407-b788-8f6ea8457860",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "be2239de-ae8e-442d-a9f6-d34460b94e94",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "85849149-b36f-4562-9478-65c4e8f97dec",
@@ -15035,7 +15035,7 @@
         },
         {
           "dest-uuid": "f25cf3cf-53b8-4fa4-be4c-d0a7a02bf739",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c1d8aa38-aefb-4ea8-8c80-2dfa05eaaecb",
@@ -15051,11 +15051,11 @@
       "related": [
         {
           "dest-uuid": "07b8a45e-6435-4c67-ac15-47db21c1d1b9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "344f0add-d372-4e0e-88c6-f48e6b424434",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "54ca26f3-c172-4231-93e5-ccebcac2161f",
@@ -15063,15 +15063,15 @@
         },
         {
           "dest-uuid": "80e4f847-a149-423b-a179-cbcf4afd06b9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bf166688-0c78-43a5-bb87-3159c1b86584",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e1063b92-9be0-4d25-9df5-bae4171c8153",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6b681059-99f7-46ff-bd36-96fd414074d4",
@@ -15087,11 +15087,11 @@
       "related": [
         {
           "dest-uuid": "4cf44d48-1a0f-45a4-9a25-8bee9677ab52",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "500ae9f9-c6c2-4160-ac03-072d963eba63",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d0613359-5781-4fd2-b5be-c269270be1f6",
@@ -15099,7 +15099,7 @@
         },
         {
           "dest-uuid": "da6d7de2-a666-4fa3-aa53-54692a8167ae",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1764bbd5-67d1-4225-9c06-0d5aa74d056f",
@@ -15119,7 +15119,7 @@
         },
         {
           "dest-uuid": "31542445-39c5-4ae9-806f-09649581056a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9bfe6e65-c691-44fa-9d00-bf7fd5e6479f",
@@ -15139,7 +15139,7 @@
         },
         {
           "dest-uuid": "9fb6bb78-418a-483f-ae23-518ffde414d1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f722c058-8449-49ee-8e18-c3e76ec60a51",
@@ -15159,7 +15159,7 @@
         },
         {
           "dest-uuid": "c46d9fac-eac9-479e-91d3-4f5a1066972d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7eb6ccf9-8fb5-4c7d-8a2c-33081c3ddf81",
@@ -15175,7 +15175,7 @@
       "related": [
         {
           "dest-uuid": "0297fd45-97bc-4913-8d38-218eae431544",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "810aa4ad-61c9-49cb-993f-daa06199421d",
@@ -15195,7 +15195,7 @@
       "related": [
         {
           "dest-uuid": "3517708a-f80e-4335-a122-65b9b3505e8d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4d2a5b3e-340d-4600-9123-309dd63c9bf8",
@@ -15203,7 +15203,7 @@
         },
         {
           "dest-uuid": "de71bbc0-66b2-41ae-a3f3-4911ac31b391",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bdbd724e-b3e2-44d7-a9d6-ba2a4915762c",
@@ -15219,11 +15219,11 @@
       "related": [
         {
           "dest-uuid": "4a7169fa-79d4-4724-ad55-6e9842b7cb94",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e1db1813-109f-4f24-87e3-5d7b5e506dd3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb6cf439-1bcb-4d10-bc68-1eed844ed7b3",
@@ -15243,11 +15243,11 @@
       "related": [
         {
           "dest-uuid": "0048442c-54c9-4816-a2ba-5e9d376d0bf2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "36cb5f92-996c-42f4-be7e-43c5e21eee2e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cf28ca46-1fd3-46b4-b1f6-ec0b72361848",
@@ -15271,7 +15271,7 @@
         },
         {
           "dest-uuid": "ae4f420e-1d38-4f6e-b4b6-4b0932f596e7",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b172a0fa-e429-4e6e-89b4-54dcfcefa893",
@@ -15291,11 +15291,11 @@
         },
         {
           "dest-uuid": "71fc481d-53f9-4a35-9879-e01e17f425f0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9a574586-2729-4e60-8e60-5e07f200c3ff",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "06aad19e-a382-4987-a73c-a8e5c340d657",
@@ -15311,11 +15311,11 @@
       "related": [
         {
           "dest-uuid": "397a553d-c08d-497e-8fb0-9526f5a205bc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6039c777-6a85-4df4-86b9-40d95796046e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c4aef43-48d5-49aa-b2af-c0cd58d30c3d",
@@ -15323,7 +15323,7 @@
         },
         {
           "dest-uuid": "cabc275f-5097-4d2e-aabe-b49a31ba87b9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c48fd7e3-fbfb-4ab5-b577-12cc0be21f2c",
@@ -15339,7 +15339,7 @@
       "related": [
         {
           "dest-uuid": "88eaf8ce-b48d-4329-a147-dd5d065cead2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "960c3c86-1480-4d72-b4e0-8c242e84a5c5",
@@ -15347,15 +15347,15 @@
         },
         {
           "dest-uuid": "9b2ff34a-1967-46a9-b355-f9584a0715b5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e2ebd04e-074d-4b90-b94c-a43048b1c3ac",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fa36a169-1cca-4887-b362-e3cceb02414f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "110a934e-881a-4e42-9619-b6de30f4a39e",
@@ -15371,7 +15371,7 @@
       "related": [
         {
           "dest-uuid": "1a27d3ed-86e8-4389-927d-1d43d94dc719",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc6e0637-76d2-4af3-a604-9d8d3ff8a6b3",
@@ -15391,7 +15391,7 @@
       "related": [
         {
           "dest-uuid": "cb4c4b76-3f6d-4387-ab20-74b461bbb211",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d4536441-1bcc-49fa-80ae-a596ed3f7ffd",
@@ -15399,7 +15399,7 @@
         },
         {
           "dest-uuid": "f44bab9b-554c-4dc7-b57f-4011ce609c2b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "538bc808-b0f5-4f86-81f2-63be2cf63e80",
@@ -15415,11 +15415,11 @@
       "related": [
         {
           "dest-uuid": "2adf0c92-5d0a-459d-affc-f4abd4d406d0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "52f4a572-0d43-4684-9598-6bc8cf2bffb1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a9d4b653-6915-42af-98b2-5758c4ceee56",
@@ -15427,11 +15427,11 @@
         },
         {
           "dest-uuid": "c5556dd5-005a-4c11-b028-240fa379d827",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ebd61e14-852c-403b-8b50-7e15a1c32d05",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4a89bf52-7be1-405d-8d02-462e52553bc5",
@@ -15451,19 +15451,19 @@
         },
         {
           "dest-uuid": "1443f662-d249-4458-b8fe-2c2da7b64569",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "aa2dc7aa-0cc5-4a75-96b2-8c089c46944b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bdba541c-3a01-4a6d-95ae-15e283f2909b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ef76221d-d5fe-4285-af27-54711e94e2b5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "24eeb599-bc8c-4e86-9adf-232153bcb14b",
@@ -15479,11 +15479,11 @@
       "related": [
         {
           "dest-uuid": "036a6a5d-bd87-45c7-bd68-43df76167786",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6feb9746-7b2c-4f6f-92c9-bfdb14eddddc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c31aebd6-c9b5-420f-ba2a-5853bbf897fa",
@@ -15503,7 +15503,7 @@
       "related": [
         {
           "dest-uuid": "98dfbd23-232b-410a-bb71-25ba191ff746",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dd818ea5-adf5-41c7-93b5-f3b839a219fb",
@@ -15527,11 +15527,11 @@
         },
         {
           "dest-uuid": "6d2d8aff-7d23-40bc-bc29-54852baed5f1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee4ce869-6b88-46f8-829a-9838f7607a8f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "39efdb0b-2a05-4caf-8f37-876dfad294d6",
@@ -15551,7 +15551,7 @@
         },
         {
           "dest-uuid": "75eaee42-f7b5-4792-9611-74626bd98838",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0d03e753-a278-4a32-a33f-6199967220de",
@@ -15567,11 +15567,11 @@
       "related": [
         {
           "dest-uuid": "1e8d1470-1e76-4f6f-b2c9-633800c4478a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bfbe9c72-f373-4d03-a08a-1448f31dd92f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d2e112dc-f6d4-488d-b8df-ecbfb57a0a2d",
@@ -15591,7 +15591,7 @@
       "related": [
         {
           "dest-uuid": "78864416-9ea3-4285-aab4-ecf31c935253",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "970a3432-3237-47ad-bcca-7d8cbb217736",
@@ -15611,7 +15611,7 @@
       "related": [
         {
           "dest-uuid": "d8d5a1c0-9ba1-4735-af42-3d5b9d7a6603",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d94b3ae9-8059-4989-8e9f-ea0f601f80a7",
@@ -15635,11 +15635,11 @@
         },
         {
           "dest-uuid": "77c81bf1-beef-429a-a426-a716b489383a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a4242809-30bc-4c00-b247-b6cc11644a07",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "694c70ab-0518-432a-a149-a7b185ad814b",
@@ -15655,7 +15655,7 @@
       "related": [
         {
           "dest-uuid": "b8685b0b-f96e-41a4-8e01-eec252756447",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c1b68a96-3c48-49ea-a6c0-9b27359f9c19",
@@ -15663,11 +15663,11 @@
         },
         {
           "dest-uuid": "c625c090-edcc-431a-a2fb-c31e4eb5f2cf",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ffc71b21-982b-4fc7-8276-bd679d67bc95",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9d3a5603-ae0e-41fe-b2f5-7f3e44c903d7",
@@ -15687,11 +15687,11 @@
         },
         {
           "dest-uuid": "8a463850-89e6-4de8-bd8d-20fd70dff959",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9253e546-bc55-42c1-bf8c-b4337a1ea5b5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "411f7c72-356c-4de6-bbf0-27a7952d3be5",
@@ -15707,7 +15707,7 @@
       "related": [
         {
           "dest-uuid": "1076f33e-a959-49b8-97a3-2edf0360fae2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "351c0927-2fc1-4a2c-ad84-cbbee7eb8172",
@@ -15715,7 +15715,7 @@
         },
         {
           "dest-uuid": "f463fae8-5697-4539-b6c7-e67aadf81c73",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5d42f7a1-78dd-4569-936e-78fe4601cb73",
@@ -15731,7 +15731,7 @@
       "related": [
         {
           "dest-uuid": "18ab8a54-68bc-4d43-884d-2b9284eb723e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "315f51f0-6b03-4c1e-bfb2-84740afb8e21",
@@ -15739,11 +15739,11 @@
         },
         {
           "dest-uuid": "93fd8592-d8ce-4b5e-b095-71cd66062298",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "de1d4807-fcb5-4112-b310-ea0c4df45af2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a5600691-be46-424a-b8ef-a2c9159da49a",
@@ -15759,7 +15759,7 @@
       "related": [
         {
           "dest-uuid": "18e81e76-bae3-44c8-b573-dfd3564a00ad",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "215d9700-5881-48b8-8265-6449dbb7195d",
@@ -15767,11 +15767,11 @@
         },
         {
           "dest-uuid": "b55c3339-2d4c-4392-8d26-c257ea2f1bb9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d9ee822c-6a91-4c83-9698-779ca0bf8663",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ff6c2db6-cc1b-47e0-89a6-536f83b74906",
@@ -15787,7 +15787,7 @@
       "related": [
         {
           "dest-uuid": "3307605e-f2ac-4cfb-be12-5d880e1bfa11",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6ecbc2eb-e85a-440a-ab68-4d98f8d56fbe",
@@ -15795,7 +15795,7 @@
         },
         {
           "dest-uuid": "79897090-662d-4118-b73a-145f79e31829",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1cabf349-a457-422b-a179-475795013f8a",
@@ -15815,7 +15815,7 @@
         },
         {
           "dest-uuid": "ac4bf64e-da14-4416-8961-f0736eb4d9be",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6b173b90-4b1d-4de8-a506-95b8b10921a7",
@@ -15831,7 +15831,7 @@
       "related": [
         {
           "dest-uuid": "c37bba44-9ca2-4444-8ee9-7cab0b2fd5fd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d9e88203-2b5d-405f-a406-2933b1e3d7e4",
@@ -15851,7 +15851,7 @@
       "related": [
         {
           "dest-uuid": "3d12c26c-740d-4393-9659-52a424586b20",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ec4c4baa-026f-43e8-8f56-58c36f3162dd",
@@ -15859,7 +15859,7 @@
         },
         {
           "dest-uuid": "f1e295df-0598-4263-b7c4-737d66660bbe",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d9ca9fb7-01dd-465c-86a1-a48b6812b1c5",
@@ -15875,7 +15875,7 @@
       "related": [
         {
           "dest-uuid": "114cd15c-a02f-4bac-8ed3-3ae71c1761ec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3e091a89-a493-4a6c-8e88-d57be19bb98d",
@@ -15883,7 +15883,7 @@
         },
         {
           "dest-uuid": "f42dbde8-e7a0-41ed-b13c-7ade678fa782",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7f914be4-061a-43a7-8d36-a758b123ca3b",
@@ -15899,7 +15899,7 @@
       "related": [
         {
           "dest-uuid": "90052e39-40c3-4194-a2a2-fc240639ab0f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c6e17ca2-08b5-4379-9786-89bd05241831",
@@ -15923,7 +15923,7 @@
         },
         {
           "dest-uuid": "ca1afe09-7edb-4415-a240-92a0f30ac22f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9031c511-d7ff-410e-9144-d3afee390210",
@@ -15939,7 +15939,7 @@
       "related": [
         {
           "dest-uuid": "0f186e7f-fe33-45d6-ba1e-02a334cf1cb3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "191cc6af-1bb2-4344-ab5f-28e496638720",
@@ -15947,11 +15947,11 @@
         },
         {
           "dest-uuid": "9e95639e-633f-47cf-b343-3ea771c19192",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ec9d296-173f-4e47-8bc4-d20d558e6e18",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ec870f2d-bba3-43f9-95b8-c2f85678dba4",
@@ -15971,7 +15971,7 @@
         },
         {
           "dest-uuid": "7687688c-f91c-4487-948e-1d5b372fcdac",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d881e35b-5401-46c0-b966-8880c64681ab",
@@ -15991,15 +15991,15 @@
         },
         {
           "dest-uuid": "18cf5cf7-f46b-4258-a0aa-503881c9c88e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "89cfa3ac-22c9-462f-a6a5-b142124e22a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ebfa3aa8-dc7c-4d56-868e-169c873b5e78",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e8528ab8-3467-423b-92b6-115f8ecc266d",
@@ -16019,15 +16019,15 @@
         },
         {
           "dest-uuid": "4bdc0555-f7f0-4b5b-80c9-77f361881a01",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4ecd8727-bcf3-4fce-8c04-e8d0bad1267e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "90e51090-9857-4a28-98b9-f21401ddbe85",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a3dcb195-d1b5-4bce-b62b-ba9bdaed56d5",
@@ -16043,7 +16043,7 @@
       "related": [
         {
           "dest-uuid": "08314a8b-becd-4853-8a6c-dd5a947b36c0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6831414d-bb70-42b7-8030-d4e06b2660c9",
@@ -16051,7 +16051,7 @@
         },
         {
           "dest-uuid": "c7d513f4-5113-4031-8125-7f145128c2e1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bc8cd246-1521-4643-a07e-428d45093b38",
@@ -16071,7 +16071,7 @@
         },
         {
           "dest-uuid": "5c5afe0d-b967-49ac-8c3e-eeb9cc01667d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "52cee5e7-a92e-433e-9b56-38c8f7b16264",
@@ -16087,15 +16087,15 @@
       "related": [
         {
           "dest-uuid": "67ff7cc5-7b9b-4d15-b115-b55c3d164c64",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9cf3c7bb-296e-445a-ba30-012060b9ccac",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9d7fd025-d8eb-48ab-8fca-df6b09761aec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a3e1e6c5-9c74-4fc0-a16c-a9d228c17829",
@@ -16115,15 +16115,15 @@
       "related": [
         {
           "dest-uuid": "4e3afe58-e384-4b9e-9137-adaa0bac72af",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "785c44d0-7e5b-4d3e-a3cd-0c5e96b8891b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ea7f21e-700f-4900-a1d4-dfc171d399fe",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b18eae87-b469-4e14-b454-b171b416bc18",
@@ -16131,7 +16131,7 @@
         },
         {
           "dest-uuid": "dba32c3a-1ae7-46a4-9b04-d011f37aa801",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cc8324a7-03d0-47d1-8e2b-3caec44fc129",
@@ -16147,23 +16147,23 @@
       "related": [
         {
           "dest-uuid": "0119786d-ee1e-4857-b31a-3a43830e28e7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3ccd6662-c579-494f-bbfa-ffc3530e3db2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a1619e8f-10aa-46ab-8776-898e8c3d5b43",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c0bbe0a5-680f-487b-8f5f-27703efb52b7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c14042f6-5ebd-42a2-b293-b2367b300fb6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3b6daca-e963-4a69-aee6-ed4fd653ad58",
@@ -16183,19 +16183,19 @@
       "related": [
         {
           "dest-uuid": "20c2cbdf-2a02-40d1-9d10-b91d9bbe3004",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6ad3d8bb-fc6f-45fb-b44e-871c263230d8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8586fd06-9801-473e-8ea6-d3da0ec82267",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8ea556b8-d6d3-430c-a438-847b00e607a5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fde016f6-211a-41c8-a4ab-301f1e419c62",
@@ -16215,15 +16215,15 @@
       "related": [
         {
           "dest-uuid": "01588556-4b25-4418-b746-9bca0279be2c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "02fb4d83-d2db-4d49-acbc-85eff3b517d6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2f6dd4a5-b0cc-4c13-abb8-e2d747d591b2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "613d08bc-e8f4-4791-80b0-c8b974340dfd",
@@ -16247,7 +16247,7 @@
         },
         {
           "dest-uuid": "dea5f6cc-d3bb-404b-8aab-f7366988a96e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "481a55d3-5f23-4428-9438-0220eab78678",
@@ -16267,15 +16267,15 @@
         },
         {
           "dest-uuid": "3643a313-1aa7-44d1-b3e2-e97ad65c6837",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "620cae28-1874-462d-a2e4-47ddd75098ea",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fd7bf05d-6f80-471c-99bf-7aa82ab25440",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f9175415-59ba-497c-b96f-639e01f4cf4e",
@@ -16291,7 +16291,7 @@
       "related": [
         {
           "dest-uuid": "0b0e244e-9386-4520-b030-9e330c6c1930",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a91262d5-b9ff-463f-b8d2-12e4ea1eb3c9",
@@ -16299,7 +16299,7 @@
         },
         {
           "dest-uuid": "b6618b3a-370c-44af-86db-d4640799ed6e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0f41110f-099f-468f-af46-65d2a34f05d9",
@@ -16319,7 +16319,7 @@
         },
         {
           "dest-uuid": "c752faa1-9cc2-421a-b646-0efe4da990c9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3ada68d4-a4ab-4c06-98ce-33aaef54a115",
@@ -16335,11 +16335,11 @@
       "related": [
         {
           "dest-uuid": "025e89c6-9383-48b5-b9f2-85ab31b6a7bb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "0ea214f3-5d66-4170-b33d-58a6577bb074",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c898c4b5-bf36-4e6e-a4ad-5b8c4c13e35b",
@@ -16347,7 +16347,7 @@
         },
         {
           "dest-uuid": "f9f7e5e7-edbf-442b-b4ea-d35455982ba8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6d2e2f19-f5ae-4ba0-aea7-52cc257169e5",
@@ -16363,11 +16363,11 @@
       "related": [
         {
           "dest-uuid": "0a1f9686-4fd6-4719-84ef-7a590d02d1fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "16e57a41-f305-4aa7-9125-15272052419e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dff263cc-328e-42b4-afbc-1fee8b6a8913",
@@ -16375,7 +16375,7 @@
         },
         {
           "dest-uuid": "f84124d2-8bc6-4dae-a579-f0ddb0338a2f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1d8154f6-6890-4441-863f-007600867088",
@@ -16391,11 +16391,11 @@
       "related": [
         {
           "dest-uuid": "3928ff9c-961e-455c-a2b1-d79ca788591f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9d76d84b-6393-45cf-b872-eb5921508ee3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cba37adb-d6fb-4610-b069-dd04c0643384",
@@ -16403,7 +16403,7 @@
         },
         {
           "dest-uuid": "d0d1375d-f5c2-4271-b5e7-415c478d5e86",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e2409f82-e24c-4bb9-ad44-b20d97fb7a5a",
@@ -16419,11 +16419,11 @@
       "related": [
         {
           "dest-uuid": "04e54116-5787-4bb0-9c4a-2b620a80b5dc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "55699534-c11f-4f9b-8908-a0c7d59160fd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e2ea7f6b-8d4f-49c3-819d-660530d12b77",
@@ -16447,19 +16447,19 @@
         },
         {
           "dest-uuid": "a39fccda-e5ea-49de-80f9-d67ae3b8c799",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b18b93d1-3f63-4788-8e26-68db032995e0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cfc7b6bc-2ca3-4407-a835-b40bf6a98efc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e08e4dd6-cab5-41c0-b136-1bc8426c25ed",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ed58a144-2554-495c-9c60-18e6f817aa75",
@@ -16475,7 +16475,7 @@
       "related": [
         {
           "dest-uuid": "6852479f-7c3d-4c69-82b9-b5b9976e4101",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c049d7b-c92a-4733-9381-27e2bd2ccadc",
@@ -16495,19 +16495,19 @@
       "related": [
         {
           "dest-uuid": "0bf5b548-50d0-4e73-bb3c-413cbdfafd97",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1e2211b9-1730-4645-89f6-11259b35e0a4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3533fba3-e80d-4ad0-be45-62460b28ad7c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5e3f407f-192b-4e6f-aab0-e0682da3a4a9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9e7452df-5144-4b6e-b04a-b66dd4016747",
@@ -16515,7 +16515,7 @@
         },
         {
           "dest-uuid": "b5b53b9d-f72b-4cd5-946b-d1ddfdad3c0f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "acc27d20-8aad-42ce-b928-6cda3c22e51b",
@@ -16531,7 +16531,7 @@
       "related": [
         {
           "dest-uuid": "a05f564d-365c-46ce-ab98-ba377aa3b660",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c071d8c1-3b3a-4f22-9407-ca4e96921069",
@@ -16551,11 +16551,11 @@
       "related": [
         {
           "dest-uuid": "20157d55-1760-483c-a3b1-c6e219eeb75c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cad9e775-f40f-42fb-8e86-c7aba249a8e4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d511a6f6-4a33-41d5-bc95-c343875d1377",
@@ -16563,7 +16563,7 @@
         },
         {
           "dest-uuid": "e6e98024-2fa7-444c-af90-32ec5d4d2666",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "72d668ba-f4d1-43ff-b7b1-0dbad9ec6ed9",
@@ -16579,7 +16579,7 @@
       "related": [
         {
           "dest-uuid": "dd7242e8-12d5-46b4-bc2c-cff6c2dbaa27",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e2c2249a-eb82-4614-8dd4-9c514dde65e2",
@@ -16599,15 +16599,15 @@
       "related": [
         {
           "dest-uuid": "13f8d339-8239-4d84-adf2-1abf1a0f3d5d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2e700f3b-bf9c-427c-a099-b80d233c1ccb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "64d6b35c-4785-4e2b-bc93-1f54f626a7a7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ac9e6b22-11bf-45d7-9181-c1cb08360931",
@@ -16627,11 +16627,11 @@
       "related": [
         {
           "dest-uuid": "1e72355d-3350-4b60-8c92-2ded50a3fdd1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bfa12b75-13ab-409f-8fe9-a93c8bcac466",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3b936a4-6321-4172-9114-038a866362ec",
@@ -16651,7 +16651,7 @@
       "related": [
         {
           "dest-uuid": "cf5aa9ca-0f1b-4707-94af-484228fd6199",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ed730f20-0e44-48b9-85f8-0e2adeb76867",
@@ -16675,11 +16675,11 @@
         },
         {
           "dest-uuid": "87d2ccc4-f82e-493d-9c6f-03303253aec2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9c721bd4-75df-4381-bd70-29679aa78a4b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9935655b-cd9b-485f-84ea-1b3b4b765413",
@@ -16695,23 +16695,23 @@
       "related": [
         {
           "dest-uuid": "0eb6cf59-4ba8-4cea-b64a-686ce7c69f70",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5c69f3b9-8f73-455e-8eb1-5281cd6ce6d5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "616ccbf4-08f2-4b54-8e41-a8e362e31827",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "74565d24-df58-49b6-86e0-01a03d6dc2a7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "842ba5ee-dcd0-42bd-9ef8-867a4ab1c703",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a10641f4-87b4-45a3-a906-92a149cb2c27",
@@ -16719,7 +16719,7 @@
         },
         {
           "dest-uuid": "eb4a55f0-eff2-40f8-912e-43ba7e34603c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d6c4cc3b-6875-4288-8193-bf4c864560ab",
@@ -16739,7 +16739,7 @@
         },
         {
           "dest-uuid": "176d2eda-e41b-48d0-b66a-daaccb5a77cd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5a9d7ef3-35bf-4a89-8f61-084e2eecc070",
@@ -16759,7 +16759,7 @@
         },
         {
           "dest-uuid": "51133710-7c09-4eb5-a0bc-6fc5338cd68d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "172b779a-9d14-4c5f-ba4c-3e784b4ae1b6",
@@ -16775,7 +16775,7 @@
       "related": [
         {
           "dest-uuid": "0d358eda-4f7e-462e-8201-96d8a661001d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "45a5fe76-eda3-4d40-8f22-c186efd6278d",
@@ -16783,7 +16783,7 @@
         },
         {
           "dest-uuid": "4708044d-651a-40c7-a1b2-6d7f13d17d7d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2627c9c4-0241-41b7-b494-657cc58d4611",
@@ -16803,7 +16803,7 @@
         },
         {
           "dest-uuid": "40c8a3ac-4fe9-49c3-a9bd-f8f684d42003",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4d41c48b-ef2a-49a1-baaa-039625612c20",
@@ -16819,23 +16819,23 @@
       "related": [
         {
           "dest-uuid": "3f74d068-0a8b-4312-91f3-34da6c630c4a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4b16cb6e-7a81-4f97-a4ad-5e461e1cc154",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9311924d-7d8f-489a-8105-058a60f572fc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9cf6c89d-73f7-42f8-b5e4-c87bf3abbb7d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c71bf861-9b5a-4f39-a53f-bb6f45f7a971",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "eb897572-8979-4242-a089-56f294f4c91d",
@@ -16859,15 +16859,15 @@
         },
         {
           "dest-uuid": "8cd6ae3d-7f14-42bf-9aff-870209fc333f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f84fc52-ab74-443b-b618-aa1c0941377a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "db9b55b0-7e54-4625-92d5-fbe9ed8ac868",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "99294309-83fd-46f3-9925-7443c03e5b79",
@@ -16887,11 +16887,11 @@
         },
         {
           "dest-uuid": "7f84f2b8-6ef3-4167-b059-a455d7c40a7d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b755f519-cc0c-44a4-865f-fa9ead44590f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d87dc800-38cb-4d82-b76e-3c501dbd9c0a",
@@ -16907,15 +16907,15 @@
       "related": [
         {
           "dest-uuid": "3d9fb03c-fcc9-4f19-9c49-09d8321f28b9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7ef0d746-f233-4b41-b999-43a6b1484574",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b3bad14e-39a8-4e90-b3e3-46974fd9c2bd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cbb66055-0325-4111-aca0-40547b6ad5b0",
@@ -16939,15 +16939,15 @@
         },
         {
           "dest-uuid": "4bad86cf-6cab-46f4-8748-28dc8c8ec81b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8f0ac116-4c8a-4819-b7c0-744e05d672c9",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ef50b854-172a-457b-9d0e-c95d9835eaaa",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "50569af3-7910-4591-977e-cbf4caa12cfd",
@@ -16963,15 +16963,15 @@
       "related": [
         {
           "dest-uuid": "0c4a2cfd-a064-4f45-9c07-eb5c1044dd61",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "38300670-8c96-4f80-bc1b-d69242023a20",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c0055eb3-5579-48a8-b9d3-df6dd67bc388",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e1c2db92-7ae3-4e6a-90b4-157c1c1565cb",
@@ -16979,7 +16979,7 @@
         },
         {
           "dest-uuid": "e7a0e155-e0bc-45b5-b0ef-98ec4f5eea63",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6dec9c28-6dcb-4470-ad69-6cdb520adb53",
@@ -16999,7 +16999,7 @@
         },
         {
           "dest-uuid": "cb78ff0f-6f8a-41a8-a199-4660a0addec9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "973a4da0-af9c-4d57-ab62-21fbc308f8b3",
@@ -17015,7 +17015,7 @@
       "related": [
         {
           "dest-uuid": "944c3eaa-2809-4db3-ac7c-d1868e205793",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f05fc151-aa62-47e3-ae57-2d1b23d64bf6",
@@ -17035,7 +17035,7 @@
       "related": [
         {
           "dest-uuid": "9301fed2-1abe-4250-85b0-7794431e9034",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b1ccd744-3f78-4a0e-9bb2-2002057f7928",
@@ -17055,7 +17055,7 @@
       "related": [
         {
           "dest-uuid": "8503331d-09f5-49d3-838c-f0d3b1d55e30",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "986f80f7-ff0e-4f48-87bd-0394814bbce5",
@@ -17063,7 +17063,7 @@
         },
         {
           "dest-uuid": "acc1bb20-bd46-4228-abba-f4befe82e926",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "83a0e3a2-5828-4707-84f5-eec67cf6b50e",
@@ -17083,11 +17083,11 @@
         },
         {
           "dest-uuid": "72604d06-ac1b-4d57-adb4-f303f2f82055",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "99227275-37f5-400f-95ae-b5e17abfb0fd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "48e300f8-190e-46fa-a56d-8701f7a152d3",
@@ -17103,7 +17103,7 @@
       "related": [
         {
           "dest-uuid": "23855fa6-f6d6-4a9c-a270-ea1f2830ef60",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "51e54974-a541-4fb6-a61b-0518e4c6de41",
@@ -17123,7 +17123,7 @@
       "related": [
         {
           "dest-uuid": "4ba33f5f-5f75-40c5-96ab-b014e772f9a8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "db8f5003-3b20-48f0-9b76-123e44208120",
@@ -17147,11 +17147,11 @@
         },
         {
           "dest-uuid": "86aa8777-e12a-4dab-81ed-354bed18f3db",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d7e3296a-9f95-4061-b3f5-0f02910745ab",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5aa9f16e-253d-4ca6-b5e2-8311e5a76290",
@@ -17171,7 +17171,7 @@
         },
         {
           "dest-uuid": "705168ad-1701-453c-9aea-c75029492b89",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cfedfc6c-6e31-481b-be1e-e23a760fec44",
@@ -17191,11 +17191,11 @@
         },
         {
           "dest-uuid": "50a9f608-68aa-4bf2-b24d-2a22f2a96db4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "76cb5e62-9291-411d-90bf-57642b63f8b8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "63b2446e-fa01-4440-bcd6-0f8505d630a6",
@@ -17211,7 +17211,7 @@
       "related": [
         {
           "dest-uuid": "9d36e6e7-9c6c-495c-9431-464fb525c4e8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a51eb150-93b1-484b-a503-e51453b127a4",
@@ -17231,7 +17231,7 @@
       "related": [
         {
           "dest-uuid": "663bba48-7043-4407-875f-59691655d13c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cca0ccb6-a068-4574-a722-b1556f86833a",
@@ -17255,11 +17255,11 @@
         },
         {
           "dest-uuid": "4d499685-2a71-4d66-8b44-fae780c3e998",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a180ad2e-e3fa-4cec-a1f0-8baf754d9543",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c2155dfa-140f-4da9-bfe8-61481a9693c0",
@@ -17275,11 +17275,11 @@
       "related": [
         {
           "dest-uuid": "13810047-61f4-4cd0-aeda-6727d652da90",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "42bae633-1033-40da-bf3a-87bcd1b0297f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "866d0d6d-02c6-42bd-aa2f-02907fdc0969",
@@ -17287,15 +17287,15 @@
         },
         {
           "dest-uuid": "8f998965-ad70-4ec6-8bc1-85831edc0497",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ee468e26-d179-47ba-af8b-43118db24939",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f5b9ad98-3a10-4ff3-9e25-890488253bef",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "170a958d-79a6-433a-8ab0-c8d654e2ca86",
@@ -17315,11 +17315,11 @@
         },
         {
           "dest-uuid": "9bc8daed-e8ea-4c70-95bc-dcb2905b33d3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b2120e89-a453-4575-8458-7700ea59f85a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a7e4704b-4286-4928-88df-d0c151432495",
@@ -17339,11 +17339,11 @@
         },
         {
           "dest-uuid": "9aa716a2-0301-49cd-89c0-a441e5da0551",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c1cdc6fb-9b7f-4076-9634-c939ddaef2bf",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "8d518627-1df4-4bf8-b1fb-0828fb9f6d31",
@@ -17359,7 +17359,7 @@
       "related": [
         {
           "dest-uuid": "10222534-1e1d-473c-a2cb-674126f87ad8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "36aa137f-5166-41f8-b2f0-a4cfa1b4133e",
@@ -17379,7 +17379,7 @@
       "related": [
         {
           "dest-uuid": "0922c3e9-26fb-4330-8d7a-2b9a4661db88",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "34b3f738-bd64-40e5-a112-29b0542bc8bf",
@@ -17403,15 +17403,15 @@
         },
         {
           "dest-uuid": "5e8af32c-5246-43e1-a7d9-c4d263c7b135",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8384d942-2f83-4968-9959-fd2f55afb311",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ba6a9282-30e0-491c-90a7-35bf4ad25ba3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7a084a47-c4ea-4996-8d23-ffe0b19206fb",
@@ -17427,15 +17427,15 @@
       "related": [
         {
           "dest-uuid": "1f515cf2-91a5-4bed-95a1-ed8fc8b24a87",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "31e4c4dc-3094-45b2-9d4d-1b0bf8311498",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7e9cb99b-4040-4b73-bd70-1bd68ae0f373",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bed81616-3dde-4685-be6e-ba9820f9a7ed",
@@ -17443,7 +17443,7 @@
         },
         {
           "dest-uuid": "d41cdfc1-2a82-4442-a1ca-177fe59b8dff",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9a66295a-9f47-47a8-bda4-935cd311186a",
@@ -17459,7 +17459,7 @@
       "related": [
         {
           "dest-uuid": "aae53d47-1f26-426b-9e50-848f186fed99",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b84903f0-c7d5-435d-a69e-de47cc3578c0",
@@ -17479,7 +17479,7 @@
       "related": [
         {
           "dest-uuid": "6a3e1244-3832-4523-81bc-56598a280b16",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "74e6003f-c7f4-4047-983b-708cc19b96b6",
@@ -17499,7 +17499,7 @@
       "related": [
         {
           "dest-uuid": "4884ba77-1420-4093-9dba-65e881f6dca5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "79da0971-3147-4af6-a4f5-e8cd447cd795",
@@ -17523,7 +17523,7 @@
         },
         {
           "dest-uuid": "4dbe3d83-4e01-455f-94f2-a1a31b410b47",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cfcbb930-2395-4f7a-b95c-6b2736679c81",
@@ -17539,11 +17539,11 @@
       "related": [
         {
           "dest-uuid": "03364dc1-4b76-4a30-83cf-ae101b960d8e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "3bac57c4-1539-4048-b325-88032c78ed08",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "851e071f-208d-4c79-adc6-5974c85c78f3",
@@ -17551,15 +17551,15 @@
         },
         {
           "dest-uuid": "ce3ebda8-d47e-4730-a1f4-3366d33a98ab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "efdca1e1-5a4a-4039-99ab-1cdb7e50e52c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f2aef85a-c1ea-4d1a-b359-32692c973cdc",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e767f434-dda3-41fe-a9ea-e7aaae251e61",
@@ -17575,7 +17575,7 @@
       "related": [
         {
           "dest-uuid": "0d22c60c-fd0b-47f8-abe4-2d661a73c653",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d446b9f0-06a9-4a8d-97ee-298cfee84f14",
@@ -17595,7 +17595,7 @@
       "related": [
         {
           "dest-uuid": "75c4eac4-c61c-4d02-acd9-ec8f5b6cfaff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d3bc5020-f6a2-41c0-8ccb-5e563101b60c",
@@ -17615,7 +17615,7 @@
       "related": [
         {
           "dest-uuid": "09ea8707-d76c-44ae-b077-19a8949faa90",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "670a4d75-103b-4b14-8a9e-4652fa795edd",
@@ -17639,7 +17639,7 @@
         },
         {
           "dest-uuid": "65390827-81d9-43d0-9c9d-16d8c6509b90",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f5ac003f-2fdc-4ac5-9f2b-3fb2ab00fe95",
@@ -17659,11 +17659,11 @@
         },
         {
           "dest-uuid": "b972ebf0-16d1-4bc2-980b-e8cb0947affa",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f3da45bb-921e-4b4c-8fc3-666c7a37dea6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "668d7e7b-dc4e-4f51-93b4-ef87cb15d507",
@@ -17683,11 +17683,11 @@
         },
         {
           "dest-uuid": "9396ec3f-2189-44d1-9c88-53ee3603236c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d11da2b2-1552-4a54-b268-3df1cb877cf6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a6da6dc3-19fe-4d1c-ab77-843c08377a19",
@@ -17703,11 +17703,11 @@
       "related": [
         {
           "dest-uuid": "085c9205-d55a-4e33-a5df-241e505be32f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4ce71d01-ba3b-4ed2-a615-766daa0ff144",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a64a820a-cb21-471f-920c-506a2ff04fa5",
@@ -17727,11 +17727,11 @@
       "related": [
         {
           "dest-uuid": "0f05915c-e146-4921-840b-1a08774ca4d2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4b47697b-ff9b-4af7-a079-d34210cebdab",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "63e3d25c-d57d-407d-8e6a-2cecd71f90be",
@@ -17739,7 +17739,7 @@
         },
         {
           "dest-uuid": "b61673d6-244f-4888-9370-1a3ef391a6c2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f54b8799-acfd-4df4-a2c4-e83071750bde",
@@ -17755,7 +17755,7 @@
       "related": [
         {
           "dest-uuid": "7247d454-c307-417a-90c7-a15452d0d83e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ea132c68-b518-4478-ae8d-1763cda26ee3",
@@ -17775,7 +17775,7 @@
       "related": [
         {
           "dest-uuid": "23b9c988-be01-4092-b9c4-0ddec8d58891",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e7cbc1de-1f79-48ee-abfd-da1241c65a15",
@@ -17795,7 +17795,7 @@
       "related": [
         {
           "dest-uuid": "23a1b062-847e-4912-8e5e-5b69867af4a4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dc01774a-d1c1-45fb-b506-0a5d1d6593d9",
@@ -17815,7 +17815,7 @@
       "related": [
         {
           "dest-uuid": "2867d1e0-cf83-4d83-bc6c-cc03404c3521",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4c58b7c6-a839-4789-bda9-9de33e4d4512",
@@ -17823,7 +17823,7 @@
         },
         {
           "dest-uuid": "8062d295-9d02-40c5-9ef9-135d08c07a22",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4809a26b-8527-49dc-81aa-ac2750fd3b75",
@@ -17839,11 +17839,11 @@
       "related": [
         {
           "dest-uuid": "4cb75669-f88d-4374-be51-e4b99e22b64e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a088cd64-106e-4fe2-a004-5796c574cfd0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fd211238-f767-4599-8c0d-9dca36624626",
@@ -17867,11 +17867,11 @@
         },
         {
           "dest-uuid": "9eeb7425-6979-4f77-aa7c-f9b0fe6b710e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f420e242-1e51-4d1a-b063-b15240283e1f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "070d40c8-1aad-47e4-93d7-05e0362f437b",
@@ -17891,7 +17891,7 @@
         },
         {
           "dest-uuid": "7d2231b0-d62e-4d5f-bc26-99e7f14ec741",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0c7e55b4-57b2-4a0f-ba0e-f50eab1a95f0",
@@ -17911,7 +17911,7 @@
         },
         {
           "dest-uuid": "e1f67192-803a-4cd3-a455-64bb623263d6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "fb15f9a5-8561-4c67-b50b-f72039ff9a44",
@@ -17927,7 +17927,7 @@
       "related": [
         {
           "dest-uuid": "4ab972bf-623b-418b-9647-2c3a56b55083",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f2877f7f-9a4c-4251-879f-1224e3006bee",
@@ -17951,11 +17951,11 @@
         },
         {
           "dest-uuid": "ddebe043-2017-44ba-96e5-cbe87916511b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dec6e0d3-f4ae-48ed-90b9-ee32fd7e8dc6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3ec475a9-b33f-42b3-a1b1-755b5fa9389b",
@@ -17971,7 +17971,7 @@
       "related": [
         {
           "dest-uuid": "7c96d701-391d-4904-b6ba-941344aaf059",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "948a447c-d783-4ba0-8516-a64140fcacd5",
@@ -17979,7 +17979,7 @@
         },
         {
           "dest-uuid": "b6ef77d6-cc8b-478c-b7f8-7767bbb58960",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7a921c8c-fdc6-4526-aba6-2632360b7f0f",
@@ -17995,7 +17995,7 @@
       "related": [
         {
           "dest-uuid": "a3b1f9ea-184b-4429-94c0-d04c3b457b91",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "be63612f-a48f-44f2-a7a6-1763509fcf80",
@@ -18003,7 +18003,7 @@
         },
         {
           "dest-uuid": "ea9bb66e-1ced-4448-8d64-4184ae1c0ac9",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f06f44c7-97ff-4f8d-8c72-650c98e0ebdc",
@@ -18019,11 +18019,11 @@
       "related": [
         {
           "dest-uuid": "3723c7a3-2ea7-455f-aec5-29300cb7ae64",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "de37eb78-5f35-4327-99d0-ad6546ab0fb6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fd339382-bfec-4bf0-8d47-1caedc9e7e57",
@@ -18047,7 +18047,7 @@
         },
         {
           "dest-uuid": "f1e4a6ae-86b5-4cf1-a044-0ffc6551196e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3e6efcf8-8308-4832-b247-ce08703c7ed9",
@@ -18063,11 +18063,11 @@
       "related": [
         {
           "dest-uuid": "29ca0e06-e848-44cd-821a-24576276a8af",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "acabb18b-e2d6-4531-92bb-4165f0a16595",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "afac5dbc-4383-4fb6-9ba6-45b25d49e530",
@@ -18075,7 +18075,7 @@
         },
         {
           "dest-uuid": "b73489af-2e95-4f41-b82e-327a84da2a1d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ad21a251-e824-4368-a04c-8a480ee653cc",
@@ -18095,11 +18095,11 @@
         },
         {
           "dest-uuid": "07c399a0-e5ad-462d-99b9-f51ce8aa5061",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f10a7842-ddb2-488b-93ac-e53fa6476614",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ea1efe01-98ef-4a49-a30d-72fde6750985",
@@ -18119,11 +18119,11 @@
         },
         {
           "dest-uuid": "5044447d-dc82-4d74-ac8c-02e5559f374c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dd9778f4-5919-4796-9d4c-b3fb6ace453d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a5f6a93c-a8f9-4660-a6bc-63761a9ee94b",
@@ -18143,7 +18143,7 @@
         },
         {
           "dest-uuid": "cf66582f-6fa3-4d3b-a322-95c2af08b49b",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "e7b468e8-3b2c-43ea-aabb-e8ba993bd7ae",
@@ -18163,11 +18163,11 @@
         },
         {
           "dest-uuid": "992c6fa4-689c-4ce1-883f-f48a8b1c5ccc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bff6f104-006e-48e5-ac3f-4633bb3abac5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "69ceab63-17ce-4e42-b247-055a180e6c2b",
@@ -18183,7 +18183,7 @@
       "related": [
         {
           "dest-uuid": "1f1d8e33-293a-4ceb-a91c-0cf71c6805ea",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "939808a7-121d-467a-b028-4441ee8b7cee",
@@ -18191,7 +18191,7 @@
         },
         {
           "dest-uuid": "c08bd552-98fd-446d-b848-3c43b3b766f1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1da26733-88c3-4cc8-8758-e2d65934f713",
@@ -18207,11 +18207,11 @@
       "related": [
         {
           "dest-uuid": "74aade7b-b61a-46d0-a68b-33fba4f09f6e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "96050801-dc36-462f-982e-df2806eaa3ea",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c3d4bdd9-2cfe-4a80-9d0c-07a29ecdce8f",
@@ -18219,11 +18219,11 @@
         },
         {
           "dest-uuid": "c7706ddb-cf88-41c7-981b-a5e1bf6cfcfc",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f931e587-28f8-4923-b054-98d6348dcafe",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ba7a75c6-fcf5-4f36-8908-1fe1c30f690f",
@@ -18243,11 +18243,11 @@
         },
         {
           "dest-uuid": "9cd8928d-a26d-42c0-8a23-0b10816c5d21",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ed67778-6277-4e12-aa3e-29f39a81e67a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0a21ca34-ffa0-4b6f-b88c-9ffdb6a7c38f",
@@ -18267,11 +18267,11 @@
         },
         {
           "dest-uuid": "a16c57b3-6a4c-4b15-92e9-d2d29f5b7d69",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f12b94b0-ec2f-4eb1-9ea4-8632e41475a1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "395c6e70-21f8-4613-bdec-96ecba03a5b4",
@@ -18287,7 +18287,7 @@
       "related": [
         {
           "dest-uuid": "3d01d29d-30f1-4b3b-bf04-54aca340a8eb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "774ad5bb-2366-4c13-a8a9-65e50b292e7c",
@@ -18307,7 +18307,7 @@
       "related": [
         {
           "dest-uuid": "a5c4230b-7064-4863-9a60-e0565042d452",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "acf8fd2a-dc98-43b4-8d37-64e10728e591",
@@ -18331,7 +18331,7 @@
         },
         {
           "dest-uuid": "d2cf1cf2-7b11-4018-b5bc-fbd48633f869",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0abd72c9-7d7f-4e8a-99d7-5ac2f791eb9d",
@@ -18351,7 +18351,7 @@
         },
         {
           "dest-uuid": "c0195ab2-3c4e-41ce-a1e4-7e58118abeb4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7bbdcd3b-241e-4ec8-ab43-6bd2c34ae77d",
@@ -18367,7 +18367,7 @@
       "related": [
         {
           "dest-uuid": "964fc2e0-96fc-4992-b89a-8101d47b7d8c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fc53309d-ebd5-4573-9242-57024ebdad4f",
@@ -18387,7 +18387,7 @@
       "related": [
         {
           "dest-uuid": "6c776c7a-0e2f-4963-9485-aa90149ae68e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bb4387ab-7a51-468b-bf5f-a9a8612f0303",
@@ -18395,7 +18395,7 @@
         },
         {
           "dest-uuid": "d5926b94-833c-4b29-b611-059f72fcda84",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0c01c90a-c8a9-40ee-b143-1e5b00f11e1f",
@@ -18411,11 +18411,11 @@
       "related": [
         {
           "dest-uuid": "7179bc7d-a2be-4ded-8c4f-88ec8f73e613",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9b036696-9e1e-42b9-9bfd-3ae785e7e10e",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a8c31121-852b-46bd-9ba4-674ae5afe7ad",
@@ -18435,7 +18435,7 @@
       "related": [
         {
           "dest-uuid": "5697a257-0888-4fd5-84fd-756f6fa67690",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ce0687a0-e692-4b77-964a-0784a8e54ff1",
@@ -18455,7 +18455,7 @@
       "related": [
         {
           "dest-uuid": "3b25198c-e31d-4e0c-9d26-eb8e714c71a8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "70910fbd-58dc-4c1c-8c48-814d11fcd022",
@@ -18475,7 +18475,7 @@
       "related": [
         {
           "dest-uuid": "332065d4-9895-485b-8674-756f4d3fab7c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c548d8c4-a0a3-4a24-bb79-2a84abbc7b36",
@@ -18499,7 +18499,7 @@
         },
         {
           "dest-uuid": "d86a141c-b4fa-48fd-a15b-2cd3254b3400",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "24ad5d49-a170-4e03-a194-3cc68ee81e1e",
@@ -18515,7 +18515,7 @@
       "related": [
         {
           "dest-uuid": "649ee05c-9f09-47fc-802a-7df2ce362563",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "693cdbff-ea73-49c6-ac3f-91e7285c31d1",
@@ -18523,7 +18523,7 @@
         },
         {
           "dest-uuid": "f2c74903-6770-4f55-9a11-edcf6e00938e",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "34fc0ca7-338c-4eb4-b4ac-618f56378dd5",
@@ -18539,7 +18539,7 @@
       "related": [
         {
           "dest-uuid": "a9a66c41-1b05-41fc-a866-272848b051ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cc723aff-ec88-40e3-a224-5af9fd983cc4",
@@ -18563,7 +18563,7 @@
         },
         {
           "dest-uuid": "462f9ed4-5b6b-4426-b383-cd331f2984c0",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "84e15e6c-ddc1-40a0-8e46-ba5605b6345b",
@@ -18583,7 +18583,7 @@
         },
         {
           "dest-uuid": "fbc0a210-8942-4fcb-81f1-a120551013d4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9c2fc530-8c91-458d-bb4e-6ec921ee2b85",
@@ -18603,7 +18603,7 @@
         },
         {
           "dest-uuid": "746ebd79-2d1f-4e58-8bdb-b49a236a9642",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cf1329da-a87c-42bb-8950-58fcf36b9b9b",
@@ -18623,7 +18623,7 @@
         },
         {
           "dest-uuid": "dda0e909-cceb-40eb-bff0-6bd0cd74e638",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "12a7802a-b0c2-4823-b03d-e59b2c4bc4de",
@@ -18639,7 +18639,7 @@
       "related": [
         {
           "dest-uuid": "240a8cec-0e3a-44ed-a485-4d212a21b127",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbe5b322-e2af-4a5e-9625-a4e62bf84ed3",
@@ -18659,7 +18659,7 @@
       "related": [
         {
           "dest-uuid": "5880eb25-eec5-4b40-a3fa-6a3c633a3e56",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f870408c-b1cd-49c7-a5c7-0ef0fc496cc6",
@@ -18683,11 +18683,11 @@
         },
         {
           "dest-uuid": "729a7413-3c5b-4637-a97b-9bba9f7734a7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c56cfd62-b8cb-49be-820b-e447a1605106",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1147c50d-907a-4c0d-8375-e23cadeae5f9",
@@ -18707,7 +18707,7 @@
         },
         {
           "dest-uuid": "24e641ec-e64a-4f2c-91b1-8bd400e97547",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "15afa7ae-955a-4c19-b48e-ad13b68d7a54",
@@ -18723,7 +18723,7 @@
       "related": [
         {
           "dest-uuid": "369938c8-6b9e-4eb3-8105-eb76a373dc35",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ed2c05a1-4f81-4d97-9e1b-aff01c34ae84",
@@ -18731,7 +18731,7 @@
         },
         {
           "dest-uuid": "f3068304-de28-4efa-96a5-a360fc7ffc97",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "6e373a06-358b-4078-a8ab-1f5c1730ddf4",
@@ -18751,7 +18751,7 @@
         },
         {
           "dest-uuid": "b123fe68-1da5-4c80-b4f0-f3d476891e11",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "33040f26-43e3-4c1d-8557-02f306bb028f",
@@ -18771,7 +18771,7 @@
         },
         {
           "dest-uuid": "e46455a1-a3a3-4de9-916d-41ffd2721062",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "55ddc6ba-a04a-4e68-bb34-741d38d2c33d",
@@ -18787,7 +18787,7 @@
       "related": [
         {
           "dest-uuid": "44d378d8-575b-41c8-b75c-375abcf3e2db",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9ef14445-6f35-4ed0-a042-5024f13a9242",
@@ -18807,11 +18807,11 @@
       "related": [
         {
           "dest-uuid": "42ce5243-8859-49dc-b221-2674536063ff",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "758e4b0e-3564-4696-8d57-9e3d81198d52",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a126c117-54e4-4b93-9e4f-72cc964e6760",
@@ -18835,7 +18835,7 @@
         },
         {
           "dest-uuid": "ab74118c-05e1-4acd-b1c2-445d1f7c5fd1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d50c5f8f-0091-4675-8264-abcb4247de26",
@@ -18851,7 +18851,7 @@
       "related": [
         {
           "dest-uuid": "4ec34db8-7214-4059-925e-bdcd58bca391",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "52eff1c7-dd30-4121-b762-24ae6fa61bbb",
@@ -18871,7 +18871,7 @@
       "related": [
         {
           "dest-uuid": "86a212ef-8e7b-4c51-9e7f-492da2283294",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e5d550f3-2202-4634-85f2-4a200a1d49b3",
@@ -18891,7 +18891,7 @@
       "related": [
         {
           "dest-uuid": "9eb9a81f-cf55-48f8-a8da-217a7684aff4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c2f59d25-87fe-44aa-8f83-e8e59d077bf5",
@@ -18915,7 +18915,7 @@
         },
         {
           "dest-uuid": "7101cd68-f6a2-4b7e-b19d-5d27b4c3b44c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1238c5f2-07ef-4a31-bc3a-e0cc0eb12516",
@@ -18931,11 +18931,11 @@
       "related": [
         {
           "dest-uuid": "166d394c-6d24-46d3-866e-4f57ca849e90",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "63e33566-c46c-45b8-acf1-247327b827e1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b7c0e45f-0206-4f75-96e7-fe7edad3aaff",
@@ -18959,7 +18959,7 @@
         },
         {
           "dest-uuid": "e4b35edc-f7fe-4f0d-aaaf-60fabc9d2698",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d6c1064c-9ea9-4067-835e-7c0627024b0c",
@@ -18979,7 +18979,7 @@
         },
         {
           "dest-uuid": "4ef6c517-011e-4155-897f-e86cea5824b4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "faa650c9-a469-45f1-870a-6acc448df9eb",
@@ -18995,7 +18995,7 @@
       "related": [
         {
           "dest-uuid": "095c16b2-3d9a-445a-82a4-fa7affd928f5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "28fdd23d-aee3-4afe-bc3f-5f1f52929258",
@@ -19003,7 +19003,7 @@
         },
         {
           "dest-uuid": "3fe80400-0e8c-4ffa-8233-cebf7511613c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "debfadd8-1df0-43b1-ae16-5f893dfc8bf3",
@@ -19019,7 +19019,7 @@
       "related": [
         {
           "dest-uuid": "66adf2b9-42aa-401f-8bc3-3830854017ee",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6ffad4be-bfe0-424f-abde-4d9a84a800ad",
@@ -19027,7 +19027,7 @@
         },
         {
           "dest-uuid": "c956f269-d282-4c68-afc6-ca68d8532ab6",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0bd280ab-7977-4ef9-b577-6c6a6014b179",
@@ -19043,7 +19043,7 @@
       "related": [
         {
           "dest-uuid": "5e90ac48-345b-445a-877f-596737ad7efb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "789ef15a-34d9-4b32-a779-8cbbc9eb32f5",
@@ -19051,7 +19051,7 @@
         },
         {
           "dest-uuid": "cbdcf6f3-00c3-4c38-bc7c-ffb6806f0a25",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0ec6ab45-a114-4ded-ba5e-a16982ccd64b",
@@ -19067,27 +19067,27 @@
       "related": [
         {
           "dest-uuid": "6e5bfc6b-3f07-426b-ac9f-6a8cc6b591c3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "791ea4ff-7a49-4aa7-a41c-51288031e0f0",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "7d099bc4-1a19-4aa3-b12b-a9390e98408a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8cbeecbb-429f-4f30-9f42-266aaa7b2c0f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8e1872c2-906c-4cf8-b0c7-afd448fe1c0b",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a789e535-cab9-49b4-9685-c10a5d3642b4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cd25c1b4-935c-4f0e-ba8d-552f28bc4783",
@@ -19107,11 +19107,11 @@
       "related": [
         {
           "dest-uuid": "a0bb0e33-c40f-46f5-b64a-07faa6946d83",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ab85ff40-2b75-477a-b5ec-f35f2fcde728",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c6a146ae-9c63-4606-97ff-e261e76e8380",
@@ -19135,7 +19135,7 @@
         },
         {
           "dest-uuid": "4e469a08-db8b-49c1-8bf6-f76ffa21860f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "a1757dd9-9abb-4fd1-a06d-6cbfd80d77e9",
@@ -19151,19 +19151,19 @@
       "related": [
         {
           "dest-uuid": "1305f37f-8333-4d86-9714-340b66c65771",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2266c86a-a47e-46ac-aa6d-c1eb6d49a1e5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "250d2977-7b94-4041-a299-0f2f1532eb95",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5c7a8194-f0cb-498a-98c6-5928859bf79f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c9e0c59e-162e-40a4-b8b1-78fab4329ada",
@@ -19171,7 +19171,7 @@
         },
         {
           "dest-uuid": "e4246c20-fbe4-4750-a29e-44e3fe179bf2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1e08be7e-451c-4b10-9e65-b6dbf8d54b38",
@@ -19191,11 +19191,11 @@
         },
         {
           "dest-uuid": "5c5225c4-2d35-431e-830d-ea1cc649c6ba",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "5d07c07e-4cde-41b9-a03e-94be43ca9bb8",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0e600ee5-de14-46f8-ada2-c0aee4ce969e",
@@ -19215,7 +19215,7 @@
         },
         {
           "dest-uuid": "da084995-0644-4152-a72d-44034845173a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "f33df6a5-7f05-415c-9971-18918c8ed4fa",
@@ -19231,11 +19231,11 @@
       "related": [
         {
           "dest-uuid": "2f0ca83e-1318-4722-88b2-1bffedb5d127",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4b2e7e2d-e1be-4829-9011-53eb5eca3dc6",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c4b96c0b-cb58-497a-a1c2-bb447d79d692",
@@ -19255,7 +19255,7 @@
       "related": [
         {
           "dest-uuid": "4403499c-b81c-4d0e-896c-67178547ac18",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "506f6f49-7045-4156-9007-7474cb44ad6d",
@@ -19275,11 +19275,11 @@
       "related": [
         {
           "dest-uuid": "28304317-cbde-45cd-bf0b-99b5cd8d1478",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "31d95dc7-aec7-47a2-bbb4-8b20ca3bc184",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "498e7b81-238d-404c-aa5e-332904d63286",
@@ -19303,7 +19303,7 @@
         },
         {
           "dest-uuid": "8619af40-05db-49a7-b7b8-476facfd4b2c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4c5608c3-b5ca-4c8e-932e-ad6c55683cd1",
@@ -19319,7 +19319,7 @@
       "related": [
         {
           "dest-uuid": "97b0c549-88d2-4739-a081-a9113e25cf1a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "edadea33-549c-4ed1-9783-8f5a5853cbdf",
@@ -19339,7 +19339,7 @@
       "related": [
         {
           "dest-uuid": "4623e949-e902-4a8c-893b-73e5ab4b57d5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6683aa0c-d98a-4f5b-ac57-ca7e9934a760",
@@ -19347,7 +19347,7 @@
         },
         {
           "dest-uuid": "d942e493-32eb-4302-890b-7729f63b7202",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3e6673dc-e2c7-440e-b632-d25e3e9f92cc",
@@ -19363,7 +19363,7 @@
       "related": [
         {
           "dest-uuid": "2df1959e-8ec4-4193-9cb8-c089c78b4d1c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "648f8051-1a35-46d3-b1d8-3a3f5cf2cc8e",
@@ -19387,7 +19387,7 @@
         },
         {
           "dest-uuid": "f6be418e-3fed-4026-b665-f055465c7359",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5848450c-38a7-421d-910c-9a10870f4ea3",
@@ -19403,7 +19403,7 @@
       "related": [
         {
           "dest-uuid": "2eb3d192-6e04-4e42-af63-ed3f54f65285",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cdfc5f0a-9bb9-4352-b896-553cfa2d8fd8",
@@ -19423,15 +19423,15 @@
       "related": [
         {
           "dest-uuid": "031ed94b-50d9-451e-a853-29ee8d845773",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "31adce9b-8935-4abf-aaf2-0a13047e25e4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4a92d2e9-fc28-4eac-9b3d-113e74d7bf2d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "774a3188-6ba9-4dc4-879d-d54ee48a5ce9",
@@ -19451,7 +19451,7 @@
       "related": [
         {
           "dest-uuid": "1fec971d-c822-4819-9489-8c27857e3481",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "84771bc3-f6a0-403e-b144-01af70e5fda0",
@@ -19475,7 +19475,7 @@
         },
         {
           "dest-uuid": "91f5dbce-d334-4b42-9554-e94866d75a26",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "020447ec-f030-4b95-a187-255177b69d9f",
@@ -19495,11 +19495,11 @@
         },
         {
           "dest-uuid": "75a0da5c-9f2b-4e96-bb94-10c30f16a9a2",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d4dc642d-922b-4476-ad3f-ba23c43702f5",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "34d06ebf-867e-4cd2-8e44-c849fcaab072",
@@ -19515,7 +19515,7 @@
       "related": [
         {
           "dest-uuid": "06c3cd77-148a-424e-a55e-1e11ff3d9504",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "1cec9319-743b-4840-bb65-431547bce82a",
@@ -19535,11 +19535,11 @@
       "related": [
         {
           "dest-uuid": "52a370ec-dca2-45e0-bba7-7384816945e8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "81a49b9b-c8cf-438c-bea0-e09149f50b34",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfe29258-ce59-421c-9dee-e85cb9fa90cd",
@@ -19559,11 +19559,11 @@
       "related": [
         {
           "dest-uuid": "05191336-6d06-41f7-babb-5d079e4168ae",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "93a35555-f71e-4230-9f2a-529a539e8612",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "dfafc230-5465-4993-8dc5-f51fa9fec002",
@@ -19583,7 +19583,7 @@
       "related": [
         {
           "dest-uuid": "38e2eb61-e650-4cdc-8f27-213b39499d34",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a9fa0d30-a8ff-45bf-922e-7720da0b7922",
@@ -19591,7 +19591,7 @@
         },
         {
           "dest-uuid": "abfa1de9-fcf5-44da-a910-f83273b60813",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "0cb492cd-7d01-46b2-b1f4-afddec10eaf2",
@@ -19611,7 +19611,7 @@
         },
         {
           "dest-uuid": "97ec7ade-18b7-43b7-b267-85470862b6ac",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "1f7b4b6e-17ab-446f-ac4e-5a1e79569dd3",
@@ -19627,7 +19627,7 @@
       "related": [
         {
           "dest-uuid": "4ba44323-b5b0-46c9-be94-f2c5d0fdbec5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e3b168bd-fcd7-439e-9382-2e6c2f63514d",
@@ -19647,7 +19647,7 @@
       "related": [
         {
           "dest-uuid": "a62c45c3-3471-4366-9f7c-738fbd9473bd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d21bb61f-08ad-4dc1-b001-81ca6cb79954",
@@ -19671,7 +19671,7 @@
         },
         {
           "dest-uuid": "babb8a91-12af-4f2d-be59-2df099acc06c",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "4cadb231-5487-4135-834b-d0db75a93a45",
@@ -19687,7 +19687,7 @@
       "related": [
         {
           "dest-uuid": "058452ee-f484-4e2f-b2ad-d562e34847fb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "6ee2dc99-91ad-4534-a7d8-a649358c331f",
@@ -19707,7 +19707,7 @@
       "related": [
         {
           "dest-uuid": "83b759ca-097c-4d9f-926b-fb41e0740644",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "99e6295e-741b-4857-b6e5-64989eb039b4",
@@ -19715,7 +19715,7 @@
         },
         {
           "dest-uuid": "f34fef81-f714-4e26-ae99-3c970959cd0d",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ac9d1b33-cfba-415e-aef2-c4c0b359ed5f",
@@ -19731,7 +19731,7 @@
       "related": [
         {
           "dest-uuid": "705ecef8-b41e-4b1f-bd7c-f3b2ff930c11",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8982a661-d84c-48c0-b4ec-1db29c6cf3bc",
@@ -19751,7 +19751,7 @@
       "related": [
         {
           "dest-uuid": "4476a312-d2c9-459e-96a3-53ac0b676c52",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "d8940e76-f9c1-4912-bea6-e21c251370b6",
@@ -19759,7 +19759,7 @@
         },
         {
           "dest-uuid": "e6c05bf0-e6d6-46f9-ba38-11b58fbf2f26",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "cb6a0874-0cb3-4d44-a77e-e93d4a26d50b",
@@ -19779,7 +19779,7 @@
         },
         {
           "dest-uuid": "8a75f571-49f8-4df8-b02c-fad2189273ee",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3268135a-a73f-4594-95e6-6ea8813a39d3",
@@ -19799,7 +19799,7 @@
         },
         {
           "dest-uuid": "816aaddd-dc6d-49da-8ecd-8afde6278181",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7f3e2c35-7394-4cc6-baef-73a830930953",
@@ -19815,7 +19815,7 @@
       "related": [
         {
           "dest-uuid": "db6010df-737d-4fa1-89af-dce6c4c3c305",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "ec4be82f-940c-4dcb-87fe-2bbdd17c692f",
@@ -19839,7 +19839,7 @@
         },
         {
           "dest-uuid": "96e1107e-7fbe-49a2-b425-9d85a6ff46df",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "56752265-8647-4ce2-bc6c-c38c2e14685c",
@@ -19859,7 +19859,7 @@
         },
         {
           "dest-uuid": "4384e648-0f49-442d-b989-6a47f2194130",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "31fef61c-301b-4a3d-aced-06632e321926",
@@ -19875,7 +19875,7 @@
       "related": [
         {
           "dest-uuid": "a69604d3-2909-46bf-afd3-39b47ac5e5fd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b327a9c0-e709-495c-aa6e-00b042136e2b",
@@ -19899,11 +19899,11 @@
         },
         {
           "dest-uuid": "1f3c9114-ac86-4c1f-bb64-fb94d65ac78c",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "4b4a369c-35aa-4389-a218-2034fb043041",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "bce77859-548a-4ee7-8002-a05b182bb5ae",
@@ -19919,7 +19919,7 @@
       "related": [
         {
           "dest-uuid": "427fe5c7-1b91-4d71-ae2c-6840d128f0bd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "73c26732-6422-4081-8b63-6d0ae93d449e",
@@ -19939,11 +19939,11 @@
       "related": [
         {
           "dest-uuid": "421fc6dc-1275-4eca-9950-150ad27d9bfd",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b1674dca-753f-45d9-b0de-4c68e459f046",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "c6421411-ae61-42bb-9098-73fddb315002",
@@ -19963,7 +19963,7 @@
       "related": [
         {
           "dest-uuid": "44001c2d-9832-4b2d-b3ac-a25cea93e03f",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "81033c3b-16a4-46e4-8fed-9b030dd03c4a",
@@ -19987,7 +19987,7 @@
         },
         {
           "dest-uuid": "e13d662d-a496-4997-b26a-39e71eb17fc2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5560747b-ad67-478e-b3f2-14e55864e532",
@@ -20007,7 +20007,7 @@
         },
         {
           "dest-uuid": "f2f01ea3-a59c-42b1-b934-83065ae1f785",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "574d055c-4501-4f4d-9b28-1109ad07a087",
@@ -20023,7 +20023,7 @@
       "related": [
         {
           "dest-uuid": "6f77061e-d663-487d-bfca-cd1e1f1d24d7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e0b9ecb8-a7d1-43c7-aa30-8e19c6a92c86",
@@ -20031,7 +20031,7 @@
         },
         {
           "dest-uuid": "e0ee0af8-96f8-4baf-b0f2-63d4b49938f2",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "03c7f8c1-0239-44a2-89e2-4cd6b47940ac",
@@ -20051,7 +20051,7 @@
         },
         {
           "dest-uuid": "80e453fd-8191-474a-b577-7a575ef5fe87",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "ce26e75b-f8bf-45d5-b0fd-601e3d8fd800",
@@ -20067,7 +20067,7 @@
       "related": [
         {
           "dest-uuid": "56622fce-489a-4ed9-b1fb-e525939667d4",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bed04f7d-e48a-4e76-bd0f-4c57fe31fc46",
@@ -20091,7 +20091,7 @@
         },
         {
           "dest-uuid": "e6500f0c-41bd-4e04-ad9d-4a3121803175",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "71b2e30c-f793-42a8-85be-f782c908772c",
@@ -20111,7 +20111,7 @@
         },
         {
           "dest-uuid": "89ee35d2-02ec-4c36-b51c-50e686eb3012",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5d826975-65f1-4515-b8c1-15cecd3339ac",
@@ -20131,7 +20131,7 @@
         },
         {
           "dest-uuid": "985e0098-b77c-4099-a262-5f195b654187",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c9242c28-ee1a-45d2-800a-948252884a7c",
@@ -20151,7 +20151,7 @@
         },
         {
           "dest-uuid": "cce3f1e3-a688-4519-bd9b-0ec5ba57bc11",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "df374bac-bd69-4351-be3f-1bd863c429ad",
@@ -20167,7 +20167,7 @@
       "related": [
         {
           "dest-uuid": "098f0607-df17-4291-a1b1-a8e3374c075a",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9b00925a-7c4b-4e53-bfc8-9a6a806fde03",
@@ -20191,11 +20191,11 @@
         },
         {
           "dest-uuid": "36ca4ab8-1a16-4989-89e6-8d20c514c8c7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "384bbe3f-bb48-4bf3-927e-3a95d13eae82",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "7a96a921-48bc-4fcf-b6b8-86a96315d4ee",
@@ -20211,11 +20211,11 @@
       "related": [
         {
           "dest-uuid": "08a391a7-1ce6-4f11-b060-fca06ef03328",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "54eb86ed-2a72-41a8-b060-2750c2fee758",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "824add00-99a1-4b15-9a2d-6c5683b7b497",
@@ -20223,7 +20223,7 @@
         },
         {
           "dest-uuid": "e61d2099-1517-4bf4-b2e6-6e61cdf94be3",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "63d80d1b-ca5b-427d-b603-cf65e6e245b9",
@@ -20239,7 +20239,7 @@
       "related": [
         {
           "dest-uuid": "193167de-400a-4ea3-a8db-93e4bf628068",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "2b5aa86b-a0df-4382-848d-30abea443327",
@@ -20259,7 +20259,7 @@
       "related": [
         {
           "dest-uuid": "888e8587-e490-4509-9226-e72b32466618",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "91177e6d-b616-4a03-ba4b-f3b32f7dda75",
@@ -20283,7 +20283,7 @@
         },
         {
           "dest-uuid": "fed95f58-2b3a-46c5-a4b1-a3d378d036cb",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "500c6151-e3d6-4c3e-8d46-6e58df27f497",
@@ -20299,7 +20299,7 @@
       "related": [
         {
           "dest-uuid": "b6d679b6-0777-4541-874c-d81f37d8fb07",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f856eaab-e84a-4265-a8a2-7bf37e5dc2fc",
@@ -20307,7 +20307,7 @@
         },
         {
           "dest-uuid": "ff9c219a-b8e7-4b0a-8ea5-4f81341375d1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d314d955-a323-4e87-a8e5-317b0b8ed203",
@@ -20323,11 +20323,11 @@
       "related": [
         {
           "dest-uuid": "7f8717e8-fea8-42db-b60c-c64375630685",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "8c29fa0f-6b35-40c2-9c99-081a0997db86",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b1c95426-2550-4621-8028-ceebf28b3a47",
@@ -20351,7 +20351,7 @@
         },
         {
           "dest-uuid": "8ad0cc97-4f6e-4ea0-a930-3fdb6b0df819",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "c377533f-702a-4e82-a254-9855b9362c22",
@@ -20371,7 +20371,7 @@
         },
         {
           "dest-uuid": "dd1b3351-f8e5-480e-9e7d-f9cfbbf01409",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "2d8db41e-e12e-46ff-be11-2810b0a2acb5",
@@ -20387,7 +20387,7 @@
       "related": [
         {
           "dest-uuid": "8722b13a-1b20-4f2e-991b-153a26bba2a8",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "b85f6ce5-81e8-4f36-aff2-3df9d02a9c9d",
@@ -20411,7 +20411,7 @@
         },
         {
           "dest-uuid": "b5842814-7d1b-484d-acd8-d1f776c6851f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "92955a28-74fb-4f60-834a-10dc93377140",
@@ -20427,7 +20427,7 @@
       "related": [
         {
           "dest-uuid": "6f7fa682-fd50-4de4-add3-cbaa3c127b70",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "a2fdce72-04b2-409a-ac10-cc1695f4fce0",
@@ -20447,7 +20447,7 @@
       "related": [
         {
           "dest-uuid": "41990c88-06e2-4453-88bf-6bebe776a9a1",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f4b843c1-7e92-4701-8fed-ce82f8be2636",
@@ -20471,7 +20471,7 @@
         },
         {
           "dest-uuid": "2a3b0030-05b4-4b85-a33c-dda07472f31f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "04f78d17-4599-4ecd-9a8f-f221ab2759cc",
@@ -20491,7 +20491,7 @@
         },
         {
           "dest-uuid": "68a7b414-9864-46c6-b629-bec6f07b5c31",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "354dfdf4-9da9-45b5-909c-13f5702fc263",
@@ -20511,7 +20511,7 @@
         },
         {
           "dest-uuid": "c755e8b9-7e07-4e9a-95a1-bc7cb88e878a",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "9695c6af-f3cc-40fa-b3a1-351014c6282f",
@@ -20531,7 +20531,7 @@
         },
         {
           "dest-uuid": "e9808ca9-3019-4395-b2d8-717f5d4863fe",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "3058b630-ede1-4bbb-b8ce-985d802e1e8d",
@@ -20551,11 +20551,11 @@
         },
         {
           "dest-uuid": "6bd50b74-5852-4800-b459-1c54d95348e3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cbb3d486-b7a3-44f0-a7c7-e2fbf668f6fa",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "98f14414-883e-4da3-930a-19a8faa1be41",
@@ -20571,7 +20571,7 @@
       "related": [
         {
           "dest-uuid": "0cadbf9f-befa-4bd8-85b8-e5af53383953",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "f9cc4d06-775f-4ee1-b401-4e2cc0da30ba",
@@ -20595,7 +20595,7 @@
         },
         {
           "dest-uuid": "81f695b5-7621-4a82-8036-536c6687b5b4",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "40b862cb-89a4-4200-baa0-bb171ecc2ce2",
@@ -20611,7 +20611,7 @@
       "related": [
         {
           "dest-uuid": "1b067cad-c75b-484e-8aaa-4b058c8ec9f7",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "31225cd3-cd46-4575-b287-c2c14011c074",
@@ -20635,7 +20635,7 @@
         },
         {
           "dest-uuid": "d52fee09-db6e-4fe5-a859-7f3d273e85f0",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "02aecf08-08b1-4f08-9272-c1fc98b5f72e",
@@ -20655,7 +20655,7 @@
         },
         {
           "dest-uuid": "de93de79-3f24-4022-9b03-7228ffacca6f",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "5c228796-349e-4d7e-a3ca-51a5f8cbf294",
@@ -20675,7 +20675,7 @@
         },
         {
           "dest-uuid": "b2ef244c-b230-4c2b-b0a6-070e5c376f32",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "b44bea1e-fc01-4c6b-b7c4-dcb0135de936",
@@ -20691,11 +20691,11 @@
       "related": [
         {
           "dest-uuid": "2f2ed160-9093-4b1f-b781-8660552bf1e5",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "9b4be141-9743-4113-a5f6-2d1a019b0eeb",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e422b6fa-4739-46b9-992e-82f1b350c780",
@@ -20715,11 +20715,11 @@
       "related": [
         {
           "dest-uuid": "07b782b2-7e86-424a-9395-0a862d9b25c3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "cd82f432-ee4e-4df0-8500-e381b36479ec",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "defc1257-4db1-4fb3-8ef5-bb77f63146df",
@@ -20743,7 +20743,7 @@
         },
         {
           "dest-uuid": "fd652339-e12f-4295-b843-0665680054bd",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "427d7e41-293a-4616-aec7-d5eea56431d0",
@@ -20759,7 +20759,7 @@
       "related": [
         {
           "dest-uuid": "0fc0c7ce-e56d-4f3f-ab91-903861124816",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "e196b5c5-8118-4a1c-ab8a-936586ce3db5",
@@ -20779,7 +20779,7 @@
       "related": [
         {
           "dest-uuid": "1762aa55-010b-4a26-b439-7afcfcc5613d",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "bbc3cba7-84ae-410d-b18b-16750731dfa2",
@@ -20799,7 +20799,7 @@
       "related": [
         {
           "dest-uuid": "cda313bc-214f-4bf8-9aa2-b3fb495379c3",
-          "type": "analyzes"
+          "type": "composed-of"
         },
         {
           "dest-uuid": "fa801609-ca8e-415e-815e-65f3826ff4df",
@@ -20823,7 +20823,7 @@
         },
         {
           "dest-uuid": "9ead155d-e99b-4cca-8ace-0a90d533e875",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "d6c882c8-0f01-4027-b988-b979d60e0030",
@@ -20843,7 +20843,7 @@
         },
         {
           "dest-uuid": "da8a7d00-6f8a-4bc6-9863-3a434c9d36c1",
-          "type": "analyzes"
+          "type": "composed-of"
         }
       ],
       "uuid": "967d05e3-0d40-40d9-a94e-f32e17397404",

--- a/tools/gen_mitre.py
+++ b/tools/gen_mitre.py
@@ -230,7 +230,7 @@ for domain in domains:
                 for ref in item['x_mitre_analytic_refs']:
                     ref_data = {
                         "dest-uuid": re.findall(r'--([0-9a-f-]+)', ref).pop(),
-                        "type": 'analyzes',
+                        "type": 'composed-of',
                     }
                     if 'related' not in value:
                         value['related'] = [ref_data]


### PR DESCRIPTION
Thank you for maintaining misp-galaxy :)

I added an `Analytics` reference to `Detection Strategy` Galaxy. I would appreciate your candid feedback. 
Thank you for your time.

https://attack.mitre.org/detectionstrategies/DET0210/
<img width="1710" height="1107" alt="スクリーンショット 2026-01-07 0 44 44" src="https://github.com/user-attachments/assets/f5333def-1919-41e4-a439-3f2d8c6abc46" />
