### PR TITLE
mkdocs: add matrix overview rendering for matrix-style galaxy pages

### DIFF
--- a/tools/mkdocs/generator.py
+++ b/tools/mkdocs/generator.py
@@ -47,9 +47,23 @@ def get_deprecated_galaxy_files():
     return deprecated_galaxy_files
 
 
+def get_galaxy_metadata():
+    metadata = {}
+    for f in os.listdir(GALAXY_PATH):
+        if not f.endswith(".json"):
+            continue
+        with open(os.path.join(GALAXY_PATH, f)) as fr:
+            galaxy_json = json.load(fr)
+            metadata[f] = {
+                "kill_chain_order": galaxy_json.get("kill_chain_order", {}),
+            }
+    return metadata
+
+
 if __name__ == "__main__":
     start_time = time.time()
     universe = Universe()
+    galaxy_metadata = get_galaxy_metadata()
 
     FILES_TO_IGNORE.extend(get_deprecated_galaxy_files())
     galaxies_fnames = []
@@ -67,6 +81,9 @@ if __name__ == "__main__":
                 json_file_name=galaxy,
                 authors=galaxy_json["authors"],
                 description=galaxy_json["description"],
+                kill_chain_order=galaxy_metadata.get(galaxy, {}).get(
+                    "kill_chain_order", {}
+                ),
             )
             for cluster in galaxy_json["values"]:
                 universe.add_cluster(

--- a/tools/mkdocs/modules/galaxy.py
+++ b/tools/mkdocs/modules/galaxy.py
@@ -1,4 +1,5 @@
 from modules.cluster import Cluster
+from utils.helper import name_to_section
 from typing import List
 import os
 
@@ -10,11 +11,13 @@ class Galaxy:
         json_file_name: str,
         authors: List[str],
         description: str,
+        kill_chain_order=None,
     ):
         self.galaxy_name = galaxy_name
         self.json_file_name = json_file_name
         self.authors = authors
         self.description = description
+        self.kill_chain_order = kill_chain_order or {}
 
         self.clusters = {}  # Maps uuid to Cluster objects
 
@@ -36,6 +39,7 @@ class Galaxy:
         entry += self._create_metadata_entry()
         entry += self._create_title_entry()
         entry += self._create_description_entry()
+        entry += self._create_matrix_entry()
         entry += self._create_authors_entry()
         entry += self._create_clusters_entry()
         return entry
@@ -73,6 +77,69 @@ class Galaxy:
             entry += f"     |----------------------------|\n"
             for author in self.authors:
                 entry += f"     |{author}|\n"
+        return entry
+
+    def _create_matrix_entry(self):
+        if not self.kill_chain_order:
+            return ""
+
+        entry = "\n## Matrix view\n"
+        entry += "This view groups clusters by matrix phase for quicker navigation.\n\n"
+
+        mapped_clusters = {matrix: {phase: [] for phase in phases} for matrix, phases in self.kill_chain_order.items()}
+        seen_entries = {matrix: {phase: set() for phase in phases} for matrix, phases in self.kill_chain_order.items()}
+
+        for cluster in self.clusters.values():
+            if not isinstance(cluster.meta, dict):
+                continue
+            kill_chain_values = cluster.meta.get("kill_chain")
+            if not isinstance(kill_chain_values, list):
+                continue
+
+            for kill_chain in kill_chain_values:
+                parts = str(kill_chain).split(":")
+                if len(parts) < 2:
+                    continue
+
+                if len(parts) >= 3:
+                    matrix = parts[-2]
+                    phase = parts[-1]
+                else:
+                    matrix = parts[0]
+                    phase = parts[1]
+
+                if matrix not in mapped_clusters or phase not in mapped_clusters[matrix]:
+                    continue
+
+                if cluster.uuid in seen_entries[matrix][phase]:
+                    continue
+
+                mapped_clusters[matrix][phase].append(cluster)
+                seen_entries[matrix][phase].add(cluster.uuid)
+
+        for matrix, phases in self.kill_chain_order.items():
+            if len(self.kill_chain_order) > 1:
+                entry += f"### {matrix}\n\n"
+
+            entry += f"| {' | '.join(phases)} |\n"
+            entry += f"| {' | '.join(['---'] * len(phases))} |\n"
+
+            row_cells = []
+            for phase in phases:
+                clusters = sorted(
+                    mapped_clusters[matrix][phase], key=lambda cluster: cluster.value.lower()
+                )
+                if not clusters:
+                    row_cells.append(" ")
+                    continue
+                links = [
+                    f"[{cluster.value}](#{name_to_section(cluster.value)})"
+                    for cluster in clusters
+                ]
+                row_cells.append("<br>".join(links))
+
+            entry += f"| {' | '.join(row_cells)} |\n\n"
+
         return entry
 
     def _create_clusters_entry(self):

--- a/tools/mkdocs/modules/universe.py
+++ b/tools/mkdocs/modules/universe.py
@@ -10,13 +10,21 @@ class Universe:
         self.add_inbound_relationship = add_inbound_relationship
         self.private_clusters = {}
 
-    def add_galaxy(self, galaxy_name, json_file_name, authors, description):
+    def add_galaxy(
+        self,
+        galaxy_name,
+        json_file_name,
+        authors,
+        description,
+        kill_chain_order=None,
+    ):
         if galaxy_name not in self.galaxies:
             self.galaxies[galaxy_name] = Galaxy(
                 galaxy_name=galaxy_name,
                 json_file_name=json_file_name,
                 authors=authors,
                 description=description,
+                kill_chain_order=kill_chain_order,
             )
 
     def add_cluster(self, galaxy_name, uuid, description, value, meta):


### PR DESCRIPTION
### Motivation
- Large matrix-style galaxies (MITRE/other matrices) are hard to navigate in the long cluster list and need a compact matrix overview for quicker navigation.
- The generator needs to surface `kill_chain_order` from `galaxies/*.json` so pages can render phase columns in the correct order.

### Description
- Load galaxy metadata (`kill_chain_order`) in `tools/mkdocs/generator.py` and pass it into the `Galaxy` objects when building the universe.
- Extend `Universe.add_galaxy()` and `Galaxy.__init__()` to accept and store `kill_chain_order` metadata.
- Add `Galaxy._create_matrix_entry()` and wire it into `generate_entry()` to render a new "Matrix view" section that builds phase-ordered tables grouping clusters by `meta.kill_chain` and linking each entry to the cluster anchor using `name_to_section`.
- Files modified: `tools/mkdocs/generator.py`, `tools/mkdocs/modules/galaxy.py`, `tools/mkdocs/modules/universe.py`.

### Testing
- Ran `python3 -m pip install -r tools/mkdocs/requirements.txt` which failed in this environment due to pinned dependency conflicts between `cffi==1.16.0` and an environment `cryptography` version (dependency resolution conflict).
- Installed `validators` separately with `python3 -m pip install validators` to satisfy runtime imports for the generator, which succeeded.
- Ran the generator from the mkdocs working directory with `python3 generator.py` (from `tools/mkdocs/`) and confirmed generation completed and matrix sections were produced for matrix-style galaxies.
- Executed a focused Python smoke-check that instantiated the Tea Matrix galaxy and verified `## Matrix view` appears in `Galaxy.generate_entry()` output, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea93efabe88324b516001f2290bdc6)