### PR TITLE
Add missing Android malware families to clusters/android.json

### DIFF
--- a/clusters/android.json
+++ b/clusters/android.json
@@ -4789,7 +4789,161 @@
       ],
       "uuid": "18291752-7340-4478-8347-63e402429a42",
       "value": "ExoBot"
+    },
+    {
+      "description": "Brain Test is an Android trojanized app campaign that subscribed victims to premium-rate SMS services without consent.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Brain_Test"
+        ]
+      },
+      "uuid": "b5aa6f39-ede9-453d-bab7-a40d7ee8e67e",
+      "value": "Brain Test"
+    },
+    {
+      "description": "CamScanner distributed a malicious SDK module in Android builds that downloaded and executed additional malicious code.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/CamScanner"
+        ]
+      },
+      "uuid": "5a023f7f-2f63-4d45-b23b-12eb40e34bf8",
+      "value": "CamScanner"
+    },
+    {
+      "description": "Cytrox is the vendor behind the Predator spyware platform used to target Android devices via exploit chains and surveillance tooling.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Cytrox",
+          "https://en.wikipedia.org/wiki/Predator_(spyware)"
+        ]
+      },
+      "uuid": "1e741522-4721-4f92-afc4-f6f2f11d7d7d",
+      "value": "Cytrox"
+    },
+    {
+      "description": "Dendroid is an Android remote access trojan sold in underground forums with capabilities for data theft and device control.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Dendroid_(malware)"
+        ]
+      },
+      "uuid": "0af5b715-8923-4927-8d82-0c866f9f0e7a",
+      "value": "Dendroid"
+    },
+    {
+      "description": "DroidKungFu is Android malware that used privilege-escalation exploits to gain root and install additional payloads.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/DroidKungFu"
+        ]
+      },
+      "uuid": "de1fbb14-add3-4e16-b996-5f4c9c5aa011",
+      "value": "DroidKungFu"
+    },
+    {
+      "description": "First Wap (Android.FakePlayer) is an early Android trojan that sent premium SMS messages from infected devices.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/First_Wap"
+        ]
+      },
+      "uuid": "96681de4-0ded-4b72-bd58-6655971d6951",
+      "value": "First Wap"
+    },
+    {
+      "description": "FluBot is an Android banking malware delivered via smishing campaigns that steals credentials and contact data.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/FluBot"
+        ]
+      },
+      "uuid": "11ce956e-2431-4a2c-9662-858340373886",
+      "value": "FluBot"
+    },
+    {
+      "description": "GingerMaster is Android malware targeting Android 2.3 devices by exploiting privilege-escalation vulnerabilities.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/GingerMaster"
+        ]
+      },
+      "uuid": "7afea72d-f4b1-4e95-b6f0-e76442678a7c",
+      "value": "GingerMaster"
+    },
+    {
+      "description": "Hermit is commercial Android spyware used in targeted attacks to exfiltrate messages, calls, and device data.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Hermit_(spyware)"
+        ]
+      },
+      "uuid": "d708d50a-9601-49e0-82b3-fee6ae87f57b",
+      "value": "Hermit"
+    },
+    {
+      "description": "NotCompatible is Android malware that turned infected phones into a proxy botnet for malicious traffic operations.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/NotCompatible"
+        ]
+      },
+      "uuid": "24d04b61-2f81-4a2a-a6c0-ba8f46f9061d",
+      "value": "NotCompatible"
+    },
+    {
+      "description": "Pegasus is advanced spyware with Android capabilities including exploit-based infection and extensive surveillance.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Pegasus_(spyware)"
+        ]
+      },
+      "uuid": "99cb1983-f748-409b-a56f-bcb9ea970a4d",
+      "value": "Pegasus"
+    },
+    {
+      "description": "Predator is Android spyware associated with Cytrox and Intellexa that supports stealthy surveillance and data collection.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Predator_(spyware)"
+        ]
+      },
+      "uuid": "20738b99-5805-4b9b-9470-3d47ba987d49",
+      "value": "Predator"
+    },
+    {
+      "description": "Shedun is Android adware/malware known for rooting devices and embedding itself as system software.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Shedun"
+        ]
+      },
+      "uuid": "c397e593-e7e7-45df-973b-4691406a948c",
+      "value": "Shedun"
+    },
+    {
+      "description": "Xafecopy Trojan is Android malware that covertly subscribes users to WAP premium services by intercepting confirmation messages.",
+      "meta": {
+        "refs": [
+          "https://en.wikipedia.org/wiki/Xafecopy_Trojan"
+        ]
+      },
+      "uuid": "2d56ec0a-4ff7-4b19-9f64-7e04c8919b66",
+      "value": "Xafecopy Trojan"
+    },
+    {
+      "description": "Mirax (also reported as MiraiX) is an Android RAT reported by Cleafy that turns infected devices into residential proxy nodes and supports remote fraud operations.",
+      "meta": {
+        "refs": [
+          "https://www.cleafy.com/cleafy-labs/mirax-a-new-android-rat-turning-infected-devices-into-potential-residential-proxy-nodes"
+        ],
+        "synonyms": [
+          "MiraiX"
+        ]
+      },
+      "uuid": "56da55d5-ad5b-4c3f-abd9-e44d918e2a5c",
+      "value": "Mirax"
     }
   ],
-  "version": 23
+  "version": 24
 }


### PR DESCRIPTION
### Motivation
- Ensure the Android galaxy cluster includes malware families referenced by public sources (Wikipedia category and Cleafy research) so the cluster is more comprehensive and up-to-date.

### Description
- Added the following Android malware entries to `clusters/android.json`: Brain Test, CamScanner, Cytrox, Dendroid, DroidKungFu, First Wap, FluBot, GingerMaster, Hermit, NotCompatible, Pegasus, Predator, Shedun, and Xafecopy Trojan.
- Added Mirax (reported by Cleafy) and recorded `MiraiX` as a synonym to preserve compatibility with alternate names.
- Incremented the cluster `version` from `23` to `24` and ensured no duplicate entries were introduced.
- Updated the JSON file at `clusters/android.json` with descriptions and reference URLs for each added value.

### Testing
- Validated JSON syntax and parseability with `python -m json.tool clusters/android.json`, which succeeded.
- Verified new entries exist in the file using `rg -n` for the added family names, which succeeded.
- Confirmed the file remains well-formed by running `python -m json.tool clusters/android.json >/dev/null && echo OK`, which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8b7ac2048324944e577ea3eead57)