### PR TITLE
Reduce numeric-identifier noise in threat actor similarity report

### DIFF
--- a/tools/threat_actor_similarity_report.py
+++ b/tools/threat_actor_similarity_report.py
@@ -18,6 +18,17 @@ def normalize_name(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip()
 
 
+def strip_numeric_tokens(value: str) -> str:
+    """Return a normalized name with digits removed (keeps non-numeric tokens)."""
+    value = re.sub(r"\d+", " ", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def numeric_tokens(value: str):
+    """Extract numeric token sequences from a normalized name."""
+    return tuple(re.findall(r"\d+", value))
+
+
 def load_threat_actor_names(cluster_path: Path):
     """Return a map: normalized name -> map of canonical threat actor name -> UUID."""
     data = json.loads(cluster_path.read_text(encoding="utf-8"))
@@ -46,7 +57,11 @@ def load_threat_actor_names(cluster_path: Path):
 
 
 def find_similar_name_pairs(names_to_actors, min_similarity=0.88, max_results=200):
-    """Compute similar name pairs using difflib.SequenceMatcher."""
+    """Compute similar name pairs using difflib.SequenceMatcher.
+
+    Numeric-heavy variants (same non-numeric stem, different numeric tokens) are
+    intentionally skipped to reduce noisy matches like "apt 28" vs "apt 29".
+    """
     names = sorted(names_to_actors)
     results = []
 
@@ -61,6 +76,23 @@ def find_similar_name_pairs(names_to_actors, min_similarity=0.88, max_results=20
         left_actors = names_to_actors[left]
         right_actors = names_to_actors[right]
         if left_actors == right_actors:
+            continue
+
+        left_non_numeric = strip_numeric_tokens(left)
+        right_non_numeric = strip_numeric_tokens(right)
+        left_numbers = numeric_tokens(left)
+        right_numbers = numeric_tokens(right)
+
+        # Threat-actor names often reuse a textual stem with a different numeric id.
+        # Treat these as distinct identifiers to avoid over-reporting false positives.
+        if (
+            left_numbers
+            and right_numbers
+            and left_non_numeric
+            and right_non_numeric
+            and left_non_numeric == right_non_numeric
+            and left_numbers != right_numbers
+        ):
             continue
 
         longer = max(len(left), len(right))


### PR DESCRIPTION
### Motivation
- Threat-actor names frequently reuse a textual stem with different numeric identifiers (e.g., `apt 28` vs `apt 29`), which creates noisy high-similarity matches; the change aims to reduce these false positives while keeping comparisons focused on non-numeric content.

### Description
- Add `strip_numeric_tokens()` to remove digit sequences from normalized names and `numeric_tokens()` to extract numeric token sequences.  
- Update `find_similar_name_pairs()` to skip candidate pairs when both names contain numeric tokens, share the same non-numeric stem, but have different numeric sequences.  
- Document the numeric-variant filtering behavior in the function docstring and keep all other similarity logic (length pre-filter, `SequenceMatcher`) unchanged.  
- No changes to the CLI or output formats were made; markdown and JSON outputs remain the same.

### Testing
- Ran `python3 -m py_compile tools/threat_actor_similarity_report.py` which succeeded.  
- Ran `python3 tools/threat_actor_similarity_report.py --help | head -n 20` to validate CLI help which printed successfully.  
- Executed `python3 tools/threat_actor_similarity_report.py --max-results 5 --markdown-output /tmp/threat_report.md --json-output /tmp/threat_report.json` which produced a report and JSON file, printing analysis summary (reports written) with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db60167a6483248b9a108deb1f6f93)