### PR TITLE
Add Shamoon Group actor and Mabna Institute Group synonym to threat-actor galaxy

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -127,6 +127,23 @@
       "value": "Dust Storm"
     },
     {
+      "description": "Shamoon Group is an Iran-linked threat actor associated with destructive Shamoon wiper operations targeting organizations in the Middle East, especially in the energy sector.",
+      "meta": {
+        "attribution-confidence": "50",
+        "country": "IR",
+        "refs": [
+          "https://www.cfr.org/cyber-operations/shamoon",
+          "https://securelist.com/shamoon-2-0-the-return-of-the-disttrack-wiper/77232/",
+          "https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-055a"
+        ],
+        "synonyms": [
+          "Cutting Sword of Justice"
+        ]
+      },
+      "uuid": "092622dd-7673-487b-af2e-03529809c910",
+      "value": "Shamoon Group"
+    },
+    {
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
@@ -8243,7 +8260,8 @@
           "Mabna Institute",
           "TA407",
           "TA4900",
-          "Yellow Nabu"
+          "Yellow Nabu",
+          "Mabna Institute Group"
         ]
       },
       "uuid": "5059b44d-2753-4977-b987-4922f09afe6b",


### PR DESCRIPTION
### Motivation
- Ensure the MISP threat-actor galaxy covers Iranian actors referenced in the provided ETH Zurich report and the linked gist, specifically adding the Shamoon wiper actor and aligning Mabna naming.

### Description
- Add a new `Shamoon Group` entry to `clusters/threat-actor.json` with Iran attribution (`country: IR`), an `attribution-confidence`, supporting `refs`, and the alias `Cutting Sword of Justice` in `synonyms`.
- Extend the `Silent Librarian` entry in `clusters/threat-actor.json` by adding the synonym `Mabna Institute Group` to align with the source document naming.
- Preserve file formatting and insert the new actor near the existing actor list so the cluster remains valid JSON.

### Testing
- Ran `python -m json.tool clusters/threat-actor.json` to validate JSON structure, which completed successfully. 
- Executed a Python presence check that verifies the main Iranian actor names appear in either `value` or `meta.synonyms`, which returned no missing names (result: `missing []`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db398636e483248168325d68542c87)