### PR TITLE
Link threat-actor entries to targets and operating locations in exercise-world.json

### DIFF
--- a/clusters/exercise-world.json
+++ b/clusters/exercise-world.json
@@ -964,7 +964,25 @@
         ]
       },
       "uuid": "6c922d71-43e3-40c4-a1ea-85929f0c2f1a",
-      "value": "TA-700 Obsidian Jackal"
+      "value": "TA-700 Obsidian Jackal",
+      "related": [
+        {
+          "dest-uuid": "e3d6ab68-ad7b-4deb-9c0d-c0250013d1bb",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ba6c4261-b74f-4e36-ba47-9af4ad63bfd4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "93130c22-9361-405b-a91e-de5bd1c2e718",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "cb97ba71-e477-4acb-9470-10f3e6c9e1a9",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -990,7 +1008,25 @@
         ]
       },
       "uuid": "e8b1ce9a-128c-4546-907d-02178fc72e49",
-      "value": "TA-701 Silver Mantis"
+      "value": "TA-701 Silver Mantis",
+      "related": [
+        {
+          "dest-uuid": "df601e63-1a5f-4cec-a071-152f1c62f310",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "8cccd3e0-3ade-48c8-83b9-b09523ddec00",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "28daddab-1f7e-4116-a8ce-285dd3bb2a8d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e4cd09cc-7be7-46ef-8989-5b9a812b49fe",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1016,7 +1052,25 @@
         ]
       },
       "uuid": "8ea5ed6e-8753-4150-946f-157b3bf49bc0",
-      "value": "TA-702 Crimson Rook"
+      "value": "TA-702 Crimson Rook",
+      "related": [
+        {
+          "dest-uuid": "7477aeca-f4ba-4d9c-a261-7e5609033ad6",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2da913d9-d380-4461-9acd-44f67178589a",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "40e99f1c-44aa-4ae1-9b57-f3ee963d6a91",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "74d2286a-1b87-4984-8dd1-c5bd466ecca5",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1042,7 +1096,25 @@
         ]
       },
       "uuid": "56eb0bfc-4fe4-4fbc-bd0d-9e26a87e1217",
-      "value": "TA-703 Violet Hydra"
+      "value": "TA-703 Violet Hydra",
+      "related": [
+        {
+          "dest-uuid": "2531f94d-d514-4530-b4eb-35fce204aa36",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "0bbd45b1-a029-4497-8d93-9df82ca4b8c3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "fdc855e6-4827-4f80-84f6-eafd7687aed5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "4a600b9f-b843-446f-a234-415aded47e1b",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1068,7 +1140,25 @@
         ]
       },
       "uuid": "716458aa-8ba1-4a82-9783-926381bfeb43",
-      "value": "TA-704 Amber Drift"
+      "value": "TA-704 Amber Drift",
+      "related": [
+        {
+          "dest-uuid": "d688f826-d566-41c9-99af-16574aa05921",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "de2e6bc9-64df-4b7b-8c10-698aed474d2c",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "a72d657f-b242-4b6b-ab31-1aa15bff4c4f",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "cfe1b22e-38b5-4077-bb90-b2bc5fedb965",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1094,7 +1184,25 @@
         ]
       },
       "uuid": "cfecc787-5ee0-4786-a285-dc3c7919e7a0",
-      "value": "TA-705 Cobalt Jackal"
+      "value": "TA-705 Cobalt Jackal",
+      "related": [
+        {
+          "dest-uuid": "8d018f2a-03c2-4467-8b4e-14ee2ea33df8",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bbac3990-2ae8-4872-a24a-2d9bf3a44086",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "5b8a3c47-d6d4-470d-bca3-de2ef41391c9",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "970fd807-b09e-4379-9a44-bebc5d0b9869",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1120,7 +1228,25 @@
         ]
       },
       "uuid": "10170ce4-b93c-48e0-84a5-a32f7e6818be",
-      "value": "TA-706 Onyx Mantis"
+      "value": "TA-706 Onyx Mantis",
+      "related": [
+        {
+          "dest-uuid": "5196ad35-99b3-41fd-bb4a-286bf08adc4c",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "6c295716-28f9-485e-af6f-0619677d9e37",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "d7748db1-8949-456f-a3b3-1072c6baacc3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1e875520-fb3e-4d26-a982-44a5fb7f9375",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1146,7 +1272,25 @@
         ]
       },
       "uuid": "7a6197e0-ee8f-4e21-ba48-ce0a42f67856",
-      "value": "TA-707 Ivory Rook"
+      "value": "TA-707 Ivory Rook",
+      "related": [
+        {
+          "dest-uuid": "d3631b81-e8b1-473c-bd9e-d2daf003a467",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "10ed09dc-bd53-466a-bfc5-c47c65c75141",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "5621dc5a-ba38-45b7-93c6-40c19c9b0b4c",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "91f273f8-66c0-446f-bdb2-4233fd0c55ef",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1172,7 +1316,25 @@
         ]
       },
       "uuid": "fd0dcf97-33f4-47d7-84c7-9a1559929f3e",
-      "value": "TA-708 Sable Hydra"
+      "value": "TA-708 Sable Hydra",
+      "related": [
+        {
+          "dest-uuid": "f68c4a8e-beff-4666-8c85-78deb549088e",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "47a8428c-1427-4eb2-b7a6-6f4f40b69ed1",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "a8685ecb-33cc-4f6a-850d-7b3e7ff21be6",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "c4be7f53-6d08-4472-8480-49ccb7946e78",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1198,7 +1360,25 @@
         ]
       },
       "uuid": "f3d700cb-3106-46d6-8d3d-a7b6da24d107",
-      "value": "TA-709 Copper Drift"
+      "value": "TA-709 Copper Drift",
+      "related": [
+        {
+          "dest-uuid": "f0ca111f-53b1-491f-9c3e-f8ef6a83e974",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "412eadf8-d9ff-414f-8001-9635322d4bd9",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f869e852-7648-4066-a0dc-ed743e11aa05",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "54670ad5-49fe-4d0c-8a81-84b06a8b5050",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1224,7 +1404,25 @@
         ]
       },
       "uuid": "e69c8045-5c58-4c57-adca-050f8bfe6d9b",
-      "value": "TA-710 Obsidian Jackal"
+      "value": "TA-710 Obsidian Jackal",
+      "related": [
+        {
+          "dest-uuid": "e3d6ab68-ad7b-4deb-9c0d-c0250013d1bb",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ba6c4261-b74f-4e36-ba47-9af4ad63bfd4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "93130c22-9361-405b-a91e-de5bd1c2e718",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "cb97ba71-e477-4acb-9470-10f3e6c9e1a9",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1250,7 +1448,25 @@
         ]
       },
       "uuid": "aeb9675f-e0e6-4353-9773-d59aa3bfbc73",
-      "value": "TA-711 Silver Mantis"
+      "value": "TA-711 Silver Mantis",
+      "related": [
+        {
+          "dest-uuid": "df601e63-1a5f-4cec-a071-152f1c62f310",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "8cccd3e0-3ade-48c8-83b9-b09523ddec00",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "28daddab-1f7e-4116-a8ce-285dd3bb2a8d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e4cd09cc-7be7-46ef-8989-5b9a812b49fe",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1276,7 +1492,25 @@
         ]
       },
       "uuid": "a99082c4-860b-4dd2-8582-da152d27332c",
-      "value": "TA-712 Crimson Rook"
+      "value": "TA-712 Crimson Rook",
+      "related": [
+        {
+          "dest-uuid": "7477aeca-f4ba-4d9c-a261-7e5609033ad6",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2da913d9-d380-4461-9acd-44f67178589a",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "40e99f1c-44aa-4ae1-9b57-f3ee963d6a91",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "74d2286a-1b87-4984-8dd1-c5bd466ecca5",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1302,7 +1536,25 @@
         ]
       },
       "uuid": "81444ffd-67c9-43e7-9a5c-5dc3a9119778",
-      "value": "TA-713 Violet Hydra"
+      "value": "TA-713 Violet Hydra",
+      "related": [
+        {
+          "dest-uuid": "2531f94d-d514-4530-b4eb-35fce204aa36",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "0bbd45b1-a029-4497-8d93-9df82ca4b8c3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "fdc855e6-4827-4f80-84f6-eafd7687aed5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "4a600b9f-b843-446f-a234-415aded47e1b",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1328,7 +1580,25 @@
         ]
       },
       "uuid": "5c0cc8ef-72b8-4794-bc5c-a9cb7c549f75",
-      "value": "TA-714 Amber Drift"
+      "value": "TA-714 Amber Drift",
+      "related": [
+        {
+          "dest-uuid": "d688f826-d566-41c9-99af-16574aa05921",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "de2e6bc9-64df-4b7b-8c10-698aed474d2c",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "a72d657f-b242-4b6b-ab31-1aa15bff4c4f",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "cfe1b22e-38b5-4077-bb90-b2bc5fedb965",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1354,7 +1624,25 @@
         ]
       },
       "uuid": "5487d618-0462-4a0b-8b03-b16f1253ed20",
-      "value": "TA-715 Cobalt Jackal"
+      "value": "TA-715 Cobalt Jackal",
+      "related": [
+        {
+          "dest-uuid": "8d018f2a-03c2-4467-8b4e-14ee2ea33df8",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bbac3990-2ae8-4872-a24a-2d9bf3a44086",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "5b8a3c47-d6d4-470d-bca3-de2ef41391c9",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "970fd807-b09e-4379-9a44-bebc5d0b9869",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1380,7 +1668,25 @@
         ]
       },
       "uuid": "9b878df9-4c6e-416f-8d48-2ef872055622",
-      "value": "TA-716 Onyx Mantis"
+      "value": "TA-716 Onyx Mantis",
+      "related": [
+        {
+          "dest-uuid": "5196ad35-99b3-41fd-bb4a-286bf08adc4c",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "6c295716-28f9-485e-af6f-0619677d9e37",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "d7748db1-8949-456f-a3b3-1072c6baacc3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1e875520-fb3e-4d26-a982-44a5fb7f9375",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1406,7 +1712,25 @@
         ]
       },
       "uuid": "84d00f48-6a15-45fd-bc4a-0aa9c8dac8cf",
-      "value": "TA-717 Ivory Rook"
+      "value": "TA-717 Ivory Rook",
+      "related": [
+        {
+          "dest-uuid": "d3631b81-e8b1-473c-bd9e-d2daf003a467",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "10ed09dc-bd53-466a-bfc5-c47c65c75141",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "5621dc5a-ba38-45b7-93c6-40c19c9b0b4c",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "91f273f8-66c0-446f-bdb2-4233fd0c55ef",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1432,7 +1756,25 @@
         ]
       },
       "uuid": "3a98840d-72f2-4f65-9781-bc02aee78193",
-      "value": "TA-718 Sable Hydra"
+      "value": "TA-718 Sable Hydra",
+      "related": [
+        {
+          "dest-uuid": "f68c4a8e-beff-4666-8c85-78deb549088e",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "47a8428c-1427-4eb2-b7a6-6f4f40b69ed1",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "a8685ecb-33cc-4f6a-850d-7b3e7ff21be6",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "c4be7f53-6d08-4472-8480-49ccb7946e78",
+          "type": "operates-from"
+        }
+      ]
     },
     {
       "description": "Non-real threat actor profile designed for politically neutral cyber exercises.",
@@ -1458,7 +1800,25 @@
         ]
       },
       "uuid": "82b93df3-2d87-4018-a5d4-cb93cad38cdc",
-      "value": "TA-719 Copper Drift"
+      "value": "TA-719 Copper Drift",
+      "related": [
+        {
+          "dest-uuid": "f0ca111f-53b1-491f-9c3e-f8ef6a83e974",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "412eadf8-d9ff-414f-8001-9635322d4bd9",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f869e852-7648-4066-a0dc-ed743e11aa05",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "54670ad5-49fe-4d0c-8a81-84b06a8b5050",
+          "type": "operates-from"
+        }
+      ]
     }
   ],
   "version": 1


### PR DESCRIPTION
### Motivation

- Enrich threat-actor profiles in the exercise world dataset by explicitly recording relationships to target entities and operating locations to support more realistic exercises and CTI training.

### Description

- Added a `related` array to multiple `threat-actor` objects in `clusters/exercise-world.json` connecting each actor to target UUIDs with type `targets` and to a location UUID with type `operates-from`.
- Kept existing `meta`, `uuid`, and `value` fields unchanged while populating the new relationship references across the affected entries.
- Changes are confined to `clusters/exercise-world.json` and follow the existing JSON object structure used in the cluster file.

### Testing

- Validated the updated JSON file for syntax using `python -m json.tool`, which succeeded.
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005971aae483248db73087ec2a2417)