### PR TITLE
Add synthetic exercise-world galaxy with fictional entities

### DIFF
--- a/clusters/exercise-world.json
+++ b/clusters/exercise-world.json
@@ -1,0 +1,1465 @@
+{
+  "authors": [
+    "MISP Project",
+    "GPT-5.3-Codex"
+  ],
+  "category": "tool",
+  "description": "Self-contained fictional world dataset for cyber exercises and standards documents.",
+  "name": "Synthetic Exercise World",
+  "source": "https://www.misp-project.org/galaxy.html",
+  "type": "exercise-world",
+  "uuid": "7d6d7f2f-b3d4-4bc5-9f27-43e12f7f4658",
+  "values": [
+    {
+      "value": "Asterin Union",
+      "uuid": "cb97ba71-e477-4acb-9470-10f3e6c9e1a9",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Northern supercontinent"
+        ],
+        "capital": [
+          "Asterin Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Velkar Republic",
+      "uuid": "e4cd09cc-7be7-46ef-8989-5b9a812b49fe",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Inland industrial basin"
+        ],
+        "capital": [
+          "Velkar Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Orinthia",
+      "uuid": "74d2286a-1b87-4984-8dd1-c5bd466ecca5",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Archipelago of research hubs"
+        ],
+        "capital": [
+          "Orinthia Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Caelum Protectorate",
+      "uuid": "4a600b9f-b843-446f-a234-415aded47e1b",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "High-altitude plateau state"
+        ],
+        "capital": [
+          "Caelum Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Neruva Federation",
+      "uuid": "cfe1b22e-38b5-4077-bb90-b2bc5fedb965",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Delta megacities and ports"
+        ],
+        "capital": [
+          "Neruva Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Thyros Commonwealth",
+      "uuid": "970fd807-b09e-4379-9a44-bebc5d0b9869",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Resource-rich steppe"
+        ],
+        "capital": [
+          "Thyros Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Ilyndor",
+      "uuid": "1e875520-fb3e-4d26-a982-44a5fb7f9375",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Neutral trade corridor"
+        ],
+        "capital": [
+          "Ilyndor Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Brinax Collective",
+      "uuid": "91f273f8-66c0-446f-bdb2-4233fd0c55ef",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Energy-grid cooperative state"
+        ],
+        "capital": [
+          "Brinax Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Soreth Dominion",
+      "uuid": "c4be7f53-6d08-4472-8480-49ccb7946e78",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Polar logistics nation"
+        ],
+        "capital": [
+          "Soreth Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "Quenari League",
+      "uuid": "54670ad5-49fe-4d0c-8a81-84b06a8b5050",
+      "description": "Synthetic country on planet Nacre used for neutral cyber exercise narratives.",
+      "meta": {
+        "entity-type": [
+          "country"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "geography": [
+          "Equatorial agri-tech alliance"
+        ],
+        "capital": [
+          "Quenari Prime"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "tabletop",
+          "training"
+        ]
+      }
+    },
+    {
+      "value": "NovaCore Systems",
+      "uuid": "e3d6ab68-ad7b-4deb-9c0d-c0250013d1bb",
+      "description": "Fictional energy enterprise operating in Asterin Union for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Energy"
+        ],
+        "headquarters": [
+          "Asterin Union"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "HelixCore Group",
+      "uuid": "df601e63-1a5f-4cec-a071-152f1c62f310",
+      "description": "Fictional finance enterprise operating in Velkar Republic for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Finance"
+        ],
+        "headquarters": [
+          "Velkar Republic"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "IronCore Dynamics",
+      "uuid": "7477aeca-f4ba-4d9c-a261-7e5609033ad6",
+      "description": "Fictional healthcare enterprise operating in Orinthia for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Healthcare"
+        ],
+        "headquarters": [
+          "Orinthia"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "BlueBridge Networks",
+      "uuid": "2531f94d-d514-4530-b4eb-35fce204aa36",
+      "description": "Fictional telecommunications enterprise operating in Caelum Protectorate for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Telecommunications"
+        ],
+        "headquarters": [
+          "Caelum Protectorate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "SkyBridge Labs",
+      "uuid": "d688f826-d566-41c9-99af-16574aa05921",
+      "description": "Fictional aerospace enterprise operating in Neruva Federation for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Aerospace"
+        ],
+        "headquarters": [
+          "Neruva Federation"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "VertexBridge Systems",
+      "uuid": "8d018f2a-03c2-4467-8b4e-14ee2ea33df8",
+      "description": "Fictional logistics enterprise operating in Thyros Commonwealth for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Logistics"
+        ],
+        "headquarters": [
+          "Thyros Commonwealth"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "CinderHarbor Group",
+      "uuid": "5196ad35-99b3-41fd-bb4a-286bf08adc4c",
+      "description": "Fictional manufacturing enterprise operating in Ilyndor for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Manufacturing"
+        ],
+        "headquarters": [
+          "Ilyndor"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "AuroraHarbor Dynamics",
+      "uuid": "d3631b81-e8b1-473c-bd9e-d2daf003a467",
+      "description": "Fictional maritime enterprise operating in Brinax Collective for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Maritime"
+        ],
+        "headquarters": [
+          "Brinax Collective"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "DeltaHarbor Networks",
+      "uuid": "f68c4a8e-beff-4666-8c85-78deb549088e",
+      "description": "Fictional food enterprise operating in Soreth Dominion for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Food"
+        ],
+        "headquarters": [
+          "Soreth Dominion"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "QuantumMatrix Labs",
+      "uuid": "f0ca111f-53b1-491f-9c3e-f8ef6a83e974",
+      "description": "Fictional media enterprise operating in Quenari League for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Media"
+        ],
+        "headquarters": [
+          "Quenari League"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "NovaMatrix Systems",
+      "uuid": "ba6c4261-b74f-4e36-ba47-9af4ad63bfd4",
+      "description": "Fictional energy enterprise operating in Asterin Union for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Energy"
+        ],
+        "headquarters": [
+          "Asterin Union"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "HelixMatrix Group",
+      "uuid": "8cccd3e0-3ade-48c8-83b9-b09523ddec00",
+      "description": "Fictional finance enterprise operating in Velkar Republic for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Finance"
+        ],
+        "headquarters": [
+          "Velkar Republic"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "IronPulse Dynamics",
+      "uuid": "2da913d9-d380-4461-9acd-44f67178589a",
+      "description": "Fictional healthcare enterprise operating in Orinthia for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Healthcare"
+        ],
+        "headquarters": [
+          "Orinthia"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "BluePulse Networks",
+      "uuid": "0bbd45b1-a029-4497-8d93-9df82ca4b8c3",
+      "description": "Fictional telecommunications enterprise operating in Caelum Protectorate for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Telecommunications"
+        ],
+        "headquarters": [
+          "Caelum Protectorate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "SkyPulse Labs",
+      "uuid": "de2e6bc9-64df-4b7b-8c10-698aed474d2c",
+      "description": "Fictional aerospace enterprise operating in Neruva Federation for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Aerospace"
+        ],
+        "headquarters": [
+          "Neruva Federation"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "VertexFoundry Systems",
+      "uuid": "bbac3990-2ae8-4872-a24a-2d9bf3a44086",
+      "description": "Fictional logistics enterprise operating in Thyros Commonwealth for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Logistics"
+        ],
+        "headquarters": [
+          "Thyros Commonwealth"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "CinderFoundry Group",
+      "uuid": "6c295716-28f9-485e-af6f-0619677d9e37",
+      "description": "Fictional manufacturing enterprise operating in Ilyndor for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Manufacturing"
+        ],
+        "headquarters": [
+          "Ilyndor"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "AuroraFoundry Dynamics",
+      "uuid": "10ed09dc-bd53-466a-bfc5-c47c65c75141",
+      "description": "Fictional maritime enterprise operating in Brinax Collective for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Maritime"
+        ],
+        "headquarters": [
+          "Brinax Collective"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "DeltaNimbus Networks",
+      "uuid": "47a8428c-1427-4eb2-b7a6-6f4f40b69ed1",
+      "description": "Fictional food enterprise operating in Soreth Dominion for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Food"
+        ],
+        "headquarters": [
+          "Soreth Dominion"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "QuantumNimbus Labs",
+      "uuid": "412eadf8-d9ff-414f-8001-9635322d4bd9",
+      "description": "Fictional media enterprise operating in Quenari League for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Media"
+        ],
+        "headquarters": [
+          "Quenari League"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "NovaNimbus Systems",
+      "uuid": "93130c22-9361-405b-a91e-de5bd1c2e718",
+      "description": "Fictional energy enterprise operating in Asterin Union for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Energy"
+        ],
+        "headquarters": [
+          "Asterin Union"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "HelixForge Group",
+      "uuid": "28daddab-1f7e-4116-a8ce-285dd3bb2a8d",
+      "description": "Fictional finance enterprise operating in Velkar Republic for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Finance"
+        ],
+        "headquarters": [
+          "Velkar Republic"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "IronForge Dynamics",
+      "uuid": "40e99f1c-44aa-4ae1-9b57-f3ee963d6a91",
+      "description": "Fictional healthcare enterprise operating in Orinthia for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Healthcare"
+        ],
+        "headquarters": [
+          "Orinthia"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "BlueForge Networks",
+      "uuid": "fdc855e6-4827-4f80-84f6-eafd7687aed5",
+      "description": "Fictional telecommunications enterprise operating in Caelum Protectorate for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Telecommunications"
+        ],
+        "headquarters": [
+          "Caelum Protectorate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "SkyLattice Labs",
+      "uuid": "a72d657f-b242-4b6b-ab31-1aa15bff4c4f",
+      "description": "Fictional aerospace enterprise operating in Neruva Federation for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Aerospace"
+        ],
+        "headquarters": [
+          "Neruva Federation"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "VertexLattice Systems",
+      "uuid": "5b8a3c47-d6d4-470d-bca3-de2ef41391c9",
+      "description": "Fictional logistics enterprise operating in Thyros Commonwealth for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Logistics"
+        ],
+        "headquarters": [
+          "Thyros Commonwealth"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "CinderLattice Group",
+      "uuid": "d7748db1-8949-456f-a3b3-1072c6baacc3",
+      "description": "Fictional manufacturing enterprise operating in Ilyndor for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Manufacturing"
+        ],
+        "headquarters": [
+          "Ilyndor"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "AuroraBeacon Dynamics",
+      "uuid": "5621dc5a-ba38-45b7-93c6-40c19c9b0b4c",
+      "description": "Fictional maritime enterprise operating in Brinax Collective for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Maritime"
+        ],
+        "headquarters": [
+          "Brinax Collective"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "DeltaBeacon Networks",
+      "uuid": "a8685ecb-33cc-4f6a-850d-7b3e7ff21be6",
+      "description": "Fictional food enterprise operating in Soreth Dominion for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Food"
+        ],
+        "headquarters": [
+          "Soreth Dominion"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "QuantumBeacon Labs",
+      "uuid": "f869e852-7648-4066-a0dc-ed743e11aa05",
+      "description": "Fictional media enterprise operating in Quenari League for simulation scenarios.",
+      "meta": {
+        "entity-type": [
+          "company"
+        ],
+        "sector": [
+          "Media"
+        ],
+        "headquarters": [
+          "Quenari League"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "red-blue-exercise"
+        ]
+      }
+    },
+    {
+      "value": "TA-700 Obsidian Jackal",
+      "uuid": "6c922d71-43e3-40c4-a1ea-85929f0c2f1a",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Asterin Union"
+        ],
+        "primary-motivation": [
+          "Espionage"
+        ],
+        "sophistication": [
+          "minimal"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-701 Silver Mantis",
+      "uuid": "e8b1ce9a-128c-4546-907d-02178fc72e49",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Velkar Republic"
+        ],
+        "primary-motivation": [
+          "Financial disruption"
+        ],
+        "sophistication": [
+          "intermediate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-702 Crimson Rook",
+      "uuid": "8ea5ed6e-8753-4150-946f-157b3bf49bc0",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Orinthia"
+        ],
+        "primary-motivation": [
+          "Strategic signaling"
+        ],
+        "sophistication": [
+          "advanced"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-703 Violet Hydra",
+      "uuid": "56eb0bfc-4fe4-4fbc-bd0d-9e26a87e1217",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Caelum Protectorate"
+        ],
+        "primary-motivation": [
+          "Technology theft"
+        ],
+        "sophistication": [
+          "expert"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-704 Amber Drift",
+      "uuid": "716458aa-8ba1-4a82-9783-926381bfeb43",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Neruva Federation"
+        ],
+        "primary-motivation": [
+          "Influence operations"
+        ],
+        "sophistication": [
+          "minimal"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-705 Cobalt Jackal",
+      "uuid": "cfecc787-5ee0-4786-a285-dc3c7919e7a0",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Thyros Commonwealth"
+        ],
+        "primary-motivation": [
+          "Espionage"
+        ],
+        "sophistication": [
+          "intermediate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-706 Onyx Mantis",
+      "uuid": "10170ce4-b93c-48e0-84a5-a32f7e6818be",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Ilyndor"
+        ],
+        "primary-motivation": [
+          "Financial disruption"
+        ],
+        "sophistication": [
+          "advanced"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-707 Ivory Rook",
+      "uuid": "7a6197e0-ee8f-4e21-ba48-ce0a42f67856",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Brinax Collective"
+        ],
+        "primary-motivation": [
+          "Strategic signaling"
+        ],
+        "sophistication": [
+          "expert"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-708 Sable Hydra",
+      "uuid": "fd0dcf97-33f4-47d7-84c7-9a1559929f3e",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Soreth Dominion"
+        ],
+        "primary-motivation": [
+          "Technology theft"
+        ],
+        "sophistication": [
+          "minimal"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-709 Copper Drift",
+      "uuid": "f3d700cb-3106-46d6-8d3d-a7b6da24d107",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Quenari League"
+        ],
+        "primary-motivation": [
+          "Influence operations"
+        ],
+        "sophistication": [
+          "intermediate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-710 Obsidian Jackal",
+      "uuid": "e69c8045-5c58-4c57-adca-050f8bfe6d9b",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Asterin Union"
+        ],
+        "primary-motivation": [
+          "Espionage"
+        ],
+        "sophistication": [
+          "advanced"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-711 Silver Mantis",
+      "uuid": "aeb9675f-e0e6-4353-9773-d59aa3bfbc73",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Velkar Republic"
+        ],
+        "primary-motivation": [
+          "Financial disruption"
+        ],
+        "sophistication": [
+          "expert"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-712 Crimson Rook",
+      "uuid": "a99082c4-860b-4dd2-8582-da152d27332c",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Orinthia"
+        ],
+        "primary-motivation": [
+          "Strategic signaling"
+        ],
+        "sophistication": [
+          "minimal"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-713 Violet Hydra",
+      "uuid": "81444ffd-67c9-43e7-9a5c-5dc3a9119778",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Caelum Protectorate"
+        ],
+        "primary-motivation": [
+          "Technology theft"
+        ],
+        "sophistication": [
+          "intermediate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-714 Amber Drift",
+      "uuid": "5c0cc8ef-72b8-4794-bc5c-a9cb7c549f75",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Neruva Federation"
+        ],
+        "primary-motivation": [
+          "Influence operations"
+        ],
+        "sophistication": [
+          "advanced"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-715 Cobalt Jackal",
+      "uuid": "5487d618-0462-4a0b-8b03-b16f1253ed20",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Thyros Commonwealth"
+        ],
+        "primary-motivation": [
+          "Espionage"
+        ],
+        "sophistication": [
+          "expert"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-716 Onyx Mantis",
+      "uuid": "9b878df9-4c6e-416f-8d48-2ef872055622",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Ilyndor"
+        ],
+        "primary-motivation": [
+          "Financial disruption"
+        ],
+        "sophistication": [
+          "minimal"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-717 Ivory Rook",
+      "uuid": "84d00f48-6a15-45fd-bc4a-0aa9c8dac8cf",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Brinax Collective"
+        ],
+        "primary-motivation": [
+          "Strategic signaling"
+        ],
+        "sophistication": [
+          "intermediate"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-718 Sable Hydra",
+      "uuid": "3a98840d-72f2-4f65-9781-bc02aee78193",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Soreth Dominion"
+        ],
+        "primary-motivation": [
+          "Technology theft"
+        ],
+        "sophistication": [
+          "advanced"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    },
+    {
+      "value": "TA-719 Copper Drift",
+      "uuid": "82b93df3-2d87-4018-a5d4-cb93cad38cdc",
+      "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
+      "meta": {
+        "entity-type": [
+          "threat-actor"
+        ],
+        "origin": [
+          "Quenari League"
+        ],
+        "primary-motivation": [
+          "Influence operations"
+        ],
+        "sophistication": [
+          "expert"
+        ],
+        "planet": [
+          "Nacre"
+        ],
+        "exercise-use": [
+          "standard-drafting",
+          "cti-training"
+        ]
+      }
+    }
+  ],
+  "version": 1
+}

--- a/galaxies/exercise-world.json
+++ b/galaxies/exercise-world.json
@@ -1,0 +1,9 @@
+{
+  "description": "Exercise-only synthetic world entities for cyber scenarios and standards drafting.",
+  "icon": "globe",
+  "name": "Synthetic Exercise World",
+  "namespace": "misp",
+  "type": "exercise-world",
+  "uuid": "3c3de5f0-5982-4c7f-88cf-8abf43b8d6c1",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation

- Provide a self-contained, politically neutral dataset suitable for cyber exercises and standards drafting to avoid referencing real countries, actors or trademarked companies.
- Enable red/blue exercises, tabletop scenarios and CTI training using synthetic entities that are realistic in structure but explicitly fictional.
- Present data within a coherent sci‑fi setting (planet `Nacre`) to make geographic/sector relationships consistent and reusable in standards.

### Description

- Add a new galaxy file `galaxies/exercise-world.json` defining a `type: "exercise-world"` galaxy with metadata (`description`, `icon`, `namespace`, `uuid`, `version`).
- Add a new cluster file `clusters/exercise-world.json` containing 60 synthetic entries with stable UUIDs and structured `meta` fields.
- The cluster includes `10` fictional countries (with `geography` and `capital`), `30` fictional companies (with `sector` and `headquarters`), and `20` fictional threat actors (with `origin`, `primary-motivation`, and `sophistication`).
- All entries include exercise-focused tags such as `planet: ["Nacre"]` and `exercise-use` and the cluster `authors` list includes `"MISP Project"` and `"GPT-5.3-Codex"`.

### Testing

- Validated JSON syntax for both files using `python -m json.tool` with no errors.
- Ran the repository validation workflow `./validate_all.sh` (schema checks, UUID/metadata processing and formatting) which processed the new cluster and galaxy without schema errors.
- Programmatically verified entity counts with a small Python check confirming `country: 10`, `company: 30`, and `threat-actor: 20`.
- Confirmed `tools/add_missing_uuid.py` and repository JSON formatting steps executed during validation and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbc1d749c8324aab46295ab70f976)