### PR TITLE
Add Vertigo Panda alias to UNC6384 threat-actor entry

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -19137,11 +19137,14 @@
       "value": "UNC6485"
     },
     {
-      "description": "UNC6384 is a Chinese-affiliated APT that conducts targeted espionage campaigns primarily against diplomatic entities in Southeast Asia and Europe, specifically Belgium and Hungary. The group exploits the ZDI-CAN-25373 Windows shortcut vulnerability to gain initial code execution via malicious .LNK files, deploying the PlugX RAT through sophisticated delivery mechanisms, including DLL side-loading and adversary-in-the-middle attacks. Their operations involve social engineering tactics, such as spear-phishing emails themed around diplomatic events, to entice victims into executing malicious payloads. UNC6384's use of valid code signing and HTTPS hosting enhances their evasion of detection and increases the likelihood of user interaction.",
+      "description": "UNC6384 (also tracked as Vertigo Panda) is a Chinese-affiliated APT that conducts targeted espionage campaigns primarily against diplomatic entities in Southeast Asia and Europe, specifically Belgium and Hungary. The group exploits the ZDI-CAN-25373 Windows shortcut vulnerability to gain initial code execution via malicious .LNK files, deploying the PlugX RAT through sophisticated delivery mechanisms, including DLL side-loading and adversary-in-the-middle attacks. Their operations involve social engineering tactics, such as spear-phishing emails themed around diplomatic events, to entice victims into executing malicious payloads. UNC6384's use of valid code signing and HTTPS hosting enhances their evasion of detection and increases the likelihood of user interaction.",
       "meta": {
         "country": "CN",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/prc-nexus-espionage-targets-diplomats/"
+        ],
+        "synonyms": [
+          "Vertigo Panda"
         ]
       },
       "uuid": "a3e4a57e-4b50-4bca-9282-3307e92e5539",


### PR DESCRIPTION
### Motivation
- Issue #1102 asked to add Vertigo Panda; the existing `UNC6384` entry corresponds to the same reporting, so adding an alias avoids creating a duplicated threat actor and improves discoverability by alternate naming.

### Description
- Updated `clusters/threat-actor.json` to modify the `UNC6384` entry by adding `Vertigo Panda` to `meta.synonyms` and updating the `description` to note it is "also tracked as Vertigo Panda", and ensured the GTIG reference is present.

### Testing
- Ran `python -m json.tool clusters/threat-actor.json` which succeeded, and executed `./validate_all.sh` which performed the full schema validation successfully but exited non-zero at the end due to the repository policy check that detects local changes during the validation pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db63c13ac883248a0039980091403b)