### PR TITLE
Fix graph exporter output extension handling and clarify generic exporter text

### DIFF
--- a/tools/gen_graphml.py
+++ b/tools/gen_graphml.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a GraphML export for all MISP galaxies and clusters.
+"""Generate graph exports for MISP galaxies and clusters.
 
 The graph contains:
 - One node per galaxy definition (`galaxies/*.json`)
@@ -307,9 +307,29 @@ def to_json_graph(nodes: list[GraphNode], edges: list[GraphEdge]) -> str:
     return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
 
 
+def output_suffix(output_format: str) -> str:
+    """Return the expected file suffix for each supported output format."""
+    return {
+        "graphml": ".graphml",
+        "dot": ".dot",
+        "json-graph": ".json",
+    }[output_format]
+
+
+def resolve_output_path(requested_path: Path, output_format: str) -> Path:
+    """Ensure output file extension matches the selected graph export format."""
+    expected_suffix = output_suffix(output_format)
+    if requested_path.suffix != expected_suffix:
+        return requested_path.with_suffix(expected_suffix)
+    return requested_path
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Generate a GraphML graph from galaxies and clusters JSON files."
+        description=(
+            "Generate a graph export from MISP galaxy and cluster JSON files "
+            "(GraphML, Graphviz DOT, or JSON graph)."
+        )
     )
     parser.add_argument(
         "--clusters-dir",
@@ -328,7 +348,7 @@ def parse_args() -> argparse.Namespace:
         "--output",
         type=Path,
         default=Path("misp-galaxies.graphml"),
-        help="Output GraphML file path.",
+        help="Output file path (its extension is aligned with --output-format).",
     )
     parser.add_argument(
         "--output-format",
@@ -367,17 +387,18 @@ def main() -> int:
         inferred_mode=args.cross_cluster_matching,
     )
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
+    output_path = resolve_output_path(args.output, args.output_format)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     if args.output_format == "graphml":
         graphml = build_graphml(nodes, edges)
-        graphml.write(args.output, encoding="utf-8", xml_declaration=True)
+        graphml.write(output_path, encoding="utf-8", xml_declaration=True)
     elif args.output_format == "dot":
-        args.output.write_text(to_dot(nodes, edges), encoding="utf-8")
+        output_path.write_text(to_dot(nodes, edges), encoding="utf-8")
     else:
-        args.output.write_text(to_json_graph(nodes, edges), encoding="utf-8")
+        output_path.write_text(to_json_graph(nodes, edges), encoding="utf-8")
 
     print(
-        f"{args.output_format} graph written to {args.output} with {len(galaxies)} galaxies and {len(clusters)} clusters."
+        f"{args.output_format} graph written to {output_path} with {len(galaxies)} galaxies and {len(clusters)} clusters."
     )
     return 0
 


### PR DESCRIPTION
### Motivation
- Ensure the output file name/extension matches the selected export format so users don't end up with a .graphml file containing DOT or JSON content.
- Clarify that the script is a generic MISP galaxy graph exporter supporting GraphML, Graphviz DOT and a JSON graph format, not GraphML-only.

### Description
- Updated module docstring and CLI help to describe the tool as a generic MISP galaxy graph exporter supporting `graphml`, `dot`, and `json-graph` formats.
- Added `output_suffix()` and `resolve_output_path()` helpers to map `--output-format` to the expected file suffix and adjust the requested path accordingly.
- Changed `main()` to write to the resolved `output_path` for all formats and updated the final status message to reference the resolved path.

### Testing
- Ran `python3 tools/gen_graphml.py --output-format dot --output /tmp/misp-galaxies.graphml` and it succeeded, writing to `/tmp/misp-galaxies.dot`.
- Ran `python3 tools/gen_graphml.py --output-format json-graph --output /tmp/misp-galaxies.graphml` and it succeeded, writing to `/tmp/misp-galaxies.json`.
- Ran `python3 tools/gen_graphml.py --output-format graphml --output /tmp/misp-galaxies.dot` and it succeeded, writing to `/tmp/misp-galaxies.graphml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf2c2ce1c8324b81808f5dd0e360f)