### PR TITLE
Add SCOR TENs galaxy + Galaxy 2.0 related[] edges on scor-attack-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,14 @@ Category: *incident* - source: *Open sources* - total: *11* elements
 
 [[HTML](https://www.misp-galaxy.org/scor-incidents)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/scor-incidents.json)]
 
+## SCOR TENs
+
+[SCOR TENs](https://www.misp-galaxy.org/scor-tens) - Taxonomic Element Nomenclatures (TENs) of the METEORSTORM five-layer data model. Each value is one stable template (LAYER-TAG-LABEL) that analysts consume during enumeration to produce ETENs (LAYER:TAG:LABEL:ORDINAL) on a specific platform. Attack-path and other analytic cluster values reference these TENs by UUID via related[] arrays with relation type TOE/TDM/TRE per §6.2. Definitions follow METEORSTORM Quick Guide §8.
+
+Category: *meta* - source: *METEORSTORM Quick Guide §8 (Full Data Model).* - total: *30* elements
+
+[[HTML](https://www.misp-galaxy.org/scor-tens)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/scor-tens.json)]
+
 ## Sector
 
 [Sector](https://www.misp-galaxy.org/sector) - Activity sectors

--- a/clusters/scor-attack-paths.json
+++ b/clusters/scor-attack-paths.json
@@ -73,6 +73,106 @@
           "AST:DA:Data:00"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000001",
+          "tags": [
+            "scor-eten:\"PCE:TE:Terrestrial:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000004",
+          "tags": [
+            "scor-eten:\"PCE:OR:Orbital:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000003",
+          "tags": [
+            "scor-eten:\"SEG:GR:Ground:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000002",
+          "tags": [
+            "scor-eten:\"SEG:LI:Link:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000004",
+          "tags": [
+            "scor-eten:\"SEG:US:User:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000009",
+          "tags": [
+            "scor-eten:\"SEG:SP:Space:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000001",
+          "tags": [
+            "scor-eten:\"SVC:CP:Control Plane:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000002",
+          "tags": [
+            "scor-eten:\"SVC:DP:Data Plane:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000003",
+          "tags": [
+            "scor-eten:\"AST:SW:Software:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000002",
+          "tags": [
+            "scor-eten:\"AST:FW:Firmware:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000001",
+          "tags": [
+            "scor-eten:\"AST:HW:Hardware:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000005",
+          "tags": [
+            "scor-eten:\"AST:SI:Signal:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000004",
+          "tags": [
+            "scor-eten:\"AST:DA:Data:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000003",
+          "tags": [
+            "scor-eten:\"AN:ATT:Attack Path:00\""
+          ],
+          "type": "instance-of"
+        }
+      ],
       "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-000000000001",
       "value": "Viasat KA-SAT AcidRain (2022)"
     },
@@ -126,6 +226,64 @@
           "AST:SI:Signal:00"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000003",
+          "tags": [
+            "scor-eten:\"PCE:AE:Aerial:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000001",
+          "tags": [
+            "scor-eten:\"PCE:TE:Terrestrial:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000006",
+          "tags": [
+            "scor-eten:\"SEG:LO:Low Altitude:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000003",
+          "tags": [
+            "scor-eten:\"SEG:GR:Ground:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000001",
+          "tags": [
+            "scor-eten:\"SVC:CP:Control Plane:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000001",
+          "tags": [
+            "scor-eten:\"AST:HW:Hardware:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000005",
+          "tags": [
+            "scor-eten:\"AST:SI:Signal:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000003",
+          "tags": [
+            "scor-eten:\"AN:ATT:Attack Path:00\""
+          ],
+          "type": "instance-of"
+        }
+      ],
       "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-000000000002",
       "value": "Gatwick UAS Incursions (2018)"
     },
@@ -174,6 +332,50 @@
           "AST:DA:Data:00"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000004",
+          "tags": [
+            "scor-eten:\"PCE:OR:Orbital:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000009",
+          "tags": [
+            "scor-eten:\"SEG:SP:Space:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000002",
+          "tags": [
+            "scor-eten:\"SVC:DP:Data Plane:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000001",
+          "tags": [
+            "scor-eten:\"AST:HW:Hardware:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000004",
+          "tags": [
+            "scor-eten:\"AST:DA:Data:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000003",
+          "tags": [
+            "scor-eten:\"AN:ATT:Attack Path:00\""
+          ],
+          "type": "instance-of"
+        }
+      ],
       "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-000000000003",
       "value": "Fengyun-1C Chinese ASAT Test (2007)"
     },
@@ -224,6 +426,57 @@
           "AST:DA:Data:00"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000002",
+          "tags": [
+            "scor-eten:\"PCE:AQ:Aquatic:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000005",
+          "tags": [
+            "scor-eten:\"SEG:AQ:Aquatic:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000001",
+          "tags": [
+            "scor-eten:\"SVC:CP:Control Plane:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000005",
+          "tags": [
+            "scor-eten:\"AST:SI:Signal:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000001",
+          "tags": [
+            "scor-eten:\"AST:HW:Hardware:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000004",
+          "tags": [
+            "scor-eten:\"AST:DA:Data:00\""
+          ],
+          "type": "TOE"
+        },
+        {
+          "dest-uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000003",
+          "tags": [
+            "scor-eten:\"AN:ATT:Attack Path:00\""
+          ],
+          "type": "instance-of"
+        }
+      ],
       "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-000000000004",
       "value": "Yacht GPS Spoofing PoC (UT Austin, 2013)"
     }

--- a/clusters/scor-tens.json
+++ b/clusters/scor-tens.json
@@ -1,0 +1,344 @@
+{
+  "authors": [
+    "H4CK32N4U75®"
+  ],
+  "category": "meta",
+  "description": "Taxonomic Element Nomenclatures (TENs) of the METEORSTORM five-layer data model. Each value is one stable template (LAYER-TAG-LABEL) that analysts consume during enumeration to produce ETENs (LAYER:TAG:LABEL:ORDINAL) on a specific platform. Attack-path and other analytic cluster values reference these TENs by UUID via related[] arrays with relation type TOE/TDM/TRE per §6.2. Definitions follow METEORSTORM Quick Guide §8.",
+  "name": "SCOR TENs",
+  "source": "METEORSTORM Quick Guide §8 (Full Data Model).",
+  "type": "scor-tens",
+  "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-0d1e2f3a4b04",
+  "values": [
+    {
+      "description": "Surface-based operational zones on planetary bodies. Root of the structural ontology; PCE entries enumerate no PARENT reference.",
+      "meta": {
+        "doc_section": "§8.1",
+        "label": "Terrestrial",
+        "layer": "PCE",
+        "tag": "TE"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000001",
+      "value": "PCE-TE-Terrestrial"
+    },
+    {
+      "description": "Water-based operational zones, including maritime domains.",
+      "meta": {
+        "doc_section": "§8.1",
+        "label": "Aquatic",
+        "layer": "PCE",
+        "tag": "AQ"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000002",
+      "value": "PCE-AQ-Aquatic"
+    },
+    {
+      "description": "Atmospheric operational zones spanning low, high, and near-space regions.",
+      "meta": {
+        "doc_section": "§8.1",
+        "label": "Aerial",
+        "layer": "PCE",
+        "tag": "AE"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000003",
+      "value": "PCE-AE-Aerial"
+    },
+    {
+      "description": "Operational zones within planetary or satellite orbits.",
+      "meta": {
+        "doc_section": "§8.1",
+        "label": "Orbital",
+        "layer": "PCE",
+        "tag": "OR"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000004",
+      "value": "PCE-OR-Orbital"
+    },
+    {
+      "description": "Operational zones beyond planetary orbital regimes.",
+      "meta": {
+        "doc_section": "§8.1",
+        "label": "Deep Space",
+        "layer": "PCE",
+        "tag": "DS"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-100000000005",
+      "value": "PCE-DS-Deep Space"
+    },
+    {
+      "description": "Surface-based services and assets for primary launch operations. Every Segment enumerates a PARENT reference to one or more PCE entries.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Launch",
+        "layer": "SEG",
+        "tag": "LA"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000001",
+      "value": "SEG-LA-Launch"
+    },
+    {
+      "description": "Services and assets enabling platform communications across signal paths.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Link",
+        "layer": "SEG",
+        "tag": "LI"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000002",
+      "value": "SEG-LI-Link"
+    },
+    {
+      "description": "Surface-based services and assets for primary platform operations; primary locus of control-plane activity.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Ground",
+        "layer": "SEG",
+        "tag": "GR"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000003",
+      "value": "SEG-GR-Ground"
+    },
+    {
+      "description": "Services and assets for primary end-user operations.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "User",
+        "layer": "SEG",
+        "tag": "US"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000004",
+      "value": "SEG-US-User"
+    },
+    {
+      "description": "Water-based services and assets for primary platform operations.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Aquatic",
+        "layer": "SEG",
+        "tag": "AQ"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000005",
+      "value": "SEG-AQ-Aquatic"
+    },
+    {
+      "description": "Aerial services and assets in the lower atmosphere.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Low Altitude",
+        "layer": "SEG",
+        "tag": "LO"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000006",
+      "value": "SEG-LO-Low Altitude"
+    },
+    {
+      "description": "Aerial services and assets above the lower atmosphere but below near space.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "High Altitude",
+        "layer": "SEG",
+        "tag": "HI"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000007",
+      "value": "SEG-HI-High Altitude"
+    },
+    {
+      "description": "Aerial services and assets above high altitude and below orbital regions.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Near Space",
+        "layer": "SEG",
+        "tag": "NE"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000008",
+      "value": "SEG-NE-Near Space"
+    },
+    {
+      "description": "Services and assets operating in planetary or satellite orbits.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Space",
+        "layer": "SEG",
+        "tag": "SP"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000009",
+      "value": "SEG-SP-Space"
+    },
+    {
+      "description": "Services and assets operating beyond planetary orbital regimes.",
+      "meta": {
+        "doc_section": "§8.2",
+        "label": "Deep Space",
+        "layer": "SEG",
+        "tag": "DE"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-200000000010",
+      "value": "SEG-DE-Deep Space"
+    },
+    {
+      "description": "Services for managing and orchestrating platform control functions. Every Service enumerates a PARENT reference to one or more Segments plus a DISTRIBUTED flag (Y/N).",
+      "meta": {
+        "doc_section": "§8.3",
+        "label": "Control Plane",
+        "layer": "SVC",
+        "tag": "CP"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000001",
+      "value": "SVC-CP-Control Plane"
+    },
+    {
+      "description": "Services for managing and orchestrating mission product functions.",
+      "meta": {
+        "doc_section": "§8.3",
+        "label": "Data Plane",
+        "layer": "SVC",
+        "tag": "DP"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000002",
+      "value": "SVC-DP-Data Plane"
+    },
+    {
+      "description": "Services integrating both control and data plane functionalities.",
+      "meta": {
+        "doc_section": "§8.3",
+        "label": "Hybrid",
+        "layer": "SVC",
+        "tag": "HY"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-300000000003",
+      "value": "SVC-HY-Hybrid"
+    },
+    {
+      "description": "Physical components supporting platform operations. Every Asset enumerates a PARENT reference to exactly one Service and may optionally enumerate a SUBSYSTEM grouping.",
+      "meta": {
+        "doc_section": "§8.4",
+        "label": "Hardware",
+        "layer": "AST",
+        "tag": "HW"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000001",
+      "value": "AST-HW-Hardware"
+    },
+    {
+      "description": "Embedded control code governing hardware functions.",
+      "meta": {
+        "doc_section": "§8.4",
+        "label": "Firmware",
+        "layer": "AST",
+        "tag": "FW"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000002",
+      "value": "AST-FW-Firmware"
+    },
+    {
+      "description": "Applications and logic executing operational tasks.",
+      "meta": {
+        "doc_section": "§8.4",
+        "label": "Software",
+        "layer": "AST",
+        "tag": "SW"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000003",
+      "value": "AST-SW-Software"
+    },
+    {
+      "description": "Information generated, processed, or consumed by the platform.",
+      "meta": {
+        "doc_section": "§8.4",
+        "label": "Data",
+        "layer": "AST",
+        "tag": "DA"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000004",
+      "value": "AST-DA-Data"
+    },
+    {
+      "description": "Communication channels and transmission frequencies.",
+      "meta": {
+        "doc_section": "§8.4",
+        "label": "Signal",
+        "layer": "AST",
+        "tag": "SI"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000005",
+      "value": "AST-SI-Signal"
+    },
+    {
+      "description": "Composite elements combining multiple asset types.",
+      "meta": {
+        "doc_section": "§8.4",
+        "label": "Hybrid",
+        "layer": "AST",
+        "tag": "HY"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-400000000006",
+      "value": "AST-HY-Hybrid"
+    },
+    {
+      "description": "Verifiable indication that the platform has been compromised. Analytic entries do not enumerate a PARENT reference; they enumerate a TARGET reference (TOE for IOC/IOA/ATT/THR; TDM for DET; TRE for RES) plus a SOURCE phase (Real, Modeled, or Synthetic).",
+      "meta": {
+        "doc_section": "§8.5",
+        "label": "Indicator of Compromise",
+        "layer": "AN",
+        "tag": "IOC"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000001",
+      "value": "AN-IOC-Indicator of Compromise"
+    },
+    {
+      "description": "Verifiable indication that the platform has been targeted.",
+      "meta": {
+        "doc_section": "§8.5",
+        "label": "Indicator of Attack",
+        "layer": "AN",
+        "tag": "IOA"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000002",
+      "value": "AN-IOA-Indicator of Attack"
+    },
+    {
+      "description": "Known or modeled attack path for a converged space system.",
+      "meta": {
+        "doc_section": "§8.5",
+        "label": "Attack Path",
+        "layer": "AN",
+        "tag": "ATT"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000003",
+      "value": "AN-ATT-Attack Path"
+    },
+    {
+      "description": "Known adversarial threat to the platform.",
+      "meta": {
+        "doc_section": "§8.5",
+        "label": "Threat",
+        "layer": "AN",
+        "tag": "THR"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000004",
+      "value": "AN-THR-Threat"
+    },
+    {
+      "description": "Pattern, signal, or logic that triggers on contextualized threat behavior.",
+      "meta": {
+        "doc_section": "§8.5",
+        "label": "Detection Signature",
+        "layer": "AN",
+        "tag": "DET"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000005",
+      "value": "AN-DET-Detection Signature"
+    },
+    {
+      "description": "Protective capability ensuring resistance or recovery from threats, for either immediate implementation or as feedback for future platform engineering efforts.",
+      "meta": {
+        "doc_section": "§8.5",
+        "label": "Resilience Measure",
+        "layer": "AN",
+        "tag": "RES"
+      },
+      "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-500000000006",
+      "value": "AN-RES-Resilience Measure"
+    }
+  ],
+  "version": 1
+}

--- a/galaxies/scor-tens.json
+++ b/galaxies/scor-tens.json
@@ -1,0 +1,9 @@
+{
+  "description": "SCOR TENs. Taxonomic Element Nomenclatures (TENs) from the METEORSTORM five-layer data model — the stable templates analysts consume during the enumeration process to produce ETENs on specific platforms. One cluster value per TEN: 5 PCE (Primary Capability Environment), 10 SEG (Segment), 3 SVC (Service), 6 AST (Asset), 6 AN (Analytic Layer). Per the METEORSTORM Quick Guide §4-§5, a TEN identifies the TYPE of element without naming a specific instance; an ETEN is what an analyst creates from a TEN during enumeration by selecting the TEN, assigning an ordinal, and supplying a description. Attack-path cluster values reference these TENs via related[] arrays with relation type TOE (Target of Exploitation per §6.2); the per-scenario ETEN string is carried in the relation's tags. Pairs with the METEORSTORM MISP taxonomy at https://github.com/MISP/misp-taxonomies/tree/main/meteorstorm. Contact: william.o.ferguson@ethicallyhacking.space. License: CC BY 4.0. Namespace_display: SCOR. Namespace_long: Space, Cybersecurity, Operations, and Resilience. Steward: H4CK32N4U75®.",
+  "icon": "sitemap",
+  "name": "SCOR TENs",
+  "namespace": "scor",
+  "type": "scor-tens",
+  "uuid": "7e1c4a8b-3d5f-4e2a-9c8b-0d1e2f3a4b03",
+  "version": 1
+}


### PR DESCRIPTION
# Add SCOR TENs galaxy + Galaxy 2.0 `related[]` edges on scor-attack-paths

Builds on [#1216](https://github.com/MISP/misp-galaxy/pull/1216) (SCOR Attack Paths galaxy, already merged). This PR adds the stable Taxonomic Element Nomenclature (TEN) templates per the METEORSTORM data model, and wires the existing 4 attack-path values to those templates via Galaxy 2.0 `related[]` arrays. Result: MISP's Network View renders the SCOR-compliant relationship graph natively.

## What's added

**`clusters/scor-tens.json`** (new) — 30 cluster values, one per METEORSTORM TEN:

- 5 PCE (Terrestrial, Aquatic, Aerial, Orbital, Deep Space)
- 10 SEG (Launch, Link, Ground, User, Aquatic, Low Altitude, High Altitude, Near Space, Space, Deep Space)
- 3 SVC (Control Plane, Data Plane, Hybrid)
- 6 AST (Hardware, Firmware, Software, Data, Signal, Hybrid)
- 6 AN (Indicator of Compromise, Indicator of Attack, Attack Path, Threat, Detection Signature, Resilience Measure)

Each value carries a stable UUID, layer/tag/label/doc_section meta, and the canonical definition from METEORSTORM Quick Guide §8.

**`galaxies/scor-tens.json`** (new) — minimal galaxy descriptor. No `kill_chain_order` (TENs aren't a matrix).

## What's modified

**`clusters/scor-attack-paths.json`** (modified) — added `related[]` arrays to all 4 existing attack-path values (Viasat AcidRain, Gatwick UAS, Fengyun-1C ASAT, Yacht GPS Spoofing). Each `related[]` entry references a TEN cluster value by UUID:

| Relation type | Purpose | Count across 4 paths |
|---|---|---|
| `TOE` | Per §6.2, points the attack path at each structural TEN (PCE/SEG/SVC/AST) the scenario's enumeration consumed | 31 |
| `instance-of` | Declares the attack-path value as an enumerated instance of the `AN-ATT-Attack Path` TEN | 4 |
| **Total** | | **35** |

The per-scenario ETEN string is preserved on each relation's `tags` array as `scor-eten:"LAYER:TAG:LABEL:ORDINAL"`, so the ordinal context isn't lost when traversing the graph.

## Conceptual model

Per METEORSTORM Quick Guide §4–§5:

- **TEN** = `LAYER-TAG-LABEL` (hyphen-delimited). The stable type template, defined by the taxonomy.
- **ETEN** = `LAYER:TAG:LABEL:ORDINAL` (colon-delimited). What an analyst produces from a TEN during enumeration on a specific platform.

This PR makes the TENs first-class MISP cluster values so Galaxy 2.0 `related[]` arrays can point at them by UUID. The ETEN strings continue to live in the attack-path's `meta` as the per-scenario enumeration outputs.

## What this enables

Once merged, MISP's **Galaxy 2.0 Network View** renders the SCOR-compliant relationship graph:

- Attack-path nodes (Viasat, Gatwick, Fengyun-1C, Yacht) connected by `TOE` edges to the TEN templates each scenario's enumeration consumed.
- Bidirectional pivoting: open a TEN template (e.g., `PCE-OR-Orbital`) and see every attack path that has ever consumed it during enumeration.
- The per-scenario ETEN identifiers (with ordinals) remain visible on each edge's tags.

## Validation

- Both new files pass `jsonschema` validation against `schema_clusters.json` / `schema_galaxies.json`.
- The modified `scor-attack-paths.json` still validates.
- All 35 `related[]` `dest-uuid` references resolve to values in `scor-tens.json` (cross-checked programmatically).
- All UUIDs unique across the SCOR namespace.
- `tools/chk_empty_strings` clean.
- All files in `jq --sort-keys` canonical form.
- `tools/update_README_with_index.py` regenerated `README.md` to include the new scor-tens entry.

## Steward

`scor` namespace steward: H4CK32N4U75®. Contact: william.o.ferguson@ethicallyhacking.space.
