### PR TITLE
Add Operating Systems galaxy and cluster with platform metadata

### DIFF
--- a/clusters/operating-system.json
+++ b/clusters/operating-system.json
@@ -1,0 +1,648 @@
+{
+  "authors": [
+    "MISP Project"
+  ],
+  "category": "software",
+  "description": "Operating systems galaxy including major desktop, server, mobile, embedded, and mainframe operating systems with platform metadata.",
+  "name": "Operating Systems",
+  "source": "Open Sources",
+  "type": "operating-system",
+  "uuid": "0c5ba608-9f94-4354-ab31-ed4d8d517c8d",
+  "values": [
+    {
+      "description": "IBM UNIX operating system for enterprise servers.",
+      "meta": {
+        "kernel": "Monolithic (UNIX)",
+        "license": "Proprietary",
+        "platforms": [
+          "server"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "IBM"
+        ]
+      },
+      "uuid": "f94c9772-9ac6-4d50-92d6-78c26ad33361",
+      "value": "AIX"
+    },
+    {
+      "description": "Linux-based mobile operating system maintained by Google.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source core with proprietary components",
+        "platforms": [
+          "mobile",
+          "tablet",
+          "wearable",
+          "tv"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Google",
+          "Open Handset Alliance"
+        ]
+      },
+      "uuid": "1b3a0e94-7e5e-467c-a3e7-c5138ae77739",
+      "value": "Android"
+    },
+    {
+      "description": "Linux-based operating system from Google for Chromebook devices.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source core with proprietary components",
+        "platforms": [
+          "desktop",
+          "laptop"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Google"
+        ]
+      },
+      "uuid": "dfdc1357-8921-42df-bacc-cafa0e56a531",
+      "value": "ChromeOS"
+    },
+    {
+      "description": "Community-maintained GNU/Linux distribution.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "cloud"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Debian Project"
+        ]
+      },
+      "uuid": "1ceeca18-9408-4092-91b4-b87ee3513520",
+      "value": "Debian"
+    },
+    {
+      "description": "Unix-like operating system descended from FreeBSD.",
+      "meta": {
+        "kernel": "Hybrid",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "DragonFly BSD Project"
+        ]
+      },
+      "uuid": "fcb71bb8-fb67-4f21-bfe1-d658a02c714d",
+      "value": "DragonFly BSD"
+    },
+    {
+      "description": "Community Linux distribution sponsored by Red Hat.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "cloud"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Fedora Project"
+        ]
+      },
+      "uuid": "6596bd93-d5bf-48f3-8a05-496120caec82",
+      "value": "Fedora Linux"
+    },
+    {
+      "description": "Unix-like operating system focused on performance and networking.",
+      "meta": {
+        "kernel": "Monolithic with modular extensions",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "network appliance"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "The FreeBSD Project"
+        ]
+      },
+      "uuid": "45866a8c-9c52-44d2-8c6a-16f58f9ef88e",
+      "value": "FreeBSD"
+    },
+    {
+      "description": "Capability-based operating system from Google using the Zircon kernel.",
+      "meta": {
+        "kernel": "Microkernel",
+        "license": "Open source",
+        "platforms": [
+          "mobile",
+          "embedded",
+          "iot"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Google"
+        ]
+      },
+      "uuid": "e8e40860-ff27-4bc5-8d6f-7e1aff12b0bc",
+      "value": "Fuchsia"
+    },
+    {
+      "description": "Hewlett Packard Enterprise UNIX operating system.",
+      "meta": {
+        "kernel": "Monolithic (UNIX)",
+        "license": "Proprietary",
+        "platforms": [
+          "server"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Hewlett Packard Enterprise"
+        ]
+      },
+      "uuid": "d4d7acec-c030-4bc8-b175-8f646249d097",
+      "value": "HP-UX"
+    },
+    {
+      "description": "Apple mobile operating system for iPhone.",
+      "meta": {
+        "kernel": "Hybrid (XNU)",
+        "license": "Proprietary",
+        "platforms": [
+          "mobile"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Apple"
+        ]
+      },
+      "uuid": "b53c6c86-17bf-4f22-93db-2b2d2b74fc66",
+      "value": "iOS"
+    },
+    {
+      "description": "Apple operating system for iPad devices.",
+      "meta": {
+        "kernel": "Hybrid (XNU)",
+        "license": "Proprietary",
+        "platforms": [
+          "tablet"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Apple"
+        ]
+      },
+      "uuid": "0f183000-fa7e-4238-b07a-54e3486f7bbf",
+      "value": "iPadOS"
+    },
+    {
+      "description": "Mobile operating system targeting feature phones.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Mixed",
+        "platforms": [
+          "mobile",
+          "feature phone"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "KaiOS Technologies"
+        ]
+      },
+      "uuid": "04fd431a-7be2-4b9c-b808-d64c7b465d01",
+      "value": "KaiOS"
+    },
+    {
+      "description": "Kernel family used by many distributions and embedded systems.",
+      "meta": {
+        "kernel": "Monolithic with modules",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "cloud",
+          "embedded",
+          "iot"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Linux community"
+        ]
+      },
+      "uuid": "0eafbce4-9693-4e34-84a7-492b2c7c18d7",
+      "value": "Linux"
+    },
+    {
+      "description": "Apple desktop operating system for Mac computers.",
+      "meta": {
+        "kernel": "Hybrid (XNU)",
+        "license": "Proprietary",
+        "platforms": [
+          "desktop",
+          "laptop"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Apple"
+        ]
+      },
+      "uuid": "9b5f3b84-5334-4541-9242-f634fdd0f704",
+      "value": "macOS"
+    },
+    {
+      "description": "Portable Unix-like operating system with broad architecture support.",
+      "meta": {
+        "kernel": "Monolithic with modules",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "embedded"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "The NetBSD Foundation"
+        ]
+      },
+      "uuid": "cbbd799c-c2e5-4ba2-b28b-60323757a146",
+      "value": "NetBSD"
+    },
+    {
+      "description": "Security-focused Unix-like operating system.",
+      "meta": {
+        "kernel": "Monolithic with modules",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "network appliance"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "The OpenBSD Project"
+        ]
+      },
+      "uuid": "9a9d3923-2560-4d1e-9a4c-07991f89c452",
+      "value": "OpenBSD"
+    },
+    {
+      "description": "Multi-user operating system for high-availability systems.",
+      "meta": {
+        "kernel": "Monolithic",
+        "license": "Proprietary",
+        "platforms": [
+          "server"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "VMS Software Inc."
+        ]
+      },
+      "uuid": "8c7328d2-2dd8-4758-bbb7-36d4bdc1ab2f",
+      "value": "OpenVMS"
+    },
+    {
+      "description": "UNIX operating system from Oracle.",
+      "meta": {
+        "kernel": "Monolithic (UNIX)",
+        "license": "Proprietary",
+        "platforms": [
+          "server"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Oracle"
+        ]
+      },
+      "uuid": "8991c297-9950-445b-a876-0cbde0422a13",
+      "value": "Oracle Solaris"
+    },
+    {
+      "description": "Real-time operating system used in embedded and automotive devices.",
+      "meta": {
+        "kernel": "Microkernel",
+        "license": "Proprietary",
+        "platforms": [
+          "embedded",
+          "automotive",
+          "industrial"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "BlackBerry"
+        ]
+      },
+      "uuid": "0d4ae6ca-223f-4006-a977-36f65084a664",
+      "value": "QNX"
+    },
+    {
+      "description": "Commercial Linux distribution for enterprise workloads.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source with commercial support",
+        "platforms": [
+          "server",
+          "desktop",
+          "cloud"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Red Hat"
+        ]
+      },
+      "uuid": "d40a32b2-1cd1-407f-a6b4-fc251fb7803d",
+      "value": "Red Hat Enterprise Linux"
+    },
+    {
+      "description": "Community enterprise Linux distribution compatible with RHEL.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source",
+        "platforms": [
+          "server",
+          "cloud"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Rocky Enterprise Software Foundation"
+        ]
+      },
+      "uuid": "bd9be656-71ad-47a7-af53-3c6e9676c6be",
+      "value": "Rocky Linux"
+    },
+    {
+      "description": "Enterprise Linux distribution by SUSE.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source with commercial support",
+        "platforms": [
+          "server",
+          "desktop",
+          "cloud"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "SUSE"
+        ]
+      },
+      "uuid": "f17ba8dc-12a4-466c-b85f-1e73463c571d",
+      "value": "SUSE Linux Enterprise"
+    },
+    {
+      "description": "Linux-based operating system for wearables, TVs, and IoT devices.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source",
+        "platforms": [
+          "wearable",
+          "tv",
+          "iot",
+          "mobile"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Tizen Project"
+        ]
+      },
+      "uuid": "c2660af0-7730-46fb-8b35-e0e9457c71cb",
+      "value": "Tizen"
+    },
+    {
+      "description": "Debian-based Linux distribution by Canonical.",
+      "meta": {
+        "kernel": "Monolithic (Linux)",
+        "license": "Open source",
+        "platforms": [
+          "desktop",
+          "server",
+          "cloud",
+          "iot"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Canonical"
+        ]
+      },
+      "uuid": "6afc875d-a67e-4966-b485-13cabb74e8ad",
+      "value": "Ubuntu"
+    },
+    {
+      "description": "Family of multiuser operating systems derived from original Unix designs.",
+      "meta": {
+        "kernel": "Mostly monolithic",
+        "license": "Mixed",
+        "platforms": [
+          "server",
+          "workstation"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Multiple vendors"
+        ]
+      },
+      "uuid": "3827cfd7-1c2e-4fae-bfb7-b978561b2df1",
+      "value": "UNIX"
+    },
+    {
+      "description": "Apple operating system for Apple Watch.",
+      "meta": {
+        "kernel": "Hybrid (XNU)",
+        "license": "Proprietary",
+        "platforms": [
+          "wearable"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Apple"
+        ]
+      },
+      "uuid": "b2a542e0-a315-4067-9471-77dd1f7d1e3a",
+      "value": "watchOS"
+    },
+    {
+      "description": "Microsoft operating system family for desktops, servers, and endpoints.",
+      "meta": {
+        "kernel": "Hybrid (NT)",
+        "license": "Proprietary",
+        "platforms": [
+          "desktop",
+          "server",
+          "cloud",
+          "iot"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Microsoft"
+        ]
+      },
+      "uuid": "ca24393c-a975-47fe-a5f9-d454747e37c9",
+      "value": "Windows"
+    },
+    {
+      "description": "Microsoft server operating system family.",
+      "meta": {
+        "kernel": "Hybrid (NT)",
+        "license": "Proprietary",
+        "platforms": [
+          "server",
+          "cloud"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Microsoft"
+        ]
+      },
+      "uuid": "e6ec738a-ed29-4907-b623-cc5ab1f0f6e4",
+      "value": "Windows Server"
+    },
+    {
+      "description": "Windows editions for embedded and IoT environments.",
+      "meta": {
+        "kernel": "Hybrid (NT)",
+        "license": "Proprietary",
+        "platforms": [
+          "embedded",
+          "iot"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Microsoft"
+        ]
+      },
+      "uuid": "f355fc34-1387-4225-947e-f581c69e3644",
+      "value": "Windows IoT"
+    },
+    {
+      "description": "Open source real-time operating system for resource-constrained devices.",
+      "meta": {
+        "kernel": "Microkernel",
+        "license": "Open source",
+        "platforms": [
+          "embedded",
+          "iot"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "Zephyr Project"
+        ]
+      },
+      "uuid": "82cc5fb8-9604-4617-a1f6-4396a28eea17",
+      "value": "Zephyr"
+    },
+    {
+      "description": "IBM mainframe operating system.",
+      "meta": {
+        "kernel": "Monolithic",
+        "license": "Proprietary",
+        "platforms": [
+          "mainframe",
+          "server"
+        ],
+        "refs": [
+          "https://en.wikipedia.org/wiki/List_of_operating_systems",
+          "https://www.nist.gov/itl/applied-cybersecurity/national-vulnerability-database"
+        ],
+        "vendor": [
+          "IBM"
+        ]
+      },
+      "uuid": "9219726c-5b67-4c85-a49e-f0a2709bc51f",
+      "value": "z/OS"
+    }
+  ],
+  "version": 1
+}

--- a/galaxies/operating-system.json
+++ b/galaxies/operating-system.json
@@ -1,0 +1,9 @@
+{
+  "description": "Operating systems galaxy including major desktop, server, mobile, embedded, and mainframe operating systems with platform metadata.",
+  "icon": "laptop",
+  "name": "Operating Systems",
+  "namespace": "misp",
+  "type": "operating-system",
+  "uuid": "0c5ba608-9f94-4354-ab31-ed4d8d517c8d",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide a first-class Operating Systems galaxy to cover major desktop, server, mobile, embedded/IoT, and mainframe OSes to address platform mapping needs (see issue referenced). 
- Include per-OS metadata to enable richer enrichment and tooling (platforms, vendor, kernel, license, and references).

### Description
- Added `galaxies/operating-system.json` defining a new `operating-system` galaxy (name, description, icon, namespace, type, uuid, version). 
- Added `clusters/operating-system.json` containing the new **Operating Systems** cluster with a curated list of OS entries and per-entry `meta` fields: `platforms`, `vendor`, `kernel`, `license`, and `refs`. 
- Assigned UUIDs for the galaxy and each cluster entry and formatted JSON to repo conventions using the project tooling. 

### Testing
- Ran `./jq_all_the_things.sh` to normalize and validate JSON formatting and it completed successfully. 
- Ran `./validate_all.sh` which executed schema validation over galaxies and clusters; the script initially exited non-zero when uncommitted working-tree changes were present, and content was then normalized and validated as part of the workflow. 
- The new files were added and verified to conform to the repository schemas referenced by `schema_galaxies.json` and `schema_clusters.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa7373958832496d48ef26fc2fc06)