### PR TITLE
Add Taxonomy of Fraud galaxy (Issue #724)

### DIFF
--- a/clusters/taxonomy-of-fraud.json
+++ b/clusters/taxonomy-of-fraud.json
@@ -1,0 +1,2854 @@
+{
+  "authors": [
+    "Stanford Center on Longevity"
+  ],
+  "category": "financial-fraud",
+  "description": "Taxonomy of Fraud from the Stanford Center on Longevity (2015), including hierarchy nodes and attribute tags.",
+  "name": "Taxonomy of Fraud",
+  "source": "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/",
+  "type": "taxonomy-of-fraud",
+  "uuid": "dfcc3524-51a2-4190-b6e3-24eff76877e7",
+  "values": [
+    {
+      "description": "Affinity fraud",
+      "meta": {
+        "external_id": "AF",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "28984325-f4b2-4212-afa1-8747888ae51b",
+      "value": "Incident tag AF"
+    },
+    {
+      "description": "Pyramid scheme",
+      "meta": {
+        "external_id": "PS",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8871eace-b71a-46eb-90e1-c21f04897b48",
+      "value": "Incident tag PS"
+    },
+    {
+      "description": "Ponzi scheme",
+      "meta": {
+        "external_id": "PZ",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "d7531cce-9bf0-4c13-a57c-6d5c3b906b52",
+      "value": "Incident tag PZ"
+    },
+    {
+      "description": "Impersonated Government official",
+      "meta": {
+        "external_id": "IG",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "bd6169f5-64fe-4205-97a0-0d948b5fdb84",
+      "value": "Incident tag IG"
+    },
+    {
+      "description": "Pump & dump scheme",
+      "meta": {
+        "external_id": "PD",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4a75db69-c10c-468b-aae1-e34f90ec07b5",
+      "value": "Incident tag PD"
+    },
+    {
+      "description": "Health or medical related fraud",
+      "meta": {
+        "external_id": "HM",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "fff83632-bb30-46f5-8f10-a38df60cc66e",
+      "value": "Incident tag HM"
+    },
+    {
+      "description": "Continuity scam",
+      "meta": {
+        "external_id": "CS",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "22cae893-93fb-467b-9623-ba4a043775f9",
+      "value": "Incident tag CS"
+    },
+    {
+      "description": "Overpayment fraud",
+      "meta": {
+        "external_id": "OV",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "687fe1bb-446a-45a7-aa0e-938a2e392280",
+      "value": "Incident tag OV"
+    },
+    {
+      "description": "Counterfeit payment instrument",
+      "meta": {
+        "external_id": "CP",
+        "group": "attribute-tags:incident:general",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1a375d19-7b45-4afd-b247-70fab3404d85",
+      "value": "Incident tag CP"
+    },
+    {
+      "description": "Internet, email",
+      "meta": {
+        "external_id": "Ad:IE",
+        "group": "attribute-tags:incident:advertising",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8d40d562-7a60-4135-ae09-990883f49e3f",
+      "value": "Incident tag Ad:IE"
+    },
+    {
+      "description": "Text/direct message",
+      "meta": {
+        "external_id": "Ad:TX",
+        "group": "attribute-tags:incident:advertising",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "14c0857a-523c-4bb3-853e-eeffac604dce",
+      "value": "Incident tag Ad:TX"
+    },
+    {
+      "description": "Direct mail",
+      "meta": {
+        "external_id": "Ad:DM",
+        "group": "attribute-tags:incident:advertising",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9348935e-7ca3-4884-be67-8e50bedd74e6",
+      "value": "Incident tag Ad:DM"
+    },
+    {
+      "description": "TV or radio",
+      "meta": {
+        "external_id": "Ad:TVR",
+        "group": "attribute-tags:incident:advertising",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ab0c2adf-7dfd-4c5a-95c6-af0beef0bc77",
+      "value": "Incident tag Ad:TVR"
+    },
+    {
+      "description": "Telemarketing",
+      "meta": {
+        "external_id": "Ad:T",
+        "group": "attribute-tags:incident:advertising",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1e9f0c7b-e5de-42b2-a461-c933b94d14a6",
+      "value": "Incident tag Ad:T"
+    },
+    {
+      "description": "In person",
+      "meta": {
+        "external_id": "Ad:P",
+        "group": "attribute-tags:incident:advertising",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0469e46a-48ba-4e57-913e-cfabdf40e6ec",
+      "value": "Incident tag Ad:P"
+    },
+    {
+      "description": "Computer via the Internet",
+      "meta": {
+        "external_id": "PS:I",
+        "group": "attribute-tags:incident:purchase-setting",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4e706090-39e3-4c82-badd-977b09d61d7e",
+      "value": "Incident tag PS:I"
+    },
+    {
+      "description": "Mail",
+      "meta": {
+        "external_id": "PS:M",
+        "group": "attribute-tags:incident:purchase-setting",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e67f4e4d-131c-4a69-a809-b7844d0a33e8",
+      "value": "Incident tag PS:M"
+    },
+    {
+      "description": "Telephone",
+      "meta": {
+        "external_id": "PS:T",
+        "group": "attribute-tags:incident:purchase-setting",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8cddd14d-3868-48ed-b33c-2f87b02ed84c",
+      "value": "Incident tag PS:T"
+    },
+    {
+      "description": "Store",
+      "meta": {
+        "external_id": "PS:S",
+        "group": "attribute-tags:incident:purchase-setting",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2132101e-2cf4-425c-8816-79edc5d6ab3c",
+      "value": "Incident tag PS:S"
+    },
+    {
+      "description": "Person to person",
+      "meta": {
+        "external_id": "PS:P",
+        "group": "attribute-tags:incident:purchase-setting",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "18e50804-b51b-4137-a961-c6700685205f",
+      "value": "Incident tag PS:P"
+    },
+    {
+      "description": "Credit card",
+      "meta": {
+        "external_id": "MT:CC",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "90dcedcc-bfa7-403f-9709-fa9aacf00b11",
+      "value": "Incident tag MT:CC"
+    },
+    {
+      "description": "Debit/ATM card",
+      "meta": {
+        "external_id": "MT:DC",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "66c0b596-cfd8-42e8-921e-7b995d647635",
+      "value": "Incident tag MT:DC"
+    },
+    {
+      "description": "Cash",
+      "meta": {
+        "external_id": "MT:C",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "99177756-aa19-4f5e-a84d-611dcc247681",
+      "value": "Incident tag MT:C"
+    },
+    {
+      "description": "Personal check",
+      "meta": {
+        "external_id": "MT:PC",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "81a938f6-1288-4277-96bf-552b90ae86d6",
+      "value": "Incident tag MT:PC"
+    },
+    {
+      "description": "Mobile/online payment application",
+      "meta": {
+        "external_id": "MT:M",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a94d7862-6f1e-4af9-b4d5-24e1c1fc1986",
+      "value": "Incident tag MT:M"
+    },
+    {
+      "description": "Money order",
+      "meta": {
+        "external_id": "MT:MO",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e032630d-c925-45df-b542-966d54e9b266",
+      "value": "Incident tag MT:MO"
+    },
+    {
+      "description": "Wire funds",
+      "meta": {
+        "external_id": "MT:W",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e240ef99-a9cb-4dad-8d25-96b6a2a4e18c",
+      "value": "Incident tag MT:W"
+    },
+    {
+      "description": "Telephone account",
+      "meta": {
+        "external_id": "MT:T",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f6e06cfb-597f-484a-b55a-4f6851e26b66",
+      "value": "Incident tag MT:T"
+    },
+    {
+      "description": "Prepaid Card",
+      "meta": {
+        "external_id": "MT:PP",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1ab0e0a8-e165-4e15-bde0-f9a0aebb2bc1",
+      "value": "Incident tag MT:PP"
+    },
+    {
+      "description": "Bitcoin",
+      "meta": {
+        "external_id": "MT:B",
+        "group": "attribute-tags:incident:money-transfer",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "38f75eca-9d4e-4ed1-b777-c7f9d6f604b7",
+      "value": "Incident tag MT:B"
+    },
+    {
+      "description": "Male victim",
+      "meta": {
+        "external_id": "MV",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2875e0b7-2c9a-4904-b9db-1c38256e3a41",
+      "value": "Victim tag MV"
+    },
+    {
+      "description": "Female victim",
+      "meta": {
+        "external_id": "FV",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "04e3cafb-4884-4b5d-b5e8-f1d4d36e86c0",
+      "value": "Victim tag FV"
+    },
+    {
+      "description": "Elder victim, age 65+",
+      "meta": {
+        "external_id": "EV",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e3a7223a-2e80-4fbb-96d9-24b92e8aae9c",
+      "value": "Victim tag EV"
+    },
+    {
+      "description": "Veteran victim",
+      "meta": {
+        "external_id": "VV",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "82321548-c7a0-490e-8862-e259fb2f920a",
+      "value": "Victim tag VV"
+    },
+    {
+      "description": "Cognitively impaired victim",
+      "meta": {
+        "external_id": "CIV",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "07b575b0-9264-4998-8f22-68df23fbb418",
+      "value": "Victim tag CIV"
+    },
+    {
+      "description": "Repeat victim",
+      "meta": {
+        "external_id": "RV",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f081b1b0-cf2e-43cf-8c47-b515dd0e7959",
+      "value": "Victim tag RV"
+    },
+    {
+      "description": "Victim reported fraud to authorities",
+      "meta": {
+        "external_id": "RA",
+        "group": "attribute-tags:victim",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9632587d-b00d-4c4f-be5f-82852f5be8ce",
+      "value": "Victim tag RA"
+    },
+    {
+      "description": "Male perpetrator",
+      "meta": {
+        "external_id": "MP",
+        "group": "attribute-tags:perpetrator",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e78cd886-d858-44fb-8dcd-1dc3f023d689",
+      "value": "Perpetrator tag MP"
+    },
+    {
+      "description": "Female perpetrator",
+      "meta": {
+        "external_id": "FP",
+        "group": "attribute-tags:perpetrator",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "dfd45d31-abc3-4ed1-a596-d927cc62aba9",
+      "value": "Perpetrator tag FP"
+    },
+    {
+      "description": "Intimate partner perpetrator",
+      "meta": {
+        "external_id": "IP",
+        "group": "attribute-tags:perpetrator",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "fcbfbfdb-cede-416a-8805-8108b2198c5f",
+      "value": "Perpetrator tag IP"
+    },
+    {
+      "description": "Family member perpetrator (source PDF reuses FP code)",
+      "meta": {
+        "external_id": "FP-Family",
+        "group": "attribute-tags:perpetrator",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f745e224-52c4-4895-9d44-ede9a5fef904",
+      "value": "Perpetrator tag FP-Family"
+    },
+    {
+      "description": "Caregiver perpetrator",
+      "meta": {
+        "external_id": "CP",
+        "group": "attribute-tags:perpetrator",
+        "kind": "attribute-tag",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e470b451-974f-42a7-8fc8-f2293671a139",
+      "value": "Perpetrator tag CP"
+    },
+    {
+      "description": "Fraud against an individual",
+      "meta": {
+        "external_id": "1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "d9d8dd86-b911-48c1-b9d9-5b953d8b487b",
+      "value": "Individual Financial Fraud"
+    },
+    {
+      "description": "Expected investment returns",
+      "meta": {
+        "external_id": "1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4f6c34d7-35c2-4642-a667-223c62655a51",
+      "value": "Consumer Investment Fraud"
+    },
+    {
+      "description": "Securities-related investment fraud",
+      "meta": {
+        "external_id": "1.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "51c376eb-4289-4c0e-9edd-481f19fa4e11",
+      "value": "Securities fraud"
+    },
+    {
+      "description": "Equity and stock fraud",
+      "meta": {
+        "external_id": "1.1.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9d0f89f0-5bdd-44c0-bfba-1e43f904c857",
+      "value": "Equity investment fraud"
+    },
+    {
+      "description": "Penny stock scam",
+      "meta": {
+        "external_id": "1.1.1.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e3f59379-99f9-4e9a-851f-020ac8f17921",
+      "value": "Penny stock fraud"
+    },
+    {
+      "description": "Pre-IPO scam",
+      "meta": {
+        "external_id": "1.1.1.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "d624da51-a42f-4f95-b881-4395d5390acb",
+      "value": "Pre-IPO scam"
+    },
+    {
+      "description": "HYIP fraud",
+      "meta": {
+        "external_id": "1.1.1.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e43a80da-5b8e-4ac7-8c14-4879198692a0",
+      "value": "High-yield investment program fraud"
+    },
+    {
+      "description": "Real Estate Investment Trust fraud",
+      "meta": {
+        "external_id": "1.1.1.1.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "7be06181-d579-4d0f-8415-16dbc928fcf5",
+      "value": "REIT fraud"
+    },
+    {
+      "description": "Oil and gas exploration scam",
+      "meta": {
+        "external_id": "1.1.1.1.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "eef217ab-d551-4d6a-9625-81856126f8b1",
+      "value": "Oil & gas exploration scam"
+    },
+    {
+      "description": "Alternative energy company scam",
+      "meta": {
+        "external_id": "1.1.1.1.6",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "81058c16-51b4-41fe-976e-fb149f0a670b",
+      "value": "Alternative energy company scam"
+    },
+    {
+      "description": "Other equity stock fraud",
+      "meta": {
+        "external_id": "1.1.1.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "7185e016-cf36-4dae-845d-ccece835afe2",
+      "value": "Other equity (stock) fraud"
+    },
+    {
+      "description": "Debt investment fraud",
+      "meta": {
+        "external_id": "1.1.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0d4cc217-6472-4ed1-b720-1795c6680dfd",
+      "value": "Debt investment fraud"
+    },
+    {
+      "description": "Promissory note fraud",
+      "meta": {
+        "external_id": "1.1.1.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1fa73e3f-6575-4ba6-b999-c66f0634bdfa",
+      "value": "Promissory note fraud"
+    },
+    {
+      "description": "Prime bank note fraud",
+      "meta": {
+        "external_id": "1.1.1.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "72250370-446d-4d8d-922e-b53771bd2803",
+      "value": "Prime bank note fraud"
+    },
+    {
+      "description": "Bond fraud",
+      "meta": {
+        "external_id": "1.1.1.2.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "31420cba-a233-4470-8317-91d22503d7fb",
+      "value": "Bond fraud"
+    },
+    {
+      "description": "Other debt investment fraud",
+      "meta": {
+        "external_id": "1.1.1.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "bd262799-8278-4028-b077-20f632e5bbf5",
+      "value": "Other debt investment fraud"
+    },
+    {
+      "description": "Other securities fraud",
+      "meta": {
+        "external_id": "1.1.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "58b93106-6d09-4ff9-a8f9-5bea9446c983",
+      "value": "Other securities fraud"
+    },
+    {
+      "description": "Commodities trading fraud",
+      "meta": {
+        "external_id": "1.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ed887f97-e7d6-4e98-893a-c9e73ae9c003",
+      "value": "Commodities trading fraud"
+    },
+    {
+      "description": "Foreign exchange fraud",
+      "meta": {
+        "external_id": "1.1.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "17254e1a-8eb6-4292-a104-92d923a8f8fb",
+      "value": "Forex fraud"
+    },
+    {
+      "description": "Commodity pool fraud",
+      "meta": {
+        "external_id": "1.1.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "bedb8eb7-4ccd-4099-b87a-e87ad4931359",
+      "value": "Commodity pool fraud"
+    },
+    {
+      "description": "Precious metals fraud",
+      "meta": {
+        "external_id": "1.1.2.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "56af5d56-1d38-4b6c-8609-d4e3894a8eae",
+      "value": "Precious metals fraud"
+    },
+    {
+      "description": "Other commodities fraud",
+      "meta": {
+        "external_id": "1.1.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0fd0feec-102c-45c0-aa29-6817c3186a69",
+      "value": "Other commodities fraud"
+    },
+    {
+      "description": "Other investment opportunities fraud",
+      "meta": {
+        "external_id": "1.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "22b135ef-7ee9-45c0-9311-e4b7e17bb9c8",
+      "value": "Other investment opportunities fraud"
+    },
+    {
+      "description": "Hollywood film scam",
+      "meta": {
+        "external_id": "1.1.3.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8338ae02-45f3-4497-9581-fb51d3709247",
+      "value": "Hollywood film scam"
+    },
+    {
+      "description": "Property or real estate scam",
+      "meta": {
+        "external_id": "1.1.3.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "caf221fc-c69d-442e-821d-62d1ba1c97b8",
+      "value": "Property/real estate scam"
+    },
+    {
+      "description": "Rare objects scam",
+      "meta": {
+        "external_id": "1.1.3.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "6f0592b9-525b-4457-bfe0-70dfeca99cc9",
+      "value": "Rare objects scam"
+    },
+    {
+      "description": "Expected products, services, and other items",
+      "meta": {
+        "external_id": "1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ebb7eaf2-fd25-402f-8a10-427df55cbb47",
+      "value": "Consumer Products and Services Fraud"
+    },
+    {
+      "description": "Intentionally entered agreement",
+      "meta": {
+        "external_id": "1.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1fd11a25-2acf-4d0c-9d2c-b962b168faf5",
+      "value": "Worthless or non-existent products"
+    },
+    {
+      "description": "Worthless products",
+      "meta": {
+        "external_id": "1.2.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a4bcb6d7-f2a2-4a08-a752-cb69786beda2",
+      "value": "Worthless products"
+    },
+    {
+      "description": "Weight-loss and supplement scams",
+      "meta": {
+        "external_id": "1.2.1.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1e41b81b-e608-4498-bbe7-92d99ad78817",
+      "value": "Weight-loss products and health supplement scams"
+    },
+    {
+      "description": "Pharma discount scam",
+      "meta": {
+        "external_id": "1.2.1.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4759a8a5-471c-481d-b27a-d7d1b04002c9",
+      "value": "Pharma discount scam"
+    },
+    {
+      "description": "Medical devices fraud",
+      "meta": {
+        "external_id": "1.2.1.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "455a1b19-ff65-437a-b93e-36c700555739",
+      "value": "Medical devices"
+    },
+    {
+      "description": "Cemetery plot scam",
+      "meta": {
+        "external_id": "1.2.1.1.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a04e0730-15b5-421f-b751-236872597e1e",
+      "value": "Cemetery plot scam"
+    },
+    {
+      "description": "Fake memorabilia",
+      "meta": {
+        "external_id": "1.2.1.1.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ce508ff7-8609-4de2-82de-6b7a7745b210",
+      "value": "Fake memorabilia"
+    },
+    {
+      "description": "Bogus software",
+      "meta": {
+        "external_id": "1.2.1.1.6",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "3fb51635-b2d9-4dfd-8273-3dbd4a6fb15e",
+      "value": "Bogus software"
+    },
+    {
+      "description": "Fake gemstones",
+      "meta": {
+        "external_id": "1.2.1.1.7",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1d370caa-2e2a-4708-a4be-b823cfe3f803",
+      "value": "Fake gemstones"
+    },
+    {
+      "description": "Other worthless products",
+      "meta": {
+        "external_id": "1.2.1.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e8182bb3-7194-4a95-8f03-af2dfe39d7f4",
+      "value": "Other worthless products"
+    },
+    {
+      "description": "Paid but never received",
+      "meta": {
+        "external_id": "1.2.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b85cf596-f5c2-4735-94d6-999a6e3104b7",
+      "value": "Paid never received"
+    },
+    {
+      "description": "Online marketplace fraud",
+      "meta": {
+        "external_id": "1.2.1.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "79a3ab01-6246-4373-b9c6-8577323dc2c5",
+      "value": "Online marketplace fraud"
+    },
+    {
+      "description": "Other paid never received",
+      "meta": {
+        "external_id": "1.2.1.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "aa637941-423b-4e7e-81c6-fa16b8eea56b",
+      "value": "Other paid never received"
+    },
+    {
+      "description": "Other worthless/non-existent products",
+      "meta": {
+        "external_id": "1.2.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "06ce7d50-14cf-448e-9c7a-5bb8099baea6",
+      "value": "Other worthless or non-existent products"
+    },
+    {
+      "description": "Intentionally entered agreement",
+      "meta": {
+        "external_id": "1.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "492d0edf-2f17-4c98-bb93-102a2e1b6027",
+      "value": "Worthless, unnecessary, or non-existent services"
+    },
+    {
+      "description": "Phony insurance",
+      "meta": {
+        "external_id": "1.2.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0d1407af-55eb-446f-aec0-736142ebd806",
+      "value": "Phony insurance"
+    },
+    {
+      "description": "Immigration services/Notario fraud",
+      "meta": {
+        "external_id": "1.2.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9a99ae4f-2eba-40bb-86ec-dff378826a3a",
+      "value": "Immigration services/Notario fraud"
+    },
+    {
+      "description": "Invention fraud",
+      "meta": {
+        "external_id": "1.2.2.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "589aea2e-06a2-413c-86ab-3b2d9a5d21ad",
+      "value": "Invention fraud"
+    },
+    {
+      "description": "Fraud loss recovery",
+      "meta": {
+        "external_id": "1.2.2.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b16ec896-fdbb-456c-8ecb-10b5ca28f8d0",
+      "value": "Fraud loss recovery"
+    },
+    {
+      "description": "Debt relief scam",
+      "meta": {
+        "external_id": "1.2.2.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "75ccfc95-eba9-4095-afd8-224d371ac9e6",
+      "value": "Debt relief scam"
+    },
+    {
+      "description": "Credit card debt relief scam",
+      "meta": {
+        "external_id": "1.2.2.5.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8bade888-2897-4546-a96c-30431c3397df",
+      "value": "Credit card debt relief scam"
+    },
+    {
+      "description": "Mortgage relief scam",
+      "meta": {
+        "external_id": "1.2.2.5.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "83ddaaf8-00c0-4f95-9e42-71f1af43c0b6",
+      "value": "Mortgage relief scam"
+    },
+    {
+      "description": "Student debt relief scam",
+      "meta": {
+        "external_id": "1.2.2.5.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4551ad19-1458-46e7-a5dc-f5ccfaa2999d",
+      "value": "Student debt relief scam"
+    },
+    {
+      "description": "Medical debt relief scam",
+      "meta": {
+        "external_id": "1.2.2.5.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "c8bd32b7-c12b-467e-b9f9-ad9dc6eeda76",
+      "value": "Medical debt relief scam"
+    },
+    {
+      "description": "Other debt relief scam",
+      "meta": {
+        "external_id": "1.2.2.5.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "65cf5aa8-183a-4a81-a368-31e5c71b5e08",
+      "value": "Other debt relief scam"
+    },
+    {
+      "description": "Credit repair scam",
+      "meta": {
+        "external_id": "1.2.2.6",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "88213de6-f7a0-43a7-a0a0-aaa0562eb64b",
+      "value": "Credit repair scam"
+    },
+    {
+      "description": "Fake credit lines and loans",
+      "meta": {
+        "external_id": "1.2.2.7",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "dd027dd8-75bc-4807-a99e-098cf5de1394",
+      "value": "Fake credit lines and loans"
+    },
+    {
+      "description": "Fake loans",
+      "meta": {
+        "external_id": "1.2.2.7.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.7",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b74084e0-452b-4621-a9af-9e20b464cba8",
+      "value": "Fake loans"
+    },
+    {
+      "description": "Fake credit lines/credit cards",
+      "meta": {
+        "external_id": "1.2.2.7.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.7",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "44cb997d-7b70-4a27-8021-407b31fb76bf",
+      "value": "Fake credit lines/credit cards"
+    },
+    {
+      "description": "Other fake credit lines/loans",
+      "meta": {
+        "external_id": "1.2.2.7.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.7",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "623cfc9c-2775-4d7a-8a5d-316f6430ac20",
+      "value": "Other fake credit lines and loans"
+    },
+    {
+      "description": "Fortune telling fraud",
+      "meta": {
+        "external_id": "1.2.2.8",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "6b3215a3-5418-44c6-8e1b-98b25ced3b49",
+      "value": "Fortune telling fraud"
+    },
+    {
+      "description": "Phishing websites, emails, or calls",
+      "meta": {
+        "external_id": "1.2.2.9",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ef43769e-6aa4-4937-b5cd-c56286f3d273",
+      "value": "Phishing websites/emails/calls"
+    },
+    {
+      "description": "Tech support scam",
+      "meta": {
+        "external_id": "1.2.2.9.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.9",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9d210034-ad54-411a-a488-ea19d3ea3f6d",
+      "value": "Tech support scam"
+    },
+    {
+      "description": "Spoofing websites",
+      "meta": {
+        "external_id": "1.2.2.9.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.9",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2d9f0b9e-ae8d-408e-99b5-793b9cb79146",
+      "value": "Spoofing websites"
+    },
+    {
+      "description": "Other phishing websites/emails/calls",
+      "meta": {
+        "external_id": "1.2.2.9.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.9",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4660da93-3091-4100-97b4-f16972141c82",
+      "value": "Other phishing fraud"
+    },
+    {
+      "description": "Timeshare resale fraud",
+      "meta": {
+        "external_id": "1.2.2.10",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8f3331bc-e115-40f1-a818-21be40708143",
+      "value": "Timeshare resale fraud"
+    },
+    {
+      "description": "Adoption scam",
+      "meta": {
+        "external_id": "1.2.2.11",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1df9b0db-8e6f-4ccc-b52c-5942055367b3",
+      "value": "Adoption scam"
+    },
+    {
+      "description": "Internet gambling fraud",
+      "meta": {
+        "external_id": "1.2.2.12",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0a47213c-2c0c-4579-ba0d-8e268c2e3fdc",
+      "value": "Internet gambling fraud"
+    },
+    {
+      "description": "Fake buyers scam",
+      "meta": {
+        "external_id": "1.2.2.13",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "52201626-024d-4647-b50c-c92329cf81a0",
+      "value": "Fake buyers scam"
+    },
+    {
+      "description": "Repair fraud",
+      "meta": {
+        "external_id": "1.2.2.14",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "5a8c53e2-1c60-4378-ac52-ae84c6696265",
+      "value": "Unnecessary/overpriced repairs, or repairs never performed"
+    },
+    {
+      "description": "Auto repair fraud",
+      "meta": {
+        "external_id": "1.2.2.14.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.14",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "576f8274-f264-4c33-808a-a184fd52ffbc",
+      "value": "Auto repair fraud"
+    },
+    {
+      "description": "Home repair fraud",
+      "meta": {
+        "external_id": "1.2.2.14.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.14",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b0965a1e-4510-4959-9a29-8fb9e0a1c364",
+      "value": "Home repair fraud"
+    },
+    {
+      "description": "Other repair fraud",
+      "meta": {
+        "external_id": "1.2.2.14.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2.14",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b3febd0f-d256-4a29-9bc3-94b00f3922ee",
+      "value": "Other repair fraud"
+    },
+    {
+      "description": "Travel booking scam",
+      "meta": {
+        "external_id": "1.2.2.15",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e475b8e5-8eb0-4434-b70a-8e604f272ad9",
+      "value": "Travel booking scam"
+    },
+    {
+      "description": "Website hosting/design scam",
+      "meta": {
+        "external_id": "1.2.2.16",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "910369e5-fc59-4a14-bcee-121c6b1d2763",
+      "value": "Website hosting/design scam"
+    },
+    {
+      "description": "Domain name scam",
+      "meta": {
+        "external_id": "1.2.2.17",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "3d6cddf4-50e2-4d51-bd50-f0ef92fa4d15",
+      "value": "Domain name scam"
+    },
+    {
+      "description": "Other worthless/unnecessary/non-existent services",
+      "meta": {
+        "external_id": "1.2.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "486e7da5-3d93-4f05-bc6f-c5cb2ab23089",
+      "value": "Other worthless/non-existent services"
+    },
+    {
+      "description": "Unauthorized billing",
+      "meta": {
+        "external_id": "1.2.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2638edaf-5e7c-4038-974d-7f86985d583d",
+      "value": "Unauthorized billing for products or services"
+    },
+    {
+      "description": "Buyer's clubs",
+      "meta": {
+        "external_id": "1.2.3.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "630d20ed-3c20-48bc-b048-e5b0a9d17505",
+      "value": "Buyer's clubs"
+    },
+    {
+      "description": "Unauthorized billing internet services",
+      "meta": {
+        "external_id": "1.2.3.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "81b5df8d-e375-43ec-b8f3-3228a00abcd0",
+      "value": "Unauthorized billing - Internet services"
+    },
+    {
+      "description": "Online yellow pages unauthorized billing",
+      "meta": {
+        "external_id": "1.2.3.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e929e02a-eb5a-4981-bdf1-79449dc9fe2a",
+      "value": "Online yellow pages"
+    },
+    {
+      "description": "Other internet service billing fraud",
+      "meta": {
+        "external_id": "1.2.3.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "c85f4a2b-19bf-4a65-a487-a4532e878bdf",
+      "value": "Other internet services billing fraud"
+    },
+    {
+      "description": "Unauthorized billing phone services",
+      "meta": {
+        "external_id": "1.2.3.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1cf67fc7-f858-4d51-9d3c-a2b318645f71",
+      "value": "Unauthorized billing - Phone services"
+    },
+    {
+      "description": "Cramming",
+      "meta": {
+        "external_id": "1.2.3.3.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4c7cd25c-d963-4e33-adad-07263f85cb2f",
+      "value": "Cramming"
+    },
+    {
+      "description": "Slamming",
+      "meta": {
+        "external_id": "1.2.3.3.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "d9b7cb2d-501d-43d0-b88e-91b6860d35ae",
+      "value": "Slamming"
+    },
+    {
+      "description": "Other phone service billing fraud",
+      "meta": {
+        "external_id": "1.2.3.3.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b2bf5e6f-900e-498e-8a78-45571006d01b",
+      "value": "Other phone services billing fraud"
+    },
+    {
+      "description": "Unauthorized billing magazines",
+      "meta": {
+        "external_id": "1.2.3.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a817b1ff-71ea-4fd5-bd4f-a5c3334b317b",
+      "value": "Unauthorized billing - Magazines"
+    },
+    {
+      "description": "Unauthorized billing credit monitoring services",
+      "meta": {
+        "external_id": "1.2.3.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "daa4f6e0-4b9e-4173-8e7b-4e83a093ed26",
+      "value": "Unauthorized billing - Credit monitoring services"
+    },
+    {
+      "description": "Other unauthorized billing fraud",
+      "meta": {
+        "external_id": "1.2.3.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "eb9f93f1-c30a-46a6-923d-aa351b73b933",
+      "value": "Other unauthorized billing fraud"
+    },
+    {
+      "description": "Other consumer products/services fraud",
+      "meta": {
+        "external_id": "1.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "82db6736-2946-4ff8-b4de-93bb42c72ce2",
+      "value": "Other consumer products & services"
+    },
+    {
+      "description": "Expected employment",
+      "meta": {
+        "external_id": "1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "945a939d-3b3f-449a-b54c-9d8a3b63bea0",
+      "value": "Employment Fraud"
+    },
+    {
+      "description": "Business opportunities fraud",
+      "meta": {
+        "external_id": "1.3.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a6ca6226-a0bd-4de5-bb83-6e6365537a2f",
+      "value": "Business opportunities fraud"
+    },
+    {
+      "description": "Multi-level marketing scheme",
+      "meta": {
+        "external_id": "1.3.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4933aaf6-c43d-43ca-9453-99375a2b90cb",
+      "value": "Multi-level marketing scheme"
+    },
+    {
+      "description": "Vending machines or ATM leasing scam",
+      "meta": {
+        "external_id": "1.3.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b958cf66-f9dd-4ca3-9f9d-3e8b1a733072",
+      "value": "Vending machines/ATM leasing scam"
+    },
+    {
+      "description": "House flipping courses scam",
+      "meta": {
+        "external_id": "1.3.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "37736d7b-6938-4b44-81cf-25c2c4382f89",
+      "value": "House flipping courses"
+    },
+    {
+      "description": "Business coaching scam",
+      "meta": {
+        "external_id": "1.3.1.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "c152be77-8264-46f4-a62d-cb430f65d3e2",
+      "value": "Business coaching scam"
+    },
+    {
+      "description": "Other business opportunities fraud",
+      "meta": {
+        "external_id": "1.3.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "264d7b06-fdd1-4222-9c39-a4daf6f5fb3a",
+      "value": "Other business opportunities fraud"
+    },
+    {
+      "description": "Work-at-home scam",
+      "meta": {
+        "external_id": "1.3.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4e32de33-0051-4e55-96c9-5d230a761627",
+      "value": "Work-at-home scam"
+    },
+    {
+      "description": "Home assembly scam",
+      "meta": {
+        "external_id": "1.3.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "121db231-5222-4556-a602-4e4404fdff5a",
+      "value": "Home assembly"
+    },
+    {
+      "description": "Envelope stuffing scam",
+      "meta": {
+        "external_id": "1.3.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "74f2471a-0b27-49b6-8095-4b0afc638f29",
+      "value": "Envelope stuffing"
+    },
+    {
+      "description": "Mystery shopper scam",
+      "meta": {
+        "external_id": "1.3.2.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "eb6f41da-5ed8-4f6e-87f2-489df7161186",
+      "value": "Mystery Shopper"
+    },
+    {
+      "description": "Reshipping scam",
+      "meta": {
+        "external_id": "1.3.2.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "cc9bd695-af7b-4eb1-b5af-7625f6b73a41",
+      "value": "Reshipping"
+    },
+    {
+      "description": "Other work-at-home scam",
+      "meta": {
+        "external_id": "1.3.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2a0626e4-e9f1-4a4d-ba31-9044c0b45fa4",
+      "value": "Other work-at-home scam"
+    },
+    {
+      "description": "Government job placement scam",
+      "meta": {
+        "external_id": "1.3.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "d5e04493-8f71-4542-9af8-86b9e859f140",
+      "value": "Government job placement scam"
+    },
+    {
+      "description": "Other employment scam",
+      "meta": {
+        "external_id": "1.3.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "81b99f36-1adf-4154-b01d-c4aba88c7526",
+      "value": "Other employment scam"
+    },
+    {
+      "description": "Nanny scam",
+      "meta": {
+        "external_id": "1.3.4.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9d1b1b11-357a-4463-9a4c-4743d32f8c46",
+      "value": "Nanny scam"
+    },
+    {
+      "description": "Modeling fraud",
+      "meta": {
+        "external_id": "1.3.4.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.3.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "fdb933f0-99a8-46e5-884d-eecf7e7dc3ad",
+      "value": "Modeling fraud"
+    },
+    {
+      "description": "Expected winnings in prize, lottery, grant, or other windfall",
+      "meta": {
+        "external_id": "1.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "31401e64-0618-4258-83b8-06233d36db4d",
+      "value": "Prize and Grant Fraud"
+    },
+    {
+      "description": "Prize promotion/sweepstakes scam",
+      "meta": {
+        "external_id": "1.4.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ee613efd-a6b7-4ea8-b520-91615795c0bd",
+      "value": "Prize promotion/Sweepstakes scam"
+    },
+    {
+      "description": "Free product scam",
+      "meta": {
+        "external_id": "1.4.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "30d5df8f-d55a-442c-a165-b86cbfa246e2",
+      "value": "Free product"
+    },
+    {
+      "description": "Free vacation scam",
+      "meta": {
+        "external_id": "1.4.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b53ecf3c-afa8-4784-92cc-8a041fb1ca73",
+      "value": "Free vacation"
+    },
+    {
+      "description": "Cash prize scam",
+      "meta": {
+        "external_id": "1.4.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f41abbde-2012-476a-a7ed-e1a4884a8fb8",
+      "value": "Cash Prize"
+    },
+    {
+      "description": "Sweepstakes scam",
+      "meta": {
+        "external_id": "1.4.1.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b8eeeca6-f775-4264-80b7-22ae9cb8e6a9",
+      "value": "Sweepstakes scam"
+    },
+    {
+      "description": "Other prize promotion/sweepstakes scam",
+      "meta": {
+        "external_id": "1.4.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "17881dcd-6e61-4441-9edf-9d1f270fc718",
+      "value": "Other prize promotion/sweepstakes scam"
+    },
+    {
+      "description": "Bogus lottery scam",
+      "meta": {
+        "external_id": "1.4.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "d058fbe7-9014-4eef-89b2-c02b2c1a5848",
+      "value": "Bogus lottery scam"
+    },
+    {
+      "description": "Foreign lottery scam",
+      "meta": {
+        "external_id": "1.4.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "cccac484-74e1-4c54-afb8-052875e3b1bf",
+      "value": "Foreign lottery scam"
+    },
+    {
+      "description": "Other bogus lottery scam",
+      "meta": {
+        "external_id": "1.4.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "7fe1f6b5-3130-4df2-86a3-d053354e8ebd",
+      "value": "Other bogus lottery scam"
+    },
+    {
+      "description": "Nigerian letter fraud",
+      "meta": {
+        "external_id": "1.4.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ee5b1e69-e733-4147-ac3e-630b63275417",
+      "value": "Nigerian letter fraud"
+    },
+    {
+      "description": "Government grant scam",
+      "meta": {
+        "external_id": "1.4.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0cde825c-5d18-4ff4-bd1a-95ca86154e96",
+      "value": "Government grant scam"
+    },
+    {
+      "description": "Inheritance scam",
+      "meta": {
+        "external_id": "1.4.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1def43ee-a212-4f24-9218-ae1d2b10fea4",
+      "value": "Inheritance scam"
+    },
+    {
+      "description": "IRS tax refund opportunity scam",
+      "meta": {
+        "external_id": "1.4.6",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "086b5c40-026c-490a-b7af-2319ef5bbb48",
+      "value": "IRS tax refund opportunity"
+    },
+    {
+      "description": "Other prize and grant fraud",
+      "meta": {
+        "external_id": "1.4.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.4",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "0bdc2628-6ac1-468d-af62-100d7a71db93",
+      "value": "Other prize & grant fraud"
+    },
+    {
+      "description": "Expected benefit is avoiding fake debt consequences",
+      "meta": {
+        "external_id": "1.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "57ff232a-6931-4f4c-a75f-30b0e4946075",
+      "value": "Phantom Debt Collection Fraud"
+    },
+    {
+      "description": "Government debt collections scam",
+      "meta": {
+        "external_id": "1.5.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "85fa5c09-b361-43ee-9c23-d9ec544a0098",
+      "value": "Government debt collections scam"
+    },
+    {
+      "description": "Court impersonation scam",
+      "meta": {
+        "external_id": "1.5.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b2697f3f-8e77-413f-b84b-6b3a5c3dddaa",
+      "value": "Court impersonation scam"
+    },
+    {
+      "description": "IRS back taxes scheme",
+      "meta": {
+        "external_id": "1.5.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f261d622-426c-42e6-8a2e-6cc5703df84a",
+      "value": "IRS back taxes scheme"
+    },
+    {
+      "description": "Other government debt collections scam",
+      "meta": {
+        "external_id": "1.5.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e7509062-3b7c-45f2-8240-971c582ce78c",
+      "value": "Other government debt collections scam"
+    },
+    {
+      "description": "Lender debt collection scam",
+      "meta": {
+        "external_id": "1.5.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "185b2e86-9ccc-4745-bbd4-7dd493715f8f",
+      "value": "Lender debt collection scam"
+    },
+    {
+      "description": "Obituary scam",
+      "meta": {
+        "external_id": "1.5.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "3cb2abce-4c66-4e55-9718-1a10b33e3c09",
+      "value": "Obituary scam"
+    },
+    {
+      "description": "Loan debt scam",
+      "meta": {
+        "external_id": "1.5.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "51e14e58-3f22-4ed2-ba96-5511634fb6a7",
+      "value": "Loan debt scam"
+    },
+    {
+      "description": "Other lender debt collection scam",
+      "meta": {
+        "external_id": "1.5.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "7b728b00-4c31-4c3f-8160-8076d73661db",
+      "value": "Other lender debt collection scam"
+    },
+    {
+      "description": "Business debt collection scam",
+      "meta": {
+        "external_id": "1.5.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "be381607-add9-42d0-bf00-b75a5ad17a60",
+      "value": "Business debt collection scam"
+    },
+    {
+      "description": "Fake health and medical debt",
+      "meta": {
+        "external_id": "1.5.3.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4651538e-1024-4336-8e53-fa8877cb2260",
+      "value": "Fake health and medical debt"
+    },
+    {
+      "description": "Other business debt collection scam",
+      "meta": {
+        "external_id": "1.5.3.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5.3",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "9b6b0ba8-58b0-4ac8-9592-4d34b12d69f8",
+      "value": "Other business debt collection scam"
+    },
+    {
+      "description": "Other phantom debt fraud",
+      "meta": {
+        "external_id": "1.5.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.5",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "01d48fea-7a9b-4cb8-8943-16e1b1c0e002",
+      "value": "Other phantom debt fraud"
+    },
+    {
+      "description": "Expected outcome is charitable giving",
+      "meta": {
+        "external_id": "1.6",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "25b88400-0862-449d-a7df-9e692f29e462",
+      "value": "Charity Fraud"
+    },
+    {
+      "description": "Bogus charitable organization",
+      "meta": {
+        "external_id": "1.6.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ae6cb670-eca3-4011-84c2-b302534f1987",
+      "value": "Bogus charitable organization"
+    },
+    {
+      "description": "Bogus natural disaster-related charity",
+      "meta": {
+        "external_id": "1.6.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f33c8ab7-3739-4ef9-938b-054e5f317274",
+      "value": "Bogus natural disaster-related charity"
+    },
+    {
+      "description": "Bogus disease-related charity",
+      "meta": {
+        "external_id": "1.6.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "38809f54-fb22-4372-93d7-690fddda98f9",
+      "value": "Bogus disease-related charity"
+    },
+    {
+      "description": "Bogus law enforcement charity",
+      "meta": {
+        "external_id": "1.6.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a8ee7390-9891-4c96-82ea-f5e02ac166c3",
+      "value": "Bogus law enforcement charity"
+    },
+    {
+      "description": "Bogus veteran charity",
+      "meta": {
+        "external_id": "1.6.1.4",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2074db0b-e7e0-439a-9aba-2a69779085a6",
+      "value": "Bogus veteran charity"
+    },
+    {
+      "description": "Bogus church/religious group charity",
+      "meta": {
+        "external_id": "1.6.1.5",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "68fb86a9-14e4-4efb-a2c6-fc2c1985ecc1",
+      "value": "Bogus church/religious group charity"
+    },
+    {
+      "description": "Bogus animal shelter",
+      "meta": {
+        "external_id": "1.6.1.6",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1ee121b5-8dfd-4c1c-a7a7-37e43ecd61be",
+      "value": "Bogus animal shelter"
+    },
+    {
+      "description": "Bogus alumni charitable giving",
+      "meta": {
+        "external_id": "1.6.1.7",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "df1497fa-e516-456a-837b-f959f67711b0",
+      "value": "Bogus alumni charitable giving"
+    },
+    {
+      "description": "Bogus children's charity",
+      "meta": {
+        "external_id": "1.6.1.8",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "32847a8e-4f28-4f7f-a74c-546a51f76334",
+      "value": "Bogus children's charity"
+    },
+    {
+      "description": "Bogus political group",
+      "meta": {
+        "external_id": "1.6.1.9",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "f5b69a5f-2c27-4f43-b2f3-aa10e6f7e63d",
+      "value": "Bogus political group"
+    },
+    {
+      "description": "Bogus youth organization",
+      "meta": {
+        "external_id": "1.6.1.10",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "db9f82e7-ce40-4b9a-918e-e4e01d3667d5",
+      "value": "Bogus youth organization"
+    },
+    {
+      "description": "Other bogus charitable organization",
+      "meta": {
+        "external_id": "1.6.1.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "51c03fe4-3f6c-42c7-974d-0e9783b0c650",
+      "value": "Other bogus charitable organization"
+    },
+    {
+      "description": "Crowdfunding for bogus cause",
+      "meta": {
+        "external_id": "1.6.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "baee246f-c322-4ce2-96f7-328da15f91e7",
+      "value": "Crowdfunding for bogus cause"
+    },
+    {
+      "description": "Fake personal medical expenses",
+      "meta": {
+        "external_id": "1.6.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "68548ff2-32bd-4a2c-ba2c-3959f6fc1776",
+      "value": "Fake personal medical expenses"
+    },
+    {
+      "description": "False identity as tragedy survivor",
+      "meta": {
+        "external_id": "1.6.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "5f03a5c1-375c-4f60-b8af-9aedadafbbc9",
+      "value": "False identity as natural disaster or national tragedy survivor"
+    },
+    {
+      "description": "Other crowdfunding for bogus cause",
+      "meta": {
+        "external_id": "1.6.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "be773b25-6576-4217-bcde-fb981e85585c",
+      "value": "Other crowdfunding for bogus cause"
+    },
+    {
+      "description": "Other charity fraud",
+      "meta": {
+        "external_id": "1.6.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.6",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "b515c63b-c1c4-4900-8f27-1c2742bbdd83",
+      "value": "Other charity fraud"
+    },
+    {
+      "description": "Expected outcome is fostering a relationship",
+      "meta": {
+        "external_id": "1.7",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1ae68cb6-1d14-4133-ab27-689a6a2fa9b3",
+      "value": "Relationship & Trust Fraud"
+    },
+    {
+      "description": "Romance or sweetheart scam",
+      "meta": {
+        "external_id": "1.7.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.7",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "96aae29a-adc7-43df-be3a-e64f16231389",
+      "value": "Romance scam/Sweetheart scam"
+    },
+    {
+      "description": "Friends/relatives imposter scam",
+      "meta": {
+        "external_id": "1.7.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.7",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4eec1789-9b03-4c80-943e-e23c7a4b90ec",
+      "value": "Friends or relatives imposter scam"
+    },
+    {
+      "description": "Grandparent scam",
+      "meta": {
+        "external_id": "1.7.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.7.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "e5d1a695-59bb-4b5d-ad85-dc61a10acf5a",
+      "value": "Grandparent scam"
+    },
+    {
+      "description": "Other friends or relatives imposter scam",
+      "meta": {
+        "external_id": "1.7.2.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.7.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2b5a12b6-7da3-43a5-8a31-4e8c65eead37",
+      "value": "Other friends/relatives imposter scam"
+    },
+    {
+      "description": "Other relationship and trust fraud",
+      "meta": {
+        "external_id": "1.7.99",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "1.7",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "8730f8eb-7158-4663-9772-5d13136ea80c",
+      "value": "Other relationship & trust fraud"
+    },
+    {
+      "description": "Fraud against an organization",
+      "meta": {
+        "external_id": "2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "1d57ee7a-6f04-4a9e-b0ac-f910a384d37a",
+      "value": "Fraud Against an Organization"
+    },
+    {
+      "description": "Fraud against government and society",
+      "meta": {
+        "external_id": "2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "a1485654-1a68-4045-b82b-90d5d66b9d79",
+      "value": "Fraud against government agencies, programs, regulations, and society"
+    },
+    {
+      "description": "Examples include welfare, disability, medicare, medicaid fraud",
+      "meta": {
+        "external_id": "2.1.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "47816f5d-7809-4374-ad35-6781c3dc30c6",
+      "value": "Government Programs"
+    },
+    {
+      "description": "Examples include immigration, voting, tax, stamp fraud",
+      "meta": {
+        "external_id": "2.1.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "2f72a9e0-112e-4c66-950a-3f1998d19ee7",
+      "value": "Government Regulations"
+    },
+    {
+      "description": "Examples include insider trading and environmental fraud",
+      "meta": {
+        "external_id": "2.1.3",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2.1",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "032e2806-bc67-4b3b-94d2-ad46ed02bcba",
+      "value": "Other"
+    },
+    {
+      "description": "Fraud against non-government organizations",
+      "meta": {
+        "external_id": "2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "ac29c785-3458-4beb-9750-76eeb7b89b73",
+      "value": "Fraud against non-governmental businesses or organizations"
+    },
+    {
+      "description": "Examples include corruption, asset misappropriation, financial statement fraud",
+      "meta": {
+        "external_id": "2.2.1",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "16ccea88-9653-47ab-9a72-555146bfca70",
+      "value": "Occupational Fraud, committed by internal perpetrator"
+    },
+    {
+      "description": "Examples include insurance fraud, bank fraud, fraudulent suppliers",
+      "meta": {
+        "external_id": "2.2.2",
+        "group": "taxonomy",
+        "kind": "taxonomy-node",
+        "parent": "2.2",
+        "refs": [
+          "https://longevity.stanford.edu/framework-for-a-taxonomy-of-fraud/"
+        ]
+      },
+      "uuid": "4c8db6fd-d2c0-4e8b-a47f-b01158818f55",
+      "value": "Fraud committed by external perpetrator"
+    }
+  ],
+  "version": 1
+}

--- a/galaxies/taxonomy-of-fraud.json
+++ b/galaxies/taxonomy-of-fraud.json
@@ -1,0 +1,9 @@
+{
+  "description": "Stanford Center on Longevity Taxonomy of Fraud (2015).",
+  "icon": "money-bill-wave",
+  "name": "Taxonomy of Fraud",
+  "namespace": "misp",
+  "type": "taxonomy-of-fraud",
+  "uuid": "3cf14007-e09c-462c-aaeb-5a2846f54acb",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable implementation of the Stanford Center on Longevity "Taxonomy of Fraud" (2015) so MISP users can tag and classify fraud incidents programmatically.
- Expose the taxonomy as a reusable galaxy/cluster pairing for event/attribute enrichment and consistent reporting across the project.
- Capture attribute tags (incident/victim/perpetrator) and taxonomy hierarchy while resolving the source ambiguity for duplicate codes (e.g., `FP`).

### Description
- Added a new galaxy definition at `galaxies/taxonomy-of-fraud.json` and a matching cluster at `clusters/taxonomy-of-fraud.json` with the Stanford taxonomy metadata and UUIDs.
- Populated the cluster with the taxonomy hierarchy and attribute tags (206 values were generated), and included per-entry metadata fields such as `external_id`, `group`, `parent`, `kind`, and `refs` where applicable.
- Implemented attribute-tag entries for incident/victim/perpetrator groups and taxonomy-node entries for Category 1 and Category 2 hierarchy levels and sublevels.
- Resolved the duplicate `FP` code in the source PDF by adding a clear `FP-Family` entry for the family-member perpetrator and keeping explanatory text in the `description` metadata.

### Testing
- Ran `./validate_all.sh` which performed schema and file validations (schema checks completed; the script initially exited non-zero due to local formatting changes prior to normalization).
- Applied repository formatting/normalization with `./jq_all_the_things.sh` and re-ran repository validators which completed successfully.
- Validation steps included running repository helpers such as `tools/add_missing_uuid.py` as part of the validation pipeline and confirmed the generated JSON files were formatted and validated by the project tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea90f512bc83248d9cd4e7a2139402)