### PR TITLE
Add IT Infrastructure Equipment galaxy and cluster

### DIFF
--- a/clusters/it-infrastructure-equipment.json
+++ b/clusters/it-infrastructure-equipment.json
@@ -234,5 +234,6 @@
       "uuid": "6f70469d-552f-4c60-9d0d-92dc723ccaf2",
       "value": "Network Monitoring Probe"
     }
-  ]
+  ],
+  "version": 1
 }

--- a/clusters/it-infrastructure-equipment.json
+++ b/clusters/it-infrastructure-equipment.json
@@ -1,0 +1,238 @@
+{
+  "authors": [
+    "MISP Project",
+    "ChatGPT"
+  ],
+  "category": "it-infrastructure-equipment",
+  "description": "Generic types of IT infrastructure equipment used in enterprise environments, including network, security, server, and client equipment.",
+  "name": "IT Infrastructure Equipment",
+  "source": "MISP Project",
+  "type": "it-infrastructure-equipment",
+  "uuid": "ab27e10a-eed4-483a-8926-147307cae75a",
+  "values": [
+    {
+      "description": "Core or distribution network device forwarding traffic between network segments.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "782fd7c5-2b2e-4c29-acf3-cb9d3e58fe7a",
+      "value": "Router"
+    },
+    {
+      "description": "Layer 2 or multilayer switching device interconnecting hosts and network devices.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "e90be5d7-137c-4018-95e7-e162b26903bb",
+      "value": "Switch"
+    },
+    {
+      "description": "Wireless network infrastructure device providing Wi-Fi connectivity.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "fcfe1a2f-9602-41c5-a878-b4128eb64423",
+      "value": "Wireless Access Point"
+    },
+    {
+      "description": "Central controller for managing multiple wireless access points.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "9abfdb99-363b-407b-8b6b-77680a21c895",
+      "value": "Wireless LAN Controller"
+    },
+    {
+      "description": "WAN edge equipment for Internet or private circuit connectivity.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "7a2317eb-80c0-462c-be43-67e6b744740e",
+      "value": "Modem"
+    },
+    {
+      "description": "Dedicated network device enforcing traffic filtering and segmentation policies.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "89149a4c-1f73-4929-b207-51db7b3690f4",
+      "value": "Firewall"
+    },
+    {
+      "description": "Inline device analyzing and blocking malicious network traffic.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "f1c2fed0-7285-4617-9e0c-b971d26a1c0e",
+      "value": "Intrusion Prevention System"
+    },
+    {
+      "description": "Network sensor for detecting potentially malicious activity.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "41bc03d0-dfae-43d8-bce7-98498b0f03e0",
+      "value": "Intrusion Detection System"
+    },
+    {
+      "description": "Security appliance providing secure remote-access tunnels.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "22c08f61-9118-4bbf-a236-9a4d26ea251a",
+      "value": "VPN Gateway"
+    },
+    {
+      "description": "Device or appliance balancing traffic across multiple backend systems.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "8b93d57d-3f53-49db-bcc8-dde97539f103",
+      "value": "Load Balancer"
+    },
+    {
+      "description": "Proxy system brokering and filtering traffic between clients and services.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "abbfb443-71f1-47d6-a229-d203e5678a49",
+      "value": "Proxy Server"
+    },
+    {
+      "description": "Application-specific firewall for HTTP and web application protection.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "d61019f7-2d87-4498-b15b-3840a6ccef8b",
+      "value": "Web Application Firewall"
+    },
+    {
+      "description": "Centralized server providing identity and authentication services.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "aa7c5c25-80c7-42cc-a28a-5c1852598fdf",
+      "value": "Directory Server"
+    },
+    {
+      "description": "System hosting business applications and services for users or machines.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "365882e7-8cf6-42c0-98ec-be315d0d7186",
+      "value": "Application Server"
+    },
+    {
+      "description": "System providing relational or non-relational data storage and query services.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "a86009e7-a04f-40c4-ab79-6a7f297efe8d",
+      "value": "Database Server"
+    },
+    {
+      "description": "System delivering file shares and centralized file storage.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "060aad03-38ee-4e66-999b-676adecacfb9",
+      "value": "File Server"
+    },
+    {
+      "description": "System managing print queues and network printing resources.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "565bad00-ae9d-427f-ae0b-9e9fa2707b47",
+      "value": "Print Server"
+    },
+    {
+      "description": "System providing outbound and inbound electronic messaging services.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "902bb039-849f-4966-a072-b536ca562841",
+      "value": "Mail Server"
+    },
+    {
+      "description": "System serving websites and web applications over HTTP/S.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "1b43a94f-a8a8-45d4-89b0-7bfaf4b5a228",
+      "value": "Web Server"
+    },
+    {
+      "description": "System providing virtual machine hosting and orchestration.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "3bb740f8-db26-4a68-8cb8-6b949f12f844",
+      "value": "Virtualization Host"
+    },
+    {
+      "description": "Dedicated storage system providing block or file storage to servers.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "e23b4cf3-0eef-47b6-992c-3f39c2bf9850",
+      "value": "Storage Array"
+    },
+    {
+      "description": "System designed for data backup, restore, and archival functions.",
+      "meta": {
+        "category": "server"
+      },
+      "uuid": "0aff9518-3fbf-4a62-b4d7-97c54d100ff8",
+      "value": "Backup Server"
+    },
+    {
+      "description": "User workstation used for day-to-day enterprise operations.",
+      "meta": {
+        "category": "client"
+      },
+      "uuid": "9b467c15-0fbf-4457-b7d6-cf700e03b872",
+      "value": "Desktop Workstation"
+    },
+    {
+      "description": "Portable endpoint computer used by end users.",
+      "meta": {
+        "category": "client"
+      },
+      "uuid": "5853181e-5277-43d9-9312-edde08a8c100",
+      "value": "Laptop"
+    },
+    {
+      "description": "Enterprise-managed mobile endpoint device.",
+      "meta": {
+        "category": "client"
+      },
+      "uuid": "46982ac0-e368-4f85-9dd2-f4c403b42b13",
+      "value": "Mobile Device"
+    },
+    {
+      "description": "Thin client endpoint relying on centralized servers for application execution.",
+      "meta": {
+        "category": "client"
+      },
+      "uuid": "bcb9cdbf-5a83-4d21-8ccb-8e495ffe7aab",
+      "value": "Thin Client"
+    },
+    {
+      "description": "Equipment for centralized logging and security event collection.",
+      "meta": {
+        "category": "security"
+      },
+      "uuid": "c14d35c9-72f7-4f25-9028-e7c5380afb33",
+      "value": "Log Management Appliance"
+    },
+    {
+      "description": "Network monitoring sensor collecting telemetry for visibility and detection.",
+      "meta": {
+        "category": "network"
+      },
+      "uuid": "6f70469d-552f-4c60-9d0d-92dc723ccaf2",
+      "value": "Network Monitoring Probe"
+    }
+  ]
+}

--- a/galaxies/it-infrastructure-equipment.json
+++ b/galaxies/it-infrastructure-equipment.json
@@ -1,0 +1,9 @@
+{
+  "description": "Generic types of IT infrastructure equipment used in enterprise environments, including network, security, server, and client equipment.",
+  "icon": "server",
+  "name": "IT Infrastructure Equipment",
+  "namespace": "misp",
+  "type": "it-infrastructure-equipment",
+  "uuid": "81d881ae-f9b8-49f3-8860-6af550e3f65a",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide a generic, vendor-neutral taxonomy for IT equipment to tag detection rules and related intelligence across network, security, server, and client assets.
- Make it easy to classify where detections or telemetry originate (e.g., network device vs server vs endpoint) for MISP and other tooling integrations.

### Description
- Added a galaxy definition at `galaxies/it-infrastructure-equipment.json` with `type: it-infrastructure-equipment`, icon, UUID and version metadata.
- Added a matching cluster at `clusters/it-infrastructure-equipment.json` containing a curated list of generic equipment types (Router, Switch, Firewall, IDS/IPS, Load Balancer, VPN Gateway, Web Server, Database Server, Desktop Workstation, Laptop, Mobile Device, etc.).
- Each cluster entry includes a brief `description`, a `meta.category` (one of `network`, `security`, `server`, `client`), and a unique `uuid` for stable referencing.
- The cluster `authors` field lists `MISP Project` and `ChatGPT` as contributors.

### Testing
- Ran `jq . galaxies/it-infrastructure-equipment.json` and `jq . clusters/it-infrastructure-equipment.json` and both checks succeeded.
- Ran `./jq_all_the_things.sh` to normalize JSON formatting and it completed successfully.
- Ran `./validate_all.sh` (schema validation ran over the repository); the script initially exited non-zero due to uncommitted diffs by design, and the files were then formatted/committed as part of the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7081367c83248a43e9271a5b4f28)