### PR TITLE
Add CTI-CMM 1.3 galaxy and cluster (matrix by domain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Category: *Cryptominers* - source: *Open Source Intelligence* - total: *5* eleme
 
 [[HTML](https://www.misp-galaxy.org/cryptominers)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/cryptominers.json)]
 
+## CTI-CMM 1.3
+
+[CTI-CMM 1.3](https://www.misp-galaxy.org/cti-cmm-1-3) - Cyber Threat Intelligence Capability Maturity Model (CTI-CMM) version 1.3 maturity-indicator practices represented as a matrix-like galaxy by stakeholder domain.
+
+Category: *cyber-threat-intelligence-maturity-model* - source: *https://github.com/cti-cmm/framework* - total: *199* elements
+
+[[HTML](https://www.misp-galaxy.org/cti-cmm-1-3)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/cti-cmm-1-3.json)]
+
 ## CyberFundamentals 2023 Assurance Requirements
 
 [CyberFundamentals 2023 Assurance Requirements](https://www.misp-galaxy.org/cyfun-assurance-requirements-2023) - CyberFundamentals 2023 assurance-level control matrix for MISP. Each cluster value is a level-specific control instance with provenance and key-measure metadata; normative text is referenced, not embedded.

--- a/clusters/cti-cmm-1-3.json
+++ b/clusters/cti-cmm-1-3.json
@@ -1,0 +1,9072 @@
+{
+  "authors": [
+    "CTI-CMM Authors",
+    "MISP Project"
+  ],
+  "category": "cyber-threat-intelligence-maturity-model",
+  "description": "Cyber Threat Intelligence Capability Maturity Model (CTI-CMM) version 1.3 maturity-indicator practices represented as a matrix-like galaxy by stakeholder domain.",
+  "name": "CTI-CMM 1.3",
+  "source": "https://github.com/cti-cmm/framework",
+  "type": "cti-cmm-1-3",
+  "uuid": "1d4541a2-ac47-52f1-b23e-3383238b25da",
+  "values": [
+    {
+      "description": "CTI has access to available asset inventory and uses that access at least in an ad hoc manner. In organizations where an asset inventory is limited — or does not exist — access and/or visibility may be limited to appropriate systems or based upon relationships with technology teams.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ASSET-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          24
+        ],
+        "source_section": "6.1",
+        "use_case": "Asset Visibility",
+        "use_case_number": 1
+      },
+      "uuid": "565f4c5d-9b03-5395-9c8f-0c90b67133a5",
+      "value": "CTI-CMM 1.3 - ASSET-1.a - Asset Visibility"
+    },
+    {
+      "description": "CTI receives alerts concurrently with the asset management team and provides analysis to that team (and other stakeholders) on threats aligned with those newly discovered assets in a timely manner to communicate risk of exposure.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ASSET-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          24
+        ],
+        "source_section": "6.1",
+        "use_case": "Asset Visibility",
+        "use_case_number": 1
+      },
+      "uuid": "f3e71a4f-bda8-5492-a121-cfa3dc4a9aaf",
+      "value": "CTI-CMM 1.3 - ASSET-1.b - Asset Visibility"
+    },
+    {
+      "description": "Intelligence includes contextualized insights and threat assessments of potential future scenarios related to the organization’s IT and operational technology (OT) assets. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ASSET-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          24
+        ],
+        "source_section": "6.1",
+        "use_case": "Asset Visibility",
+        "use_case_number": 1
+      },
+      "uuid": "7610c4d5-4000-58e9-998e-d512c75f6d69",
+      "value": "CTI-CMM 1.3 - ASSET-1.c - Asset Visibility"
+    },
+    {
+      "description": "CTI proactively works with technology teams to identify and enhance the type of information included in asset inventory (such as hardware and software versions, type of information processed or stored by the system, business function supported, network environment details, and other information that can be used to assess criticality and risk).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ASSET-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          24
+        ],
+        "source_section": "6.1",
+        "use_case": "Asset Visibility",
+        "use_case_number": 1
+      },
+      "uuid": "76bc3b33-313e-591c-842b-8acc5de9fa7f",
+      "value": "CTI-CMM 1.3 - ASSET-1.d - Asset Visibility"
+    },
+    {
+      "description": "Intelligence regularly includes prescriptive analysis and recommendations to support asset discovery and risk assessments. (see RISK and ARCHITECTURE)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ASSET-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK",
+          "ARCHITECTURE"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          24
+        ],
+        "source_section": "6.1",
+        "use_case": "Asset Visibility",
+        "use_case_number": 1
+      },
+      "uuid": "54e4c71d-41be-50e9-b5da-14126382892b",
+      "value": "CTI-CMM 1.3 - ASSET-1.e - Asset Visibility"
+    },
+    {
+      "description": "ASSET domain objectives focused on identifying and prioritizing mitigation efforts are regularly informed by CTI insights to ensure a comprehensive view of the organization’s ecosystem.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ASSET-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          24
+        ],
+        "source_section": "6.1",
+        "use_case": "Asset Visibility",
+        "use_case_number": 1
+      },
+      "uuid": "cb6f8725-723a-5d5e-9730-d2a97132ef8c",
+      "value": "CTI-CMM 1.3 - ASSET-1.f - Asset Visibility"
+    },
+    {
+      "description": "CTI maintains an understanding of “crown jewels assets” informed based on potential to disrupt business operations and cyber threat landscape trends. This prioritization is based on asset targeting, criticality, vulnerability, and potential impact in case of attack or exposure.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ASSET-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "80b75c68-2fbb-5ff9-bf08-054d754e402f",
+      "value": "CTI-CMM 1.3 - ASSET-2.a - Safeguard Assets"
+    },
+    {
+      "description": "CTI maintains regular visibility into changes in the cyber threat landscape, triaging intelligence sources to determine relevance and relative impact of newly discovered threat campaigns and vulnerabilities affecting organizational assets. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ASSET-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "fd26ab78-5192-5316-878d-0f1a4481162d",
+      "value": "CTI-CMM 1.3 - ASSET-2.b - Safeguard Assets"
+    },
+    {
+      "description": "Intelligence supports proactive risk mitigation efforts by providing contextualized insights, predictive assessments, and alerting about threats and vulnerabilities that could affect priority assets.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ASSET-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "5310f6d0-19b9-5b6d-8d9e-f5a816e5450a",
+      "value": "CTI-CMM 1.3 - ASSET-2.c - Safeguard Assets"
+    },
+    {
+      "description": "Intelligence identifies vulnerabilities that directly affect priority assets, allowing the organization to prioritize patching efforts. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ASSET-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "6681dbb0-76ac-5fbd-86af-edce3057cf37",
+      "value": "CTI-CMM 1.3 - ASSET-2.d - Safeguard Assets"
+    },
+    {
+      "description": "CTI includes prescriptive threat analysis and recommendations to protect current and pre-deployed assets and change configurations based on the threat environment.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ASSET-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "86c57d9e-d8a1-53cb-b4a6-ebe13ecfcae6",
+      "value": "CTI-CMM 1.3 - ASSET-2.e - Safeguard Assets"
+    },
+    {
+      "description": "ASSET domain risk reduction strategies are consistently informed by CTI insights.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ASSET-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "d1fae77e-1ebe-5cd9-8f24-23e7a5fcc92d",
+      "value": "CTI-CMM 1.3 - ASSET-2.f - Safeguard Assets"
+    },
+    {
+      "description": "CTI is consulted as part of the asset purchase cycle and provides insights to the organization about potential risks (e.g., specific hardware, software, or products that have been targeted in the past).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Monitor the organization’s attack surface to rapidly detect at-risk assets and reduce exposures based on the current and anticipated threat landscape.",
+        "document_version": "1.3",
+        "domain": "Asset, Change, and Configuration Management",
+        "domain_code": "ASSET",
+        "domain_purpose": "Manage the organization’s IT and OT assets, including both hardware and software and information assets, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ASSET-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Asset, Change, and Configuration Management (ASSET)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ASSET-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Asset Management",
+        "source_pages": [
+          25
+        ],
+        "source_section": "6.1",
+        "use_case": "Safeguard Assets",
+        "use_case_number": 2
+      },
+      "uuid": "90f30bf8-697e-5518-99fb-d2ee4af81199",
+      "value": "CTI-CMM 1.3 - ASSET-2.g - Safeguard Assets"
+    },
+    {
+      "description": "Indicators of compromise/behavior/attack (IoC/B/As) are collected from external threat reports and delivered to security operations teams at least in an ad hoc manner (e.g., over email) to support prevention and blocking.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          26
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "9a5fcedf-1374-5120-87eb-0fb6df5ef5c1",
+      "value": "CTI-CMM 1.3 - THREAT-1.a - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Reduction of false positives is supported at least in an ad hoc manner when identified.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          26
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "d68675a0-9381-5850-b5d1-44ccad2a8c12",
+      "value": "CTI-CMM 1.3 - THREAT-1.b - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Ongoing collection of IoC/B/As is pruned at least in an ad hoc manner or based upon default platform (TIP, security information and event management (SIEM), etc.) expiration parameters.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          26
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "aac8c23f-6705-5566-9e49-5350d2476c69",
+      "value": "CTI-CMM 1.3 - THREAT-1.c - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "IoC/B/As are collected from external feeds (usually contextualized by specific types of threats, e.g., phishing hosts, botnets, command-and-control (C2) hosts) and delivered directly to security technologies (e.g., SIEM or firewall solutions) in a mostly automated fashion.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "b8a15463-08ad-5c5b-bea4-2636e5b0c717",
+      "value": "CTI-CMM 1.3 - THREAT-1.d - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Collection of IoC/B/As is automatically ingested and pruned based upon a defined strategy that considers enterprise-specific characteristics, operational factors, and threat profile. Polling frequency occurs on a regular cadence.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "cc29d5ff-5495-5606-b12c-97fe38b26a35",
+      "value": "CTI-CMM 1.3 - THREAT-1.e - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Available threat context (e.g., type of threat, attack stage) also is provided to aid operator awareness, typically reliant on source materials as ground truth.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "e690b46c-93c5-5dbc-84a3-d63cc78d80a2",
+      "value": "CTI-CMM 1.3 - THREAT-1.f - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "IoC/B/As are collected at scale from external feeds covering most types of threats (e.g., phishing infrastructure, botnets, C2 hosts) and delivered directly to relevant security technologies automatically.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-1.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "3a88a479-5089-578a-9875-8652ccc7acc7",
+      "value": "CTI-CMM 1.3 - THREAT-1.g - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "False positives are measured and fidelity is refined. Focus is on increasing the quality of IoC/B/As collected.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-1.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "5f5589a9-aa20-5f43-9412-60af1fec9581",
+      "value": "CTI-CMM 1.3 - THREAT-1.h - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Threat context, based on internal ecosystem knowledge versus reliance solely on source material scoring (e.g., type of threat, attack stage, detection time stamps, impact for relevance), is provided for most indicators to aid operator awareness.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-1.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "32b150a5-b427-5c40-a598-c2765205872f",
+      "value": "CTI-CMM 1.3 - THREAT-1.i - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Ingested high-confidence indicators are integrated to aid in proactive defense activities. For example, adding to automation playbooks and triggering COAs where relevant (e.g., automating implementation of low-regret blocking or phishing response).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.j",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-1.j",
+        "practice_letter": "j",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "e848a65e-f2fe-54d5-8a1e-1b3565582479",
+      "value": "CTI-CMM 1.3 - THREAT-1.j - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Original indicators are correlated with internal event data (e.g., SOC/incident response (IR) investigations), actioned elsewhere within the organization (e.g., via threat hunting), and may also be shared externally.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-1.k",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-1.k",
+        "practice_letter": "k",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Attack Prevention and Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "6a03ae69-4c53-589c-9e4a-90373a0c25fe",
+      "value": "CTI-CMM 1.3 - THREAT-1.k - Enhance Attack Prevention and Preparedness"
+    },
+    {
+      "description": "Alerts about adversaries actively posing potential threats to the organization are delivered at least in an ad hoc manner to support new detection logic.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Drive Detection Engineering Improvements and Strategy",
+        "use_case_number": 2
+      },
+      "uuid": "6528d9ea-5be1-53d7-b72e-87ae02455e88",
+      "value": "CTI-CMM 1.3 - THREAT-2.a - Drive Detection Engineering Improvements and Strategy"
+    },
+    {
+      "description": "Threat profiling is routinely developed to support gap analysis activities and prioritize detection controls based on relevant threats against the organization.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Drive Detection Engineering Improvements and Strategy",
+        "use_case_number": 2
+      },
+      "uuid": "38aae23e-3ba8-5303-a954-ab04ab5352b6",
+      "value": "CTI-CMM 1.3 - THREAT-2.b - Drive Detection Engineering Improvements and Strategy"
+    },
+    {
+      "description": "Continuous detection engineering improvements are supported by requests for information (RFIs) for CTI about specific gaps and vulnerabilities.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Drive Detection Engineering Improvements and Strategy",
+        "use_case_number": 2
+      },
+      "uuid": "bd76f096-93e9-52e9-b918-92fba43d464a",
+      "value": "CTI-CMM 1.3 - THREAT-2.c - Drive Detection Engineering Improvements and Strategy"
+    },
+    {
+      "description": "Threat modeling is routinely developed to identify and contextualize priority threats relevant to the organization.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Drive Detection Engineering Improvements and Strategy",
+        "use_case_number": 2
+      },
+      "uuid": "47e5e059-b573-5387-9f7c-10f15185c2d7",
+      "value": "CTI-CMM 1.3 - THREAT-2.d - Drive Detection Engineering Improvements and Strategy"
+    },
+    {
+      "description": "CTI products regularly drive detection opportunities based on threat modeling, event logs, and external reporting.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Drive Detection Engineering Improvements and Strategy",
+        "use_case_number": 2
+      },
+      "uuid": "43b3abeb-8c3e-5246-8c49-d8146b1aac8b",
+      "value": "CTI-CMM 1.3 - THREAT-2.e - Drive Detection Engineering Improvements and Strategy"
+    },
+    {
+      "description": "Alerts about emerging atomic indicators are provided to generate awareness and reactive hunt operations at least in an ad hoc manner with minimal contextualization using open sources.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-3.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-3.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Threat Hunting",
+        "use_case_number": 3
+      },
+      "uuid": "f8f628c9-662e-5245-9d3e-890e1bb00c6c",
+      "value": "CTI-CMM 1.3 - THREAT-3.a - Enhance Threat Hunting"
+    },
+    {
+      "description": "Threat hunts are prioritized manually based on emerging reporting of threat or vulnerability risks.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-3.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-3.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Threat Hunting",
+        "use_case_number": 3
+      },
+      "uuid": "350162ca-e98b-5145-b5f3-5531b819fcbe",
+      "value": "CTI-CMM 1.3 - THREAT-3.b - Enhance Threat Hunting"
+    },
+    {
+      "description": "Threat hunt operations are routinely informed by intelligence about threat actor TTPs and behaviors, contextualized using open and commercial sources.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-3.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-3.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          27
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Threat Hunting",
+        "use_case_number": 3
+      },
+      "uuid": "8f0a7b2f-2b18-524f-9b63-00cf4aeb990e",
+      "value": "CTI-CMM 1.3 - THREAT-3.c - Enhance Threat Hunting"
+    },
+    {
+      "description": "Threat hunts are continuously prioritized based on priority intelligence requirements (PIRs) and vulnerabilities against critical assets.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-3.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-3.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Threat Hunting",
+        "use_case_number": 3
+      },
+      "uuid": "86ac3fa8-0bb4-52e5-a4da-6559eff736fd",
+      "value": "CTI-CMM 1.3 - THREAT-3.d - Enhance Threat Hunting"
+    },
+    {
+      "description": "Threat hunting methodologies are used to generate RFIs and provide context for new, original threat hunting hypotheses/abstracts (see the TaHiTI Threat Hunting Methodology2 for further details).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-3.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-3.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Enhance Threat Hunting",
+        "use_case_number": 3
+      },
+      "uuid": "bcbc080d-1391-550d-ba57-16ee8f7dfb9c",
+      "value": "CTI-CMM 1.3 - THREAT-3.e - Enhance Threat Hunting"
+    },
+    {
+      "description": "Alerts about emerging tactics, techniques, and exploit campaigns are tested at least in an ad hoc manner with limited contextualization using open sources.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-4.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-4.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Inform Offensive Security Operations",
+        "use_case_number": 4
+      },
+      "uuid": "661d1a55-1165-508e-a5ce-9cb5180e0a65",
+      "value": "CTI-CMM 1.3 - THREAT-4.a - Inform Offensive Security Operations"
+    },
+    {
+      "description": "Insights about novel techniques, procedures, and technical exploits, typically derived from open or commercial sources, are provided regularly to inform relevant offensive security operations.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-4.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-4.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Inform Offensive Security Operations",
+        "use_case_number": 4
+      },
+      "uuid": "0b837c89-6768-5c39-91b7-ff993af64fd7",
+      "value": "CTI-CMM 1.3 - THREAT-4.b - Inform Offensive Security Operations"
+    },
+    {
+      "description": "Intelligence is typically focused on threats pertaining to the organization’s unique threat profile and provided with contextualization and/or code that enables replication of reported behaviors.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-4.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-4.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Inform Offensive Security Operations",
+        "use_case_number": 4
+      },
+      "uuid": "06b15893-03e6-5218-9f81-2462b4c28302",
+      "value": "CTI-CMM 1.3 - THREAT-4.c - Inform Offensive Security Operations"
+    },
+    {
+      "description": "Alerts about new and emerging attack procedures and technical exploits are delivered regularly and typically contain enough context to enable precise recreation of observed behaviors.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-4.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-4.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Inform Offensive Security Operations",
+        "use_case_number": 4
+      },
+      "uuid": "06cf7bbb-ca64-52a2-8d02-4bcef76dfa12",
+      "value": "CTI-CMM 1.3 - THREAT-4.d - Inform Offensive Security Operations"
+    },
+    {
+      "description": "Insights focus on threats pertaining to the organization’s unique threat profile but also novel procedures that may not yet be actively exploited in the wild (e.g., new exploits published on code repositories or acquired via closed sources such as underground forums).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-4.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-4.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Inform Offensive Security Operations",
+        "use_case_number": 4
+      },
+      "uuid": "478a1d86-74fa-585f-b6d5-14fe99382028",
+      "value": "CTI-CMM 1.3 - THREAT-4.e - Inform Offensive Security Operations"
+    },
+    {
+      "description": "Offensive security operations based on threat reporting inform ad hoc collection for missing context and discovered gaps are mitigated for threat prevention.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-4.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-4.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Inform Offensive Security Operations",
+        "use_case_number": 4
+      },
+      "uuid": "8ca0bcb3-762b-5569-8404-ad376dd069cb",
+      "value": "CTI-CMM 1.3 - THREAT-4.f - Inform Offensive Security Operations"
+    },
+    {
+      "description": "Alerts are provided at least in an ad hoc manner for critical vulnerabilities that are experiencing viral popularity in mainstream open sources.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-5.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THREAT-5.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Improve Patch Prioritization",
+        "use_case_number": 5
+      },
+      "uuid": "7f52bd9d-5b99-5304-8af1-881eb3da1c7c",
+      "value": "CTI-CMM 1.3 - THREAT-5.a - Improve Patch Prioritization"
+    },
+    {
+      "description": "Vulnerability management is consistently informed in a repeatable manner for critical and high vulnerabilities that are seeing viral popularity in mainstream open and cybercriminal underground sources.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-5.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-5.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Improve Patch Prioritization",
+        "use_case_number": 5
+      },
+      "uuid": "0ab11a63-dfce-5817-8135-6aca75b888c3",
+      "value": "CTI-CMM 1.3 - THREAT-5.b - Improve Patch Prioritization"
+    },
+    {
+      "description": "Patch prioritization is influenced by availability of PoC code, observed active exploitation, and sought-after interest by adversaries observed in the dark or surface web.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-5.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THREAT-5.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Improve Patch Prioritization",
+        "use_case_number": 5
+      },
+      "uuid": "37422253-0483-5e2a-a2e5-9b61286031d7",
+      "value": "CTI-CMM 1.3 - THREAT-5.c - Improve Patch Prioritization"
+    },
+    {
+      "description": "Patch management is consistently driven by routine CTI products that prescribe key patches or mitigations that need to be implemented based on the probability of exploitation against the enterprise. uploads/TaHiTI-Threat-Hunting-Methodology-whitepaper.pdf. Accessed 26 Mar. 2024.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Maintain comprehensive and contemporary knowledge of the relevant evolving threat landscape to reduce the organization’s risk against new and emerging adversaries, malware, vulnerabilities, and exploits.",
+        "document_version": "1.3",
+        "domain": "Threat and Vulnerability Management",
+        "domain_code": "THREAT",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, identify, analyze, manage, and respond to cybersecurity threats and vulnerabilities commensurate with the risk to the organization’s infrastructure (such as critical, IT, and operational) and organizational objectives.",
+        "external_id": "THREAT-5.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Threat and Vulnerability Management (THREAT)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THREAT-5.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
+        "source_pages": [
+          28
+        ],
+        "source_section": "6.2",
+        "use_case": "Improve Patch Prioritization",
+        "use_case_number": 5
+      },
+      "uuid": "ee8f2f06-0e38-59fb-8aa3-a42d296d9381",
+      "value": "CTI-CMM 1.3 - THREAT-5.d - Improve Patch Prioritization"
+    },
+    {
+      "description": "The main risks to the organization are understood and their relation to the risk management strategy, at least in a basic manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RISK-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          29
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "5004a89d-7752-52a8-84a8-128d7fef5879",
+      "value": "CTI-CMM 1.3 - RISK-1.a - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "Collaboration with risk management stakeholders is conducted in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RISK-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          29
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "ed5c7f2e-1e66-58ac-92a8-55b566309d9f",
+      "value": "CTI-CMM 1.3 - RISK-1.b - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "CTI practices have a focused alignment to the organization’s risk management strategy and framework, aligning inclusion of risk assessment (such as through the use of Binary Risk Analysis3) within CTI products.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RISK-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          29
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "bc9fe17e-9d49-5f1d-8877-45db8dbac0ee",
+      "value": "CTI-CMM 1.3 - RISK-1.c - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "Meetings and engagements between CTI and risk management teams occur regularly.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RISK-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          29
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "528b67b9-1853-54fa-b69b-b3ff05f35f50",
+      "value": "CTI-CMM 1.3 - RISK-1.d - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "CTI practices influence proactive adjustments to risk management strategies.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RISK-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          29
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "410abb18-5c7b-5dba-9240-4f580c407099",
+      "value": "CTI-CMM 1.3 - RISK-1.e - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "CTI practices adhere to the risk framework adopted by the organization, such as NIST 800-30 and the NIST Cybersecurity Framework.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RISK-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          29
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "103a4e2c-b238-565f-a478-7bc6268f79d0",
+      "value": "CTI-CMM 1.3 - RISK-1.f - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "CTI insights are used to prioritize risk-based decisions and actions based upon the threat landscape (sometimes called a Cyber Threat Profile). If possible, risks identified from CTI insights are integrated into risk management dashboards. (see ARCHITECTURE)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RISK-1.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "ARCHITECTURE"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "0edc882c-96d3-5b0d-84a8-ecca1d16972f",
+      "value": "CTI-CMM 1.3 - RISK-1.g - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "CTI establishes ongoing alignment with risk management strategies with a focus on enhancing processes through automation. (see PROGRAM)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-1.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RISK-1.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "PROGRAM"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Align CTI Practices to Risk Management Strategies",
+        "use_case_number": 1
+      },
+      "uuid": "9ca90094-2dfd-5424-8892-94f5c49cf41e",
+      "value": "CTI-CMM 1.3 - RISK-1.h - Align CTI Practices to Risk Management Strategies"
+    },
+    {
+      "description": "Threats are identified, assessed, and prioritized at least in an ad hoc manner and often without alignment to the organization’s risk management strategy. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RISK-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "274ca4e9-db83-5056-8791-1528cdcd927f",
+      "value": "CTI-CMM 1.3 - RISK-2.a - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "CTI has a basic understanding of organizational assets, controls, operating environment, and risk posture.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RISK-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "48246ee8-d9a6-583f-a9ea-4295c8e67eef",
+      "value": "CTI-CMM 1.3 - RISK-2.b - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "CTI insights are available to support risk assessments at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RISK-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "a8891034-a311-5d00-a113-441684a64a93",
+      "value": "CTI-CMM 1.3 - RISK-2.c - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "A process for integrating CTI into risk assessments is created and used to inform basic risk controls and mitigations efforts.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RISK-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "6e0c374d-28ab-5222-9d6e-d2356c695d08",
+      "value": "CTI-CMM 1.3 - RISK-2.d - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "CTI insights are regularly leveraged within risk assessments.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RISK-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "26a333a6-3601-58cd-b02a-0c9c6b82e337",
+      "value": "CTI-CMM 1.3 - RISK-2.e - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "Risk-based controls are intermittently assessed and adjusted using CTI insights.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RISK-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "31072977-7e7b-5a11-a1ba-b4f4fa4191de",
+      "value": "CTI-CMM 1.3 - RISK-2.f - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "CTI practices provide proactive guidance for risk mitigation and management, including scenario planning and simulations. (see SITUATION)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RISK-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "SITUATION"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "a627793b-c260-5c07-a636-27c67936dffa",
+      "value": "CTI-CMM 1.3 - RISK-2.g - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "Risk-based controls and decision-making processes are periodically evaluated and refined on an ongoing basis through the collaboration with CTI.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Align CTI with the organization’s risk management strategies to inform and prioritize risk reduction efforts. Improve risk decisions, assessments, and security control tuning by identifying relevant cyber threat activities, impact potential, likelihood of occurrence, and mitigation options for use in risk assessments.",
+        "document_version": "1.3",
+        "domain": "Risk Management",
+        "domain_code": "RISK",
+        "domain_purpose": "Establish, operate, and maintain an enterprise cyber risk management program to identify, analyze, and respond to cyber risk the organization is subject to, including its business units, subsidiaries, related interconnected infrastructure, and stakeholders.",
+        "external_id": "RISK-2.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Risk Management (RISK)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RISK-2.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Risk Management",
+        "source_pages": [
+          30
+        ],
+        "source_section": "6.3",
+        "use_case": "Improve Risk Decisions, Assessments, and Controls",
+        "use_case_number": 2
+      },
+      "uuid": "b705fab5-501e-59aa-801e-5a4bb8c0518f",
+      "value": "CTI-CMM 1.3 - RISK-2.h - Improve Risk Decisions, Assessments, and Controls"
+    },
+    {
+      "description": "Alerts about leaked or compromised credentials and identities from open and commercial sources are collected and reviewed at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ACCESS-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          31
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "ebc20ce8-0cff-5c31-8be1-1861b486ab60",
+      "value": "CTI-CMM 1.3 - ACCESS-1.a - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Alerts about vulnerabilities impacting identity-related systems that threaten unauthorized access or identity compromise are collected and reviewed at least in an ad hoc manner for patch prioritization. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ACCESS-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          31
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "cdc338c3-408d-51a0-ae17-374791b3e80e",
+      "value": "CTI-CMM 1.3 - ACCESS-1.b - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "CTI assists with integration and automation of alert dissemination into repeatable workflows for ACCESS domain rapid assessment and response.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ACCESS-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          31
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "9833f023-b60b-5c69-9a33-68ca7af2c726",
+      "value": "CTI-CMM 1.3 - ACCESS-1.c - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Intelligence and associated indicators, related to emerging malware targeting identities and identity systems is delivered to enhance early warning detections and proactive mitigation measures.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ACCESS-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          31
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "00df8ab3-a8ad-55d1-a933-b3a92c2023ab",
+      "value": "CTI-CMM 1.3 - ACCESS-1.d - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Continuous monitoring is extended to identity-related threats posed by third parties. (see THIRD-PARTIES)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THIRD-PARTIES"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          31
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "90c49a3c-df4d-5462-8dbb-f6c5db7f08a0",
+      "value": "CTI-CMM 1.3 - ACCESS-1.e - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Intelligence on emerging threat actor TTPs is used for detecting anomalous activities related to user accounts, login attempts, or access patterns that may signal identity compromise.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          31
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "416512b9-8b3d-5839-ab2e-1f7560798419",
+      "value": "CTI-CMM 1.3 - ACCESS-1.f - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Intelligence includes contextualized insights and threat assessments to continuously improve identity-related discovery practices and predict future scenarios to enhance detections.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-1.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "b8e56554-8bcb-55ee-8d26-364f8c367cdc",
+      "value": "CTI-CMM 1.3 - ACCESS-1.g - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Mitigations and remediations in response to leaked compromised credentials and identities are acted upon as part of an automated process that can be invoked.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-1.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "7a010110-a165-5bff-ad90-365f68138187",
+      "value": "CTI-CMM 1.3 - ACCESS-1.h - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "Mechanisms are in place to action containment of users with access due to intelligence relating to suspected compromise of controlled data.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-1.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-1.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Accelerate Remediation of Identity-Related Threats",
+        "use_case_number": 1
+      },
+      "uuid": "b8435ef0-676c-5eed-839a-05bc79eeb67f",
+      "value": "CTI-CMM 1.3 - ACCESS-1.i - Accelerate Remediation of Identity-Related Threats"
+    },
+    {
+      "description": "CTI maintains basic awareness and monitoring of identity-related threats to logical and physical access controls — including vulnerability exploitations and security control configurations — that lead to immediate COAs.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ACCESS-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "58efd62d-4cd0-5f18-84e2-f3afe41dcea3",
+      "value": "CTI-CMM 1.3 - ACCESS-2.a - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "Collection is focused primarily on identity-related threats relevant specifically to the organization.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ACCESS-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "292a6a22-2e4e-5373-96c0-208096770566",
+      "value": "CTI-CMM 1.3 - ACCESS-2.b - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "CTI maintains a comprehensive understanding of identity-related threats to logical and physical access controls relevant to the organization’s high-risk assets. (see ASSET and RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ACCESS-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "ASSET",
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "942293c3-ec20-5e39-8fcc-34dd4a13ea01",
+      "value": "CTI-CMM 1.3 - ACCESS-2.c - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "CTI insights regularly influence proactive adjustments to enhance access control requirements and thresholds based on the threat environment, including MFA strategies and password resets.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ACCESS-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "4bb65d0a-e979-5031-a9cc-641bb644f2c0",
+      "value": "CTI-CMM 1.3 - ACCESS-2.d - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "Collection is extended to focus on identity-related threats relevant to the organization’s industry and geographic representation. (see SITUATION)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ACCESS-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "SITUATION"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "5700f1fc-6220-5996-a7dd-de02a7efc879",
+      "value": "CTI-CMM 1.3 - ACCESS-2.e - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "CTI insights regularly inform the creation of threat scenarios and simulations to test, validate, and adjust authentication and access controls and mitigations. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "c6b3152f-1593-537d-a1ca-df1d18721367",
+      "value": "CTI-CMM 1.3 - ACCESS-2.f - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "CTI insights inform tabletop exercises that fortify response and mitigation efforts across the organization. (see PROGRAM)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Proactively inform identity and access management (IAM) strategies, reduce incident detection times, accelerate remediation, and enable continuous improvements to safeguard critical assets and build resilience against identity-related threats.",
+        "document_version": "1.3",
+        "domain": "Identity and Access Management",
+        "domain_code": "ACCESS",
+        "domain_purpose": "Create and manage identities for entities that may be granted logical or physical access to the organization’s assets. Control access to the organization’s assets commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ACCESS-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Identity and Access Management (ACCESS)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ACCESS-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "PROGRAM"
+        ],
+        "source_example": "CTI3 Leading Identity and Access Management",
+        "source_pages": [
+          32
+        ],
+        "source_section": "6.4",
+        "use_case": "Fortify Identity and Access Protection",
+        "use_case_number": 2
+      },
+      "uuid": "d358b552-f0f5-57a6-a508-31dcadf94f40",
+      "value": "CTI-CMM 1.3 - ACCESS-2.g - Fortify Identity and Access Protection"
+    },
+    {
+      "description": "Situational awareness alerts and updates are collected from open and trusted sources.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "SITUATION-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          33
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "240bdc26-7b31-5192-a546-9cddcdc6e24b",
+      "value": "CTI-CMM 1.3 - SITUATION-1.a - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "Insights are provided at least in an ad hoc manner for short-term trends and observations that lead to immediate courses of action (COAs).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "SITUATION-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          33
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "febf468a-4cf6-5768-838e-bd33cdfb3878",
+      "value": "CTI-CMM 1.3 - SITUATION-1.b - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "Collection is focused primarily on all threats relevant specifically to the organization. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "SITUATION-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          33
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "6f5e92c3-734e-5df9-b360-a8142e7e1163",
+      "value": "CTI-CMM 1.3 - SITUATION-1.c - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "A systematic process, such as the one described in the ENISA Cybersecurity Threat Landscape Methodology,6 is implemented to routinely produce CTL reports. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "SITUATION-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          33
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "89dbdb5a-acd4-5d76-ad41-bed31f3d86ec",
+      "value": "CTI-CMM 1.3 - SITUATION-1.d - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "The CTL scope is mostly tactical and operational, delivering insights that provide short- to medium-term results. The audience and dissemination is to most enterprise stakeholder domains. The focus is primarily on priority threats and trends specific to the organization. CTL leverages priority intelligence requirements (PIRs) focused on tactical and operational needs.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "SITUATION-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          33
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "0d29dcfe-357c-5428-89d1-45385bb07337",
+      "value": "CTI-CMM 1.3 - SITUATION-1.e - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "CTI develops the baseline for return on investment and cost-benefit analysis between sources and products.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "SITUATION-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          34
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "8162c855-dba2-55f0-bd3d-02fd7ce542e9",
+      "value": "CTI-CMM 1.3 - SITUATION-1.f - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "The CTL scope is extended to include deliverables that regularly provide actionable intelligence to inform long-term strategic decision-making and align with risk reduction strategies. The audience and dissemination is to all enterprise stakeholder domains based on PIRs. The focus is extended to include threats, events, and trends relevant to the organization’s industry and geographic representation. (see RISK, PROGRAM and THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "SITUATION-1.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK",
+          "PROGRAM",
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          34
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "74800491-f9fd-588f-8e0a-09eab76d5a81",
+      "value": "CTI-CMM 1.3 - SITUATION-1.g - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "CTI routinely validates sources, tracks impact, and engages in return on investment reviews for all sources leveraged.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Drive threat-informed decision-making for all stakeholders based on the current and forecast threat landscape relative to the organization. Reduce uncertainty and increase predictability of the threat environment to create a commensurate state of security readiness.",
+        "document_version": "1.3",
+        "domain": "Situational Awareness",
+        "domain_code": "SITUATION",
+        "domain_purpose": "Establish and maintain activities and technologies to collect, monitor, analyze, alarm, report, and use operational, security, and threat information, including status and summary information from the other model domains, to establish situational awareness for both the organization’s operational state and cybersecurity state.",
+        "external_id": "SITUATION-1.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Situational Awareness (SITUATION)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "SITUATION-1.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Situational Awareness",
+        "source_pages": [
+          34
+        ],
+        "source_section": "6.5",
+        "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
+        "use_case_number": 1
+      },
+      "uuid": "7e6a0a79-fa78-5f60-b877-48cc9e33c828",
+      "value": "CTI-CMM 1.3 - SITUATION-1.h - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
+    },
+    {
+      "description": "Event and incident data is collected for correlation with external open and trusted sources to enable detection and manual remediation of threats.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          35
+        ],
+        "source_section": "6.6",
+        "use_case": "Strengthen Pre-Incident Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "ef67d063-54f7-57c9-8ee9-30f3ec51f9bd",
+      "value": "CTI-CMM 1.3 - RESPONSE-1.a - Strengthen Pre-Incident Preparedness"
+    },
+    {
+      "description": "CTI insights and context are provided at least in an ad hoc manner to enrich event data, reduce false positives, and hasten response.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          35
+        ],
+        "source_section": "6.6",
+        "use_case": "Strengthen Pre-Incident Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "3010b24f-c060-5fda-9776-9bb507f088a0",
+      "value": "CTI-CMM 1.3 - RESPONSE-1.b - Strengthen Pre-Incident Preparedness"
+    },
+    {
+      "description": "The IR team swiftly enhances detected events through automated integration of CTI insights on threat actors, TTPs, enriched IOCs, and contextual information, significantly boosting response efficiency.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          35
+        ],
+        "source_section": "6.6",
+        "use_case": "Strengthen Pre-Incident Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "912bbb91-fd0d-5d3b-bae7-f5fe81e0cc14",
+      "value": "CTI-CMM 1.3 - RESPONSE-1.c - Strengthen Pre-Incident Preparedness"
+    },
+    {
+      "description": "CTI insights are used for immediate control gap detection analysis and rapid remediation, conducted in a mostly automated manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          35
+        ],
+        "source_section": "6.6",
+        "use_case": "Strengthen Pre-Incident Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "5f355d77-ecfe-5b36-96e6-d2b1de099852",
+      "value": "CTI-CMM 1.3 - RESPONSE-1.d - Strengthen Pre-Incident Preparedness"
+    },
+    {
+      "description": "CTI outputs (reports, alerts, enrichments) include assessments of the threat landscape and prescriptive recommendations to enable proactive detection controls and event response prioritization. (see SITUATION)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "SITUATION"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Strengthen Pre-Incident Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "2ae1c28d-0571-5129-9182-f9f0cc87dcbe",
+      "value": "CTI-CMM 1.3 - RESPONSE-1.e - Strengthen Pre-Incident Preparedness"
+    },
+    {
+      "description": "Tabletop and scenario exercises are informed by CTI insights of the latest malware, campaigns, vulnerabilities, and threats. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Strengthen Pre-Incident Preparedness",
+        "use_case_number": 1
+      },
+      "uuid": "fd8107c2-2f28-5476-864d-5f2c85bc4a54",
+      "value": "CTI-CMM 1.3 - RESPONSE-1.f - Strengthen Pre-Incident Preparedness"
+    },
+    {
+      "description": "Incident details are reviewed and mapped to a cyber kill chain or related industry framework (e.g., Lockheed Martin’s Cyber Kill Chain, MITRE ATT&CK, the Diamond Model of Intrusion Analysis, etc.).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "67530f69-3af4-5b29-833a-2c6a93c25eda",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.a - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Findings are documented as the incident progresses through the lifecycle phases. CTI insights are incorporated into the IR report.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "b54c8c66-4e17-5b26-bb60-5b3ae165ab10",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.b - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Manual research and pivoting on TTPs and IoCs is being conducted to contextualize incidents and improve remediation, at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "fc6fa1de-f514-5e24-ae3d-c11b41ba3be7",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.c - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Findings are documented in a stand-alone CTI report and can be incorporated into or accompany the IR report.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "b061f226-6c51-5feb-a5ea-fce8ca088d5f",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.d - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Automation, which may include the use of machine learning or AI models, is used to enrich discovered indicators and map findings to cyber kill chains.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "59c35998-d4f4-5542-bb00-fb0f1184541d",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.e - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Incident IoCs and related intelligence are ingested into a threat intelligence platform (TIP), using automation that maintains mapping verbosity to industry frameworks within the TIP’s ontology. This empowers orchestration to existing security controls for added enrichment and actions by appropriate controls teams.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "409e3f87-ded5-5945-b9ac-327e83d73c6e",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.f - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Automation and process tools are used to trigger CTI analysis and escalation to the IR team.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "45d3168f-37e9-5266-8270-d2b99f2fba29",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.g - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Risk-based assessments and recommendations are routinely conveyed to the IR team. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-2.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-2.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Improve Incident Analysis and Response",
+        "use_case_number": 2
+      },
+      "uuid": "f74b9259-27b3-5999-9b80-d6f752a0f0fd",
+      "value": "CTI-CMM 1.3 - RESPONSE-2.h - Improve Incident Analysis and Response"
+    },
+    {
+      "description": "Incident findings, lessons learned, and improvement opportunities are captured within an internal knowledge base or ticket. Post-mortems are discussed internally and briefed to leadership at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-3.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "911bcd05-279a-5f41-8086-1dc8f321e502",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.a - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Manual ingestion and enrichment of intelligence, SOC internal indicators, and data occurs.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-3.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "09e5ca83-40d5-5dad-82a3-73c00c69aca2",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.b - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Partnership with the threat hunting team is initiated for ongoing collaboration. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "RESPONSE-3.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "97a92707-df09-5ce5-93bf-c522addbf2d2",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.c - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Incident findings and lessons learned are regularly reviewed to spot trends and enhance security recommendations. Key insights are shared with leadership through briefings that emphasize the risks of inaction.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-3.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "c3801ba3-1902-5010-a6df-f0e47f22e92f",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.d - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Incident response time is minimized through automation, implementing key prevention measures that utilize IoCs and TTPs from trusted sources. Automated CTI runbooks facilitate intelligence and event enrichment.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-3.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "b072c028-cd54-5575-b378-c93f3403ae12",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.e - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "CTI maps enrich TTP findings from incident investigations by mapping them to the MITRE ATT&CK framework, allowing control teams to assess them against existing detection and prevention capabilities. Additionally, the enrichment of SOC internal indicators and data with intelligence is ongoing through TIP or automation.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "RESPONSE-3.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          36
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "02cef0ab-a959-51f6-a381-cbee526611ac",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.f - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Artificial intelligence (AI) and machine learning (ML) are used for analysis of TTP mapping (MITRE TRAM).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-3.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          37
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "94fbd476-69b7-5e43-955a-73b4b384101b",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.g - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Metrics are established and tuned based upon decisions made from incident postmortems and related leadership actions.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-3.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          37
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "c8cd4e03-3ced-537b-9d2a-9b2c85023619",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.h - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Threat hunting activities are moderated by the CTI’s assessment of prevalent TTPs for priority threat actors and runbooks are updated based on threat actor TTPs. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-3.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          37
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "cd70028b-6208-5f77-9e73-5b0d767c166f",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.i - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "Current and anticipated threats are disseminated to relevant security teams using daily or weekly reporting.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Malware Intelligence",
+          "Open Source Intelligence",
+          "Vulnerability Intelligence",
+          "Counter Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Capture, correlate, prioritize, and enrich intrusion activity in the enterprise environment to create an intelligence advantage for incident responders and strengthen the organization’s overall security posture.",
+        "document_version": "1.3",
+        "domain": "Event and Incident Response, Continuity of Operations",
+        "domain_code": "RESPONSE",
+        "domain_purpose": "Establish and maintain plans, procedures, and technologies to detect, analyze, mitigate, respond to, and recover from cybersecurity events and incidents and to sustain operations during cybersecurity incidents commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "RESPONSE-3.j",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Event and Incident Response, Continuity of Operations (RESPONSE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "RESPONSE-3.j",
+        "practice_letter": "j",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
+        "source_pages": [
+          37
+        ],
+        "source_section": "6.6",
+        "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
+        "use_case_number": 3
+      },
+      "uuid": "aef30f63-0f87-56ab-99de-b79ed278437c",
+      "value": "CTI-CMM 1.3 - RESPONSE-3.j - Enhance Post-Incident Recovery and Continuity of Operations"
+    },
+    {
+      "description": "CTI has access to a list of third-party vendors and suppliers. The list may be based on incidents or organization knowledge rather than a complete list.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THIRD-PARTIES-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          38
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "077dc059-715a-5bc6-9563-b54d3dcfc529",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.a - Assess Threats to Third Parties"
+    },
+    {
+      "description": "CTI monitors data sources to assess the potential of third-party incidents at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THIRD-PARTIES-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          38
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "7a50d03b-64a6-5d6c-aa9c-4fcab8568757",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.b - Assess Threats to Third Parties"
+    },
+    {
+      "description": "Intelligence regarding threats to third parties is consistently contextualized to identify and mitigate risks. (see RISK and THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK",
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          38
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "05cbaef9-ba95-5889-9630-5d4dcfa421e9",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.c - Assess Threats to Third Parties"
+    },
+    {
+      "description": "Third parties are prioritized based on established criteria, including factors such as business and information security risk. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          38
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "ee952cd1-123b-5c38-ab64-89a7c04a1694",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.d - Assess Threats to Third Parties"
+    },
+    {
+      "description": "Changes to the list of third-party vendors and suppliers are routinely updated and made available to CTI.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          38
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "43ac3658-c303-5875-a7af-ab0bb878c4c0",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.e - Assess Threats to Third Parties"
+    },
+    {
+      "description": "Intelligence from cybercriminal underground sources is monitored to evaluate thirdparty risks arising from compromises, stolen credentials, and intellectual property theft. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          38
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "27120372-8b61-5e4c-be06-b5732181dbf8",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.f - Assess Threats to Third Parties"
+    },
+    {
+      "description": "CTI insights are used to update vendors and suppliers in a third-party risk management (TPRM) platform. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THIRD-PARTIES-1.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "0232e694-6623-5fd2-984b-26deb8db2514",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.g - Assess Threats to Third Parties"
+    },
+    {
+      "description": "CTI supports the exposure analysis of suppliers and vendors involved in mergers or acquisitions.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THIRD-PARTIES-1.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "58d3e65e-8a4e-5f8b-a3f5-7d2ccd9eca5f",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.h - Assess Threats to Third Parties"
+    },
+    {
+      "description": "Monitoring of changes in geopolitical risk is used to evaluate changes in threats to third parties. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-1.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THIRD-PARTIES-1.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Assess Threats to Third Parties",
+        "use_case_number": 1
+      },
+      "uuid": "05cc24da-640d-5216-bc0e-47c2478dbc7d",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.i - Assess Threats to Third Parties"
+    },
+    {
+      "description": "CTI monitors and assesses potential third-party exposures at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THIRD-PARTIES-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "2012832e-d144-59a7-98c2-370e0a0a52c0",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.a - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "Intelligence concerning exploited vulnerabilities is routinely reviewed with respect to third parties.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "THIRD-PARTIES-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "3ee5df87-eb4e-5031-94de-b0e246692ef6",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.b - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "CTI insights are used to assess risk of suppliers’ cybersecurity practices. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "6fbef05c-d6a4-5db1-8d65-3fe101358968",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.c - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "CTI continuously monitors and assesses potential exposures of business critical vendors and suppliers.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "0f56fb42-0b78-5cb5-9841-54e1041c2f0f",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.d - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "Intelligence includes predictive analysis about recommended COAs to reduce risk of exposure to the organization via third-party incidents. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "c9d9cbbc-3ccc-5325-b43d-29549ddfb052",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.e - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "CTI provides the SOC with TTPs and IoCs related to third-party breaches.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "THIRD-PARTIES-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "557a486f-48cc-56b3-bcfe-f5a0575ca408",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.f - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "CTI continuously monitors and assesses potential exposures of all vendors and suppliers.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THIRD-PARTIES-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "790451ec-82c9-5cfb-a284-fe8ed5ec25a6",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.g - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "Intelligence about third-party exposures is used prescriptively to identify future risk of the organization with existing third parties and their associated technologies. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Attack Surface Intelligence",
+          "Breach Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Geopolitical Intelligence",
+          "Identity Intelligence",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups",
+          "Vulnerability Intelligence"
+        ],
+        "cti_mission": "Strengthen third-party risk management by continuously monitoring, detecting, assessing, and mitigating potential incidents posed by third-party vendors and suppliers. Enhance vendor risk profile evaluations and prioritization using CTI insights and recommendations.",
+        "document_version": "1.3",
+        "domain": "Third-Party Risk Management",
+        "domain_code": "THIRD-PARTIES",
+        "domain_purpose": "Establish and maintain controls to manage the cyber risks arising from suppliers and other third parties commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "THIRD-PARTIES-2.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Third-Party Risk Management (THIRD-PARTIES)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "THIRD-PARTIES-2.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Third-Party Risk Management",
+        "source_pages": [
+          39
+        ],
+        "source_section": "6.7",
+        "use_case": "Mitigate Third-Party Risk Exposure",
+        "use_case_number": 2
+      },
+      "uuid": "c0ea4a7d-497b-5d71-bf6c-71a1bdd33c06",
+      "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.h - Mitigate Third-Party Risk Exposure"
+    },
+    {
+      "description": "To combat exploitation and threat actor targeting, social media and open source sites are reviewed for posts of compromised customer credentials, gift cards, coupon scams, and credit cards at least in an ad hoc manner to support mitigation or prevention of fraudulent activity.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          40
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "3f3fed42-74a9-5029-8502-7bae3d7179aa",
+      "value": "CTI-CMM 1.3 - FRAUD-1.a - Mitigate Financial Fraud"
+    },
+    {
+      "description": "CTI team tracks the activity and any mentions of point-of-sale (PoS) credit card skimmers on forums and social media and supports relevant team(s) with remediation and response.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "70d9f5f7-0596-50b3-b81b-2e6aaf50b614",
+      "value": "CTI-CMM 1.3 - FRAUD-1.b - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Intelligence sharing groups and private chat channels are monitored for money mule notifications and actioned with the appropriate team(s).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "8107df34-d254-5c13-aa26-2f92e6534269",
+      "value": "CTI-CMM 1.3 - FRAUD-1.c - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Information about adversary targeting toward customers, including brand impersonation and compromised credentials to facilitate fraud, is delivered in at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "82db8bc2-c4a6-573e-a73d-939717a87e68",
+      "value": "CTI-CMM 1.3 - FRAUD-1.d - Mitigate Financial Fraud"
+    },
+    {
+      "description": "CTI is a member of trust groups (such as ISACs and peer sharing) focused on mitigating financial fraud.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "c646385f-cf1a-516e-8b9d-b0c594741dde",
+      "value": "CTI-CMM 1.3 - FRAUD-1.e - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Relevant information and data from trust groups is integrated into the organization’s CTI practices.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "db944fc2-5f0f-580a-be6e-e72af4c51ae3",
+      "value": "CTI-CMM 1.3 - FRAUD-1.f - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Automated monitoring is in place for mentions of common fraud indicators including business email compromise (BEC), short message service (SMS) phishing, invoice fraud, social engineering directed toward customers, and other relevant activity.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-1.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "badebdf9-db6f-5c83-816d-61a96efbd13b",
+      "value": "CTI-CMM 1.3 - FRAUD-1.g - Mitigate Financial Fraud"
+    },
+    {
+      "description": "CTI supports a cross-functional working group within the organization that is dedicated to identifying and sharing current and emerging threats on a recurring cadence. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-1.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "f97c8d9b-23dc-55f1-9017-633c9d6cb3bd",
+      "value": "CTI-CMM 1.3 - FRAUD-1.h - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Proactive tracking of fraud actor infrastructure and membership in private chat channels is done through automated collections and tooling.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-1.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "7833f2bb-3e6a-50cc-94f0-6f879a2df5b6",
+      "value": "CTI-CMM 1.3 - FRAUD-1.i - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Implementation of cyber deception methods, including honeypots and accounts, is used for adversary tracking and collecting intelligence on TTPs and IoCs.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.j",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-1.j",
+        "practice_letter": "j",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "d3e6c92a-ee0c-5d4d-a3b4-543dd3796b16",
+      "value": "CTI-CMM 1.3 - FRAUD-1.j - Mitigate Financial Fraud"
+    },
+    {
+      "description": "IoC/B/As collected related to observed financial fraud are automatically shared with trust groups (such as through a TIP or other tooling).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.k",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-1.k",
+        "practice_letter": "k",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "85bf8419-cf9b-5839-9b7f-9e2cbdd2ed03",
+      "value": "CTI-CMM 1.3 - FRAUD-1.k - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Intelligence insights are used to create antifraud detections and regularly tuned based on the organization’s fraud observations.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-1.l",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-1.l",
+        "practice_letter": "l",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Mitigate Financial Fraud",
+        "use_case_number": 1
+      },
+      "uuid": "509decb8-743d-5efe-8abd-52ee2b849fa9",
+      "value": "CTI-CMM 1.3 - FRAUD-1.l - Mitigate Financial Fraud"
+    },
+    {
+      "description": "Manual intelligence collection and analysis is done at least in an ad hoc manner for adversary targeting including brand impersonation on corporate domains and social media accounts impersonating corporate brands and individuals.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "72ce6b49-0db6-5d76-be73-defb8ef471bd",
+      "value": "CTI-CMM 1.3 - FRAUD-2.a - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "CTI insights inform decisions on a range of cybersecurity defenses, including MFA strategies (e.g., limiting SMS or phone-based authentication where possible) and other controls designed to disrupt brand impersonation attempts.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "000692f0-3af2-5c50-bc2a-ba88d8c574cc",
+      "value": "CTI-CMM 1.3 - FRAUD-2.b - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "CTI tracks threat actors associated with fraud and abuse targeting their brand(s). (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "5ca8b088-735c-5dc7-acfb-2180dfbb5f48",
+      "value": "CTI-CMM 1.3 - FRAUD-2.c - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "CTI tracks phishing kits being used against the organization’s brand(s).",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "db83e755-287a-579f-9a3b-b62c02c1614d",
+      "value": "CTI-CMM 1.3 - FRAUD-2.d - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "Automation is used to detect malvertising campaigns and SEO poisoning for disruption actions.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "38aa23ea-be7f-5356-a972-95f865fbafa6",
+      "value": "CTI-CMM 1.3 - FRAUD-2.e - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "Automated alerting for adversary targeting, including brand impersonation, is used.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "638b4549-4e14-5d5c-8bd4-ed92b2c6ab2a",
+      "value": "CTI-CMM 1.3 - FRAUD-2.f - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "Information shared in trust groups is utilized to track and mitigate risk from specific threat actors and campaigns. (see RISK)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "7e3fe768-81dc-5f6b-8b48-19f8f9bd50af",
+      "value": "CTI-CMM 1.3 - FRAUD-2.g - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "Automated identification and disruption of phishing kits targeting the organization’s brand(s) is used.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-2.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          41
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "dd68bb6f-8fc1-540c-b29a-cbd9deb74d39",
+      "value": "CTI-CMM 1.3 - FRAUD-2.h - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "CTI provides actionable intelligence for implementation of canary tokens on Amazon Web Services (AWS) keys, sensitive documents, hostnames, and URLs (web app exposed) to detect unwanted access or attempts to access.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-2.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-2.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Improve Brand Impersonation Protection",
+        "use_case_number": 2
+      },
+      "uuid": "5dddb8ca-5268-5578-9cf3-f23473924742",
+      "value": "CTI-CMM 1.3 - FRAUD-2.i - Improve Brand Impersonation Protection"
+    },
+    {
+      "description": "CTI tracks forums, sites, and threat actors associated with fraud and abuse targeting their brand(s) to facilitate customer ATO attacks.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-3.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-3.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Enhance Account Takeover (ATO) Detection",
+        "use_case_number": 3
+      },
+      "uuid": "3dc84fca-4146-51ea-8803-1954a3fc5e0f",
+      "value": "CTI-CMM 1.3 - FRAUD-3.a - Enhance Account Takeover (ATO) Detection"
+    },
+    {
+      "description": "Manual identification of leaked customer credentials and accounts for sale on forums, social media, or websites is sent to relevant teams for immediate action.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-3.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "FRAUD-3.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Enhance Account Takeover (ATO) Detection",
+        "use_case_number": 3
+      },
+      "uuid": "c34dbbcc-8a9f-5824-8157-90dda9693e5a",
+      "value": "CTI-CMM 1.3 - FRAUD-3.b - Enhance Account Takeover (ATO) Detection"
+    },
+    {
+      "description": "CTI provides intelligence to drive the creation of fraud-specific automation and detections for anomalous customer sign-ins and sessions indicating potential ATO activity.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-3.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-3.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Enhance Account Takeover (ATO) Detection",
+        "use_case_number": 3
+      },
+      "uuid": "cee8d929-31b8-57d9-94c0-37f6cfaa437e",
+      "value": "CTI-CMM 1.3 - FRAUD-3.c - Enhance Account Takeover (ATO) Detection"
+    },
+    {
+      "description": "Feedback loops are created to include CTI when users (customers and employees) report suspicious behavior indicative of customer ATO activity.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-3.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "FRAUD-3.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Enhance Account Takeover (ATO) Detection",
+        "use_case_number": 3
+      },
+      "uuid": "88c4c470-2b64-5102-b2bd-041db78b0f13",
+      "value": "CTI-CMM 1.3 - FRAUD-3.d - Enhance Account Takeover (ATO) Detection"
+    },
+    {
+      "description": "CTI continuously delivers intelligence to drive the proactive deployment of cyber deception technologies (e.g., honeypots, canary tokens, honey accounts) and prescribe prevention methods that enable rapid containment of customer credential misuse.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-3.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-3.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Enhance Account Takeover (ATO) Detection",
+        "use_case_number": 3
+      },
+      "uuid": "aa0c4e9c-8fd3-5aa4-affa-64fc48b87dd7",
+      "value": "CTI-CMM 1.3 - FRAUD-3.e - Enhance Account Takeover (ATO) Detection"
+    },
+    {
+      "description": "CTI provides intelligence on likely threat activity to support penetration tests and purple and red team engagements to test for social engineering (cyber and physical) and actively audit security controls.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Adversary Intelligence",
+          "Brand Intelligence",
+          "Cybercriminal Underground Intelligence",
+          "Identity Intelligence",
+          "Internal Organizational Data",
+          "Open Source Intelligence",
+          "Social Media Intelligence",
+          "Trust Groups"
+        ],
+        "cti_mission": "Create awareness around new and emerging trends in fraud and abuse (the malicious use of an organization’s name, logo, or brand). Share threats and findings with relevant stakeholders to create detection and monitoring capabilities and to proactively mitigate risk.",
+        "document_version": "1.3",
+        "domain": "Fraud and Abuse Management",
+        "domain_code": "FRAUD",
+        "domain_note": "FRAUD is not included in the C2M2; CTI-CMM includes it as guidance for shielding organizations against fraud.",
+        "domain_purpose": "Fraud and Abuse Management shields organizations from malicious digital scams and attacks. It hunts for emerging threats, shares intelligence to strengthen defenses, and guides response to safeguard data, finances, and reputation. This proactive shield against bad actors fosters a secure online environment for all.",
+        "external_id": "FRAUD-3.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Fraud and Abuse Management (FRAUD)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "FRAUD-3.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Fraud and Abuse Management",
+        "source_pages": [
+          42
+        ],
+        "source_section": "6.8",
+        "use_case": "Enhance Account Takeover (ATO) Detection",
+        "use_case_number": 3
+      },
+      "uuid": "b5cafb6b-e946-5016-bf4f-60d4820c5457",
+      "value": "CTI-CMM 1.3 - FRAUD-3.f - Enhance Account Takeover (ATO) Detection"
+    },
+    {
+      "description": "CTI insights are regularly used to inform cybersecurity awareness and skills assessment strategies.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "WORKFORCE-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          43
+        ],
+        "source_section": "6.9",
+        "use_case": "Support and Safeguard Human Resources Practices",
+        "use_case_number": 1
+      },
+      "uuid": "e8a6bab8-33cc-5eda-95f8-a30c63d12267",
+      "value": "CTI-CMM 1.3 - WORKFORCE-1.a - Support and Safeguard Human Resources Practices"
+    },
+    {
+      "description": "Direct communications — and at least periodic engagement — with workforce management leadership consistently help identify cyber-related skills required for safe and effective operations of the workforce.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "WORKFORCE-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          43
+        ],
+        "source_section": "6.9",
+        "use_case": "Support and Safeguard Human Resources Practices",
+        "use_case_number": 1
+      },
+      "uuid": "ee81da51-9b09-525e-bee4-17b4c4317861",
+      "value": "CTI-CMM 1.3 - WORKFORCE-1.b - Support and Safeguard Human Resources Practices"
+    },
+    {
+      "description": "On a periodic basis, CTI provides inputs to personnel vetting/screening procedures to inform hiring decisions and to minimize potential insider threat risks.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          43
+        ],
+        "source_section": "6.9",
+        "use_case": "Support and Safeguard Human Resources Practices",
+        "use_case_number": 1
+      },
+      "uuid": "b6c481b3-49f6-5fd2-ad4f-26ec87e22b23",
+      "value": "CTI-CMM 1.3 - WORKFORCE-1.c - Support and Safeguard Human Resources Practices"
+    },
+    {
+      "description": "CTI insights are consistently applied to inform the development of organizationspecific plans for data/technology access needs, separation, and transfer procedures.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          43
+        ],
+        "source_section": "6.9",
+        "use_case": "Support and Safeguard Human Resources Practices",
+        "use_case_number": 1
+      },
+      "uuid": "a6723893-b627-5a2d-b345-cab8fb4a93fb",
+      "value": "CTI-CMM 1.3 - WORKFORCE-1.d - Support and Safeguard Human Resources Practices"
+    },
+    {
+      "description": "Personnel vetting procedures are tailored to individual positions based on risk analysis (see RISK) of the job role and the organization’s threat profile. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK",
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          43
+        ],
+        "source_section": "6.9",
+        "use_case": "Support and Safeguard Human Resources Practices",
+        "use_case_number": 1
+      },
+      "uuid": "78be0b63-3e90-545e-9ffa-5e9e2491c416",
+      "value": "CTI-CMM 1.3 - WORKFORCE-1.e - Support and Safeguard Human Resources Practices"
+    },
+    {
+      "description": "Screening tools used to assess the cybersecurity awareness of candidates and inform follow-on/remedial training requirements are developed and updated with CTI insights.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support and Safeguard Human Resources Practices",
+        "use_case_number": 1
+      },
+      "uuid": "45b1e0a1-8688-5614-a201-889b7ecc61f6",
+      "value": "CTI-CMM 1.3 - WORKFORCE-1.f - Support and Safeguard Human Resources Practices"
+    },
+    {
+      "description": "Working relationships with the teams handling development and delivery of workforce training/education have been developed and engagement occurs at least in an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "WORKFORCE-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "af74b036-f1ab-5316-9144-28abf01256c1",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.a - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Insights provided by the CTI program are generally relevant to the organization, but not necessarily aligned to specific organizational units or job roles.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "WORKFORCE-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "de41453b-e9b2-5dfa-a393-91a5e0ea24c9",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.b - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Workforce training/education initiatives are supported by CTI insights at least in an ad hoc manner and primarily related to significant changes in threat or vulnerability activity. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "WORKFORCE-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "f5244dc2-f5b8-5cbb-b386-839d61622af9",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.c - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Security policy guidance, such as data protection and secure communication practices, is regularly reviewed by the CTI program — as are IR findings and other security reporting — to determine alignment of training/education initiatives with observed threat activity.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "7e891e1a-1d82-55c8-b171-3a1516f84e3d",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.d - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Training/education teams are engaged on a routine basis to ensure alignment of materials and approaches with the organization’s threat profile.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "b2ed1bc0-b762-51a4-9bf9-c77c57fdc8d0",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.e - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "CTI products and insights are routinely integrated into cybersecurity training and education efforts.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-2.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "995dfd0e-ba02-519e-b381-32cae64904ac",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.f - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Cybersecurity training materials are regularly reviewed by CTI to ensure the knowledge, skill, and ability gaps addressed in the curriculum are aligned with the organization’s threat profile.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.g",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-2.g",
+        "practice_letter": "g",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "ed59417e-c432-5d4c-8a94-44c67bf1edd4",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.g - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "CTI insights are used to assist with tailoring cybersecurity awareness activities to individual job roles as appropriate for the organization’s threat profile. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.h",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-2.h",
+        "practice_letter": "h",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "d01e769b-1a17-5a00-af4b-e0e895a6d58f",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.h - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "The continuous improvement of training programs and education materials is facilitated by CTI insights into the current and anticipated threat landscape. (see PROGRAM)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.i",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-2.i",
+        "practice_letter": "i",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "PROGRAM"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "7b5a6e6c-0acb-50bb-bd3b-8136ca2bedb2",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.i - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "CTI insights are regularly leveraged for simulation exercises including phishing and social-engineering attacks. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.j",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-2.j",
+        "practice_letter": "j",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "032125ea-721c-57eb-bbe8-433a35cfdac3",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.j - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Regular review and evaluation are conducted to measure the effectiveness of CTI inclusion in workforce development efforts and improvements are made as appropriate.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-2.k",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-2.k",
+        "practice_letter": "k",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Development of Training and Education Assets",
+        "use_case_number": 2
+      },
+      "uuid": "a3992694-de16-5a7f-8847-5aeb9ee8333a",
+      "value": "CTI-CMM 1.3 - WORKFORCE-2.k - Support Development of Training and Education Assets"
+    },
+    {
+      "description": "Workforce development efforts are understood by the CTI program and it provides management with inputs as requested.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-3.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "WORKFORCE-3.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
+        "use_case_number": 3
+      },
+      "uuid": "6a209092-3bfe-5722-a837-c0dd45600fb7",
+      "value": "CTI-CMM 1.3 - WORKFORCE-3.a - Support Cybersecurity Management in Workforce Development Efforts"
+    },
+    {
+      "description": "The effort to identify high-risk job roles and support management in developing workforce-centric mitigation strategies is led by the CTI program.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-3.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-3.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
+        "use_case_number": 3
+      },
+      "uuid": "d394181b-0b4c-509a-a11d-b2741724355a",
+      "value": "CTI-CMM 1.3 - WORKFORCE-3.b - Support Cybersecurity Management in Workforce Development Efforts"
+    },
+    {
+      "description": "Procedures and activities associated with CTI support to workforce management efforts are documented, followed, and maintained to ensure effective and ongoing support.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-3.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "WORKFORCE-3.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
+        "use_case_number": 3
+      },
+      "uuid": "c6e1a94f-8df4-51e7-abf9-13c3cbc00c56",
+      "value": "CTI-CMM 1.3 - WORKFORCE-3.c - Support Cybersecurity Management in Workforce Development Efforts"
+    },
+    {
+      "description": "The CTI program is intimately familiar with workforce management operations and has developed proficiency at pairing content with delivery mechanisms to help optimize impact.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-3.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-3.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          44
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
+        "use_case_number": 3
+      },
+      "uuid": "a5697921-2f33-576e-aa20-6390460add51",
+      "value": "CTI-CMM 1.3 - WORKFORCE-3.d - Support Cybersecurity Management in Workforce Development Efforts"
+    },
+    {
+      "description": "Changes in the organization’s threat profile that are likely to impact workforce management efforts are routinely briefed to cybersecurity leadership.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-3.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-3.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          45
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
+        "use_case_number": 3
+      },
+      "uuid": "e1268463-32c1-56f9-96a9-09cafc0c17e7",
+      "value": "CTI-CMM 1.3 - WORKFORCE-3.e - Support Cybersecurity Management in Workforce Development Efforts"
+    },
+    {
+      "description": "Contributions to workforce management efforts are tracked, evaluated, and routinely reported to leadership.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Cybersecurity Workforce Development Strategy and Related Documents",
+          "Internal Training Resources, Function-Specific Training Strategy, and Related Policy Documents",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards"
+        ],
+        "cti_mission": "Support hardening of the human element of the organization’s attack surface by enhancing workforce management initiatives with insights into adversary tactics and organization-specific risks.",
+        "document_version": "1.3",
+        "domain": "CTI Workforce Management",
+        "domain_code": "WORKFORCE",
+        "domain_purpose": "Establish and maintain plans, procedures, technologies, and controls to create a culture of cybersecurity and to ensure the ongoing suitability and competence of personnel commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "WORKFORCE-3.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Workforce Management (WORKFORCE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "WORKFORCE-3.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
+        "source_pages": [
+          45
+        ],
+        "source_section": "6.9",
+        "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
+        "use_case_number": 3
+      },
+      "uuid": "d7fad998-2025-5455-899e-1c801a8ce14b",
+      "value": "CTI-CMM 1.3 - WORKFORCE-3.f - Support Cybersecurity Management in Workforce Development Efforts"
+    },
+    {
+      "description": "CTI is familiar with key personnel involved in cybersecurity architecture strategy and program development activities, providing input in at least an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ARCHITECTURE-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          46
+        ],
+        "source_section": "6.10",
+        "use_case": "Support Strategy Development for the Cybersecurity Architecture",
+        "use_case_number": 1
+      },
+      "uuid": "af3e830d-dce2-515e-b341-38ec57831840",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-1.a - Support Strategy Development for the Cybersecurity Architecture"
+    },
+    {
+      "description": "CTI has established communication channels and trusted relationships with cybersecurity architecture leadership or significant stakeholders, leveraging both regularly to proactively provide input to support cybersecurity architecture strategy and program development as intelligence insights are developed. (see THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ARCHITECTURE-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          46
+        ],
+        "source_section": "6.10",
+        "use_case": "Support Strategy Development for the Cybersecurity Architecture",
+        "use_case_number": 1
+      },
+      "uuid": "b447bf8f-eded-520c-8290-492559c9fae7",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-1.b - Support Strategy Development for the Cybersecurity Architecture"
+    },
+    {
+      "description": "CTI is fully integrated into the processes that shape the cybersecurity architecture strategy, leveraging its unique vantage point within the enterprise to provide novel insights such as risks associated with changes in the threat landscape and vendor practices or products that may impact enterprise cybersecurity architecture. (see THREAT) MODELING",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ARCHITECTURE-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          46
+        ],
+        "source_section": "6.10",
+        "use_case": "Support Strategy Development for the Cybersecurity Architecture",
+        "use_case_number": 1
+      },
+      "uuid": "94ec975f-bc50-512c-91cc-f663207ef3e1",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-1.c - Support Strategy Development for the Cybersecurity Architecture"
+    },
+    {
+      "description": "CTI is engaged on an ad hoc basis by cybersecurity architecture personnel to address specific questions about technologies, exploitation of vulnerabilities, or other threat-related insights in support of architecture-planning activities.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ARCHITECTURE-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
+        "use_case_number": 2
+      },
+      "uuid": "3c4bd4c9-f78a-5ed5-9922-5dc174cc4f6a",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-2.a - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
+    },
+    {
+      "description": "CTI is sufficiently familiar with the cybersecurity architecture to identify threats that cut across cybersecurity functions (potentially “slipping through the cracks” between teams) or risks manifested through the exploitation of multiple technologies and reports these regularly to the cybersecurity architecture team.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ARCHITECTURE-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
+        "use_case_number": 2
+      },
+      "uuid": "b63ced37-df24-5ae7-a240-d18a43a3c0a8",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-2.b - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
+    },
+    {
+      "description": "CTI reports for the cybersecurity architecture team regularly include recommendations for mitigating threats at the enterprise level.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ARCHITECTURE-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
+        "use_case_number": 2
+      },
+      "uuid": "2efdcedc-ea15-5ceb-adc6-1b428dcf0444",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-2.c - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
+    },
+    {
+      "description": "CTI prepares contextualized reporting and recommendations for the architecture team on a regular cadence of trends impacting controls, processes, technologies, and other elements that require enterprise-wide solutioning to resolve (e.g., discovery of extensive shadow IT, changes to product capabilities, foreign acquisition of vendors, etc.) ALIGNMENT",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ARCHITECTURE-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
+        "use_case_number": 2
+      },
+      "uuid": "41e51ab1-dd43-5024-9a37-712f3efc8114",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-2.d - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
+    },
+    {
+      "description": "CTI informs the architecture team of changes to CTI infrastructure (new tools, data storage solutions, etc.) on an ad hoc basis.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-3.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ARCHITECTURE-3.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
+        "use_case_number": 3
+      },
+      "uuid": "6b9b766c-32f2-5b60-8f7c-e3f92a8fdf72",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-3.a - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
+    },
+    {
+      "description": "CTI reports noncompliant controls, processes, technologies, and other elements it discovers in the course of its duties to the architecture team in at least an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-3.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "ARCHITECTURE-3.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
+        "use_case_number": 3
+      },
+      "uuid": "c9d2f59e-021b-501c-aa3f-f75b4bd97029",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-3.b - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
+    },
+    {
+      "description": "CTI informs architecture stakeholders in advance of changes to CTI infrastructure and provides insights into how those changes — and any resulting capabilities — might enhance or degrade enterprise cybersecurity outcomes.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-3.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ARCHITECTURE-3.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
+        "use_case_number": 3
+      },
+      "uuid": "9f9b53d4-2b50-5a49-b91f-de44b8de7981",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-3.c - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
+    },
+    {
+      "description": "CTI aligns capabilities development and technology acquisition with cybersecurity architecture needs while ensuring compliance with policies and controls.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-3.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "ARCHITECTURE-3.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
+        "use_case_number": 3
+      },
+      "uuid": "a72b8afc-3577-5f3d-82c8-0eb3d745c9ba",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-3.d - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
+    },
+    {
+      "description": "CTI has documented procedures for engaging with incident response and other teams to develop novel intelligence reporting based on internal cybersecurity events that represent unrealized risk to the enterprise cybersecurity architecture and does so on a recurring basis.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-3.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ARCHITECTURE-3.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
+        "use_case_number": 3
+      },
+      "uuid": "601c6deb-d2c5-5eae-9ac1-78ff982b65c1",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-3.e - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
+    },
+    {
+      "description": "CTI helps shape the cybersecurity architecture by leveraging its “trusted advisor” status to inject policy insights at the intersection of cybersecurity and business operations.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Organization IT and Cybersecurity Architecture",
+          "Organization-Specific Cybersecurity Strategy, Policies, and Standards",
+          "Threat and Vulnerability Management Data Sources"
+        ],
+        "cti_mission": "Support the effort to develop a robust and resilient cybersecurity architecture by providing insights into cyber threats targeting the organization and recommending mitigation options around controls, processes, technologies, and other elements.",
+        "document_version": "1.3",
+        "domain": "Cybersecurity Architecture",
+        "domain_code": "ARCHITECTURE",
+        "domain_purpose": "Establish and maintain the structure and behavior of the organization’s cybersecurity architecture, including controls, processes, technologies, and other elements, commensurate with the risk to critical infrastructure and organizational objectives.",
+        "external_id": "ARCHITECTURE-3.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:Cybersecurity Architecture (ARCHITECTURE)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "ARCHITECTURE-3.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
+        "source_pages": [
+          47
+        ],
+        "source_section": "6.10",
+        "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
+        "use_case_number": 3
+      },
+      "uuid": "4046557e-b6e6-517a-9298-238461201e04",
+      "value": "CTI-CMM 1.3 - ARCHITECTURE-3.f - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
+    },
+    {
+      "description": "CTI is aware of the enterprise cybersecurity strategy and provides inputs and support to its development in at least an ad hoc manner.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-1.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "PROGRAM-1.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          48
+        ],
+        "source_section": "6.11",
+        "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
+        "use_case_number": 1
+      },
+      "uuid": "e8f9141f-cc50-5822-96c7-31ae9b98cd91",
+      "value": "CTI-CMM 1.3 - PROGRAM-1.a - Align CTI Program with Enterprise Cybersecurity Strategy"
+    },
+    {
+      "description": "CTI understands the enterprise cybersecurity strategy and leverages that understanding to provide focused inputs and development support on a regular basis.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-1.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "PROGRAM-1.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          48
+        ],
+        "source_section": "6.11",
+        "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
+        "use_case_number": 1
+      },
+      "uuid": "5655422d-090b-5709-972b-ac6727ee5580",
+      "value": "CTI-CMM 1.3 - PROGRAM-1.b - Align CTI Program with Enterprise Cybersecurity Strategy"
+    },
+    {
+      "description": "The CTI program strategy and priorities are formally documented and aligned with the organization’s cybersecurity mission, strategic objectives, and risk to critical infrastructure and assets.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-1.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "PROGRAM-1.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          48
+        ],
+        "source_section": "6.11",
+        "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
+        "use_case_number": 1
+      },
+      "uuid": "7f2bf9ad-2326-5228-be4e-56fc2eded5f3",
+      "value": "CTI-CMM 1.3 - PROGRAM-1.c - Align CTI Program with Enterprise Cybersecurity Strategy"
+    },
+    {
+      "description": "CTI applies its understanding of the cybersecurity program strategy to inform the development of CTI capabilities that are compliant and aligned to cybersecurity program goals.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-1.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "PROGRAM-1.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          48
+        ],
+        "source_section": "6.11",
+        "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
+        "use_case_number": 1
+      },
+      "uuid": "b91e5088-0c9b-54a6-b439-7522c12c230c",
+      "value": "CTI-CMM 1.3 - PROGRAM-1.d - Align CTI Program with Enterprise Cybersecurity Strategy"
+    },
+    {
+      "description": "CTI goals and performance standards are mapped to the performance management frameworks (OKR, KPI, etc.) used by the enterprise cybersecurity program, ensuring they are working in concert.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-1.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "PROGRAM-1.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          48
+        ],
+        "source_section": "6.11",
+        "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
+        "use_case_number": 1
+      },
+      "uuid": "53aba119-336b-58c4-8dcd-31e8524a7fac",
+      "value": "CTI-CMM 1.3 - PROGRAM-1.e - Align CTI Program with Enterprise Cybersecurity Strategy"
+    },
+    {
+      "description": "CTI is fully integrated into the processes that shape the cybersecurity program strategy and leverages its unique vantage point within the enterprise to provide novel insights such as risks associated with business changes, changes in the global threat landscape, and changes in the enterprise threat profile. (see RISK and THREAT)",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-1.f",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "PROGRAM-1.f",
+        "practice_letter": "f",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "related_domains": [
+          "RISK",
+          "THREAT"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          49
+        ],
+        "source_section": "6.11",
+        "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
+        "use_case_number": 1
+      },
+      "uuid": "8e06c0f3-6b87-5923-b205-04b17c5d077b",
+      "value": "CTI-CMM 1.3 - PROGRAM-1.f - Align CTI Program with Enterprise Cybersecurity Strategy"
+    },
+    {
+      "description": "CTI is familiar with key personnel involved in cybersecurity program management and effectively leverages this access on an ad hoc basis to provide relevant inputs.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-2.a",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "PROGRAM-2.a",
+        "practice_letter": "a",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          49
+        ],
+        "source_section": "6.11",
+        "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
+        "use_case_number": 2
+      },
+      "uuid": "e2060a78-b059-5d07-b224-8e2c39dcfb2b",
+      "value": "CTI-CMM 1.3 - PROGRAM-2.a - Support Maturation of the Enterprise Cybersecurity Program"
+    },
+    {
+      "description": "CTI has a basic knowledge of the mission, structure, and functional components of the cybersecurity program, allowing it to craft useful insights on at least an ad hoc basis.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-2.b",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI1",
+        "maturity_level_name": "Foundational",
+        "maturity_level_summary": "Basic practices are mostly undocumented, ad hoc, unplanned, response-driven, and focused on short-term results.",
+        "practice_id": "PROGRAM-2.b",
+        "practice_letter": "b",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          49
+        ],
+        "source_section": "6.11",
+        "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
+        "use_case_number": 2
+      },
+      "uuid": "7021ce89-c162-5f76-b718-3021003294ab",
+      "value": "CTI-CMM 1.3 - PROGRAM-2.b - Support Maturation of the Enterprise Cybersecurity Program"
+    },
+    {
+      "description": "CTI has established communication channels and trusted relationships with cybersecurity program leadership, leveraging both regularly to provide inputs in support of maturing the cybersecurity program.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-2.c",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "PROGRAM-2.c",
+        "practice_letter": "c",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          49
+        ],
+        "source_section": "6.11",
+        "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
+        "use_case_number": 2
+      },
+      "uuid": "0403e6af-b877-5234-96f1-c947ec8571f2",
+      "value": "CTI-CMM 1.3 - PROGRAM-2.c - Support Maturation of the Enterprise Cybersecurity Program"
+    },
+    {
+      "description": "CTI has a solid understanding of the mission, structure, and functional components of the cybersecurity program, allowing delivery of focused and properly contextualized policy inputs.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-2.d",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI2",
+        "maturity_level_name": "Advanced",
+        "maturity_level_summary": "Practices are mostly documented, planned, standardized, repeatable, consistent, and use automation at scale.",
+        "practice_id": "PROGRAM-2.d",
+        "practice_letter": "d",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          49
+        ],
+        "source_section": "6.11",
+        "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
+        "use_case_number": 2
+      },
+      "uuid": "f473e46a-13b6-5bf9-960d-cd5781845e76",
+      "value": "CTI-CMM 1.3 - PROGRAM-2.d - Support Maturation of the Enterprise Cybersecurity Program"
+    },
+    {
+      "description": "CTI is a trusted and equal partner with other cybersecurity and IT functions in providing guidance that shapes the cybersecurity program.",
+      "meta": {
+        "attribution": "This material is based on the Cyber Threat Intelligence Capability Maturity Model (CTI-CMM), authored by the CTI-CMM Authors and licensed under CC BY-SA 4.0. Modifications have been made by the MISP Project to express CTI-CMM as a MISP galaxy.",
+        "cti_data_sources": [
+          "Applicable Data Sources from Other Domains",
+          "Enterprise Cybersecurity Program Documentation",
+          "Corporate Annual Reporting (8-K, 10-K, Annual Report, etc.)",
+          "Cybersecurity Program Performance Management Documentation (OKR, KPI, etc.)"
+        ],
+        "cti_mission": "Support the enterprise cybersecurity program by aligning CTI operations to the program strategy, providing organization-specific insights that support cybersecurity program maturation, and delivering decision support to cybersecurity program management teams.",
+        "document_version": "1.3",
+        "domain": "CTI Program Management",
+        "domain_code": "PROGRAM",
+        "domain_note": "This domain maps to the C2M2 and describes how CTI should support the larger cybersecurity program rather than the structure of the CTI program itself.",
+        "domain_purpose": "Establish and maintain an enterprise cybersecurity program that provides governance, strategic planning, and sponsorship for the organization’s cybersecurity activities in a manner that aligns cybersecurity objectives with both the organization’s strategic objectives and the risk to critical infrastructure.",
+        "external_id": "PROGRAM-2.e",
+        "framework_version": "1.3",
+        "kill_chain": [
+          "cti-cmm-1-3:CTI Program Management (PROGRAM)"
+        ],
+        "license": "CC BY-SA 4.0",
+        "maturity_level": "CTI3",
+        "maturity_level_name": "Leading",
+        "maturity_level_summary": "Practices are standardized, cross-functional, measurable, continuously improved, and focused on prescriptive recommendations and long-term strategic results.",
+        "practice_id": "PROGRAM-2.e",
+        "practice_letter": "e",
+        "refs": [
+          "https://github.com/cti-cmm/framework",
+          "https://github.com/cti-cmm/framework/blob/main/CTI-CMM%20book%20Version%201.3.pdf",
+          "https://creativecommons.org/licenses/by-sa/4.0/"
+        ],
+        "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
+        "source_pages": [
+          49
+        ],
+        "source_section": "6.11",
+        "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
+        "use_case_number": 2
+      },
+      "uuid": "ab227f2b-3591-5d9e-8823-bdf987598649",
+      "value": "CTI-CMM 1.3 - PROGRAM-2.e - Support Maturation of the Enterprise Cybersecurity Program"
+    }
+  ],
+  "version": 1
+}

--- a/clusters/cti-cmm-1-3.json
+++ b/clusters/cti-cmm-1-3.json
@@ -45,11 +45,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          24
+          "24"
         ],
         "source_section": "6.1",
         "use_case": "Asset Visibility",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "565f4c5d-9b03-5395-9c8f-0c90b67133a5",
       "value": "CTI-CMM 1.3 - ASSET-1.a - Asset Visibility"
@@ -89,11 +89,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          24
+          "24"
         ],
         "source_section": "6.1",
         "use_case": "Asset Visibility",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "f3e71a4f-bda8-5492-a121-cfa3dc4a9aaf",
       "value": "CTI-CMM 1.3 - ASSET-1.b - Asset Visibility"
@@ -136,11 +136,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          24
+          "24"
         ],
         "source_section": "6.1",
         "use_case": "Asset Visibility",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "7610c4d5-4000-58e9-998e-d512c75f6d69",
       "value": "CTI-CMM 1.3 - ASSET-1.c - Asset Visibility"
@@ -180,11 +180,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          24
+          "24"
         ],
         "source_section": "6.1",
         "use_case": "Asset Visibility",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "76bc3b33-313e-591c-842b-8acc5de9fa7f",
       "value": "CTI-CMM 1.3 - ASSET-1.d - Asset Visibility"
@@ -228,11 +228,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          24
+          "24"
         ],
         "source_section": "6.1",
         "use_case": "Asset Visibility",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "54e4c71d-41be-50e9-b5da-14126382892b",
       "value": "CTI-CMM 1.3 - ASSET-1.e - Asset Visibility"
@@ -272,11 +272,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          24
+          "24"
         ],
         "source_section": "6.1",
         "use_case": "Asset Visibility",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "cb6f8725-723a-5d5e-9730-d2a97132ef8c",
       "value": "CTI-CMM 1.3 - ASSET-1.f - Asset Visibility"
@@ -316,11 +316,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "80b75c68-2fbb-5ff9-bf08-054d754e402f",
       "value": "CTI-CMM 1.3 - ASSET-2.a - Safeguard Assets"
@@ -363,11 +363,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "fd26ab78-5192-5316-878d-0f1a4481162d",
       "value": "CTI-CMM 1.3 - ASSET-2.b - Safeguard Assets"
@@ -407,11 +407,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "5310f6d0-19b9-5b6d-8d9e-f5a816e5450a",
       "value": "CTI-CMM 1.3 - ASSET-2.c - Safeguard Assets"
@@ -454,11 +454,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "6681dbb0-76ac-5fbd-86af-edce3057cf37",
       "value": "CTI-CMM 1.3 - ASSET-2.d - Safeguard Assets"
@@ -498,11 +498,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "86c57d9e-d8a1-53cb-b4a6-ebe13ecfcae6",
       "value": "CTI-CMM 1.3 - ASSET-2.e - Safeguard Assets"
@@ -542,11 +542,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "d1fae77e-1ebe-5cd9-8f24-23e7a5fcc92d",
       "value": "CTI-CMM 1.3 - ASSET-2.f - Safeguard Assets"
@@ -586,11 +586,11 @@
         ],
         "source_example": "CTI3 Leading Asset Management",
         "source_pages": [
-          25
+          "25"
         ],
         "source_section": "6.1",
         "use_case": "Safeguard Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "90f30bf8-697e-5518-99fb-d2ee4af81199",
       "value": "CTI-CMM 1.3 - ASSET-2.g - Safeguard Assets"
@@ -632,11 +632,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          26
+          "26"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "9a5fcedf-1374-5120-87eb-0fb6df5ef5c1",
       "value": "CTI-CMM 1.3 - THREAT-1.a - Enhance Attack Prevention and Preparedness"
@@ -678,11 +678,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          26
+          "26"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "d68675a0-9381-5850-b5d1-44ccad2a8c12",
       "value": "CTI-CMM 1.3 - THREAT-1.b - Enhance Attack Prevention and Preparedness"
@@ -724,11 +724,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          26
+          "26"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "aac8c23f-6705-5566-9e49-5350d2476c69",
       "value": "CTI-CMM 1.3 - THREAT-1.c - Enhance Attack Prevention and Preparedness"
@@ -770,11 +770,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "b8a15463-08ad-5c5b-bea4-2636e5b0c717",
       "value": "CTI-CMM 1.3 - THREAT-1.d - Enhance Attack Prevention and Preparedness"
@@ -816,11 +816,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "cc29d5ff-5495-5606-b12c-97fe38b26a35",
       "value": "CTI-CMM 1.3 - THREAT-1.e - Enhance Attack Prevention and Preparedness"
@@ -862,11 +862,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "e690b46c-93c5-5dbc-84a3-d63cc78d80a2",
       "value": "CTI-CMM 1.3 - THREAT-1.f - Enhance Attack Prevention and Preparedness"
@@ -908,11 +908,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "3a88a479-5089-578a-9875-8652ccc7acc7",
       "value": "CTI-CMM 1.3 - THREAT-1.g - Enhance Attack Prevention and Preparedness"
@@ -954,11 +954,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "5f5589a9-aa20-5f43-9412-60af1fec9581",
       "value": "CTI-CMM 1.3 - THREAT-1.h - Enhance Attack Prevention and Preparedness"
@@ -1000,11 +1000,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "32b150a5-b427-5c40-a598-c2765205872f",
       "value": "CTI-CMM 1.3 - THREAT-1.i - Enhance Attack Prevention and Preparedness"
@@ -1046,11 +1046,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "e848a65e-f2fe-54d5-8a1e-1b3565582479",
       "value": "CTI-CMM 1.3 - THREAT-1.j - Enhance Attack Prevention and Preparedness"
@@ -1092,11 +1092,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Attack Prevention and Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "6a03ae69-4c53-589c-9e4a-90373a0c25fe",
       "value": "CTI-CMM 1.3 - THREAT-1.k - Enhance Attack Prevention and Preparedness"
@@ -1138,11 +1138,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Drive Detection Engineering Improvements and Strategy",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "6528d9ea-5be1-53d7-b72e-87ae02455e88",
       "value": "CTI-CMM 1.3 - THREAT-2.a - Drive Detection Engineering Improvements and Strategy"
@@ -1184,11 +1184,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Drive Detection Engineering Improvements and Strategy",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "38aae23e-3ba8-5303-a954-ab04ab5352b6",
       "value": "CTI-CMM 1.3 - THREAT-2.b - Drive Detection Engineering Improvements and Strategy"
@@ -1230,11 +1230,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Drive Detection Engineering Improvements and Strategy",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "bd76f096-93e9-52e9-b918-92fba43d464a",
       "value": "CTI-CMM 1.3 - THREAT-2.c - Drive Detection Engineering Improvements and Strategy"
@@ -1276,11 +1276,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Drive Detection Engineering Improvements and Strategy",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "47e5e059-b573-5387-9f7c-10f15185c2d7",
       "value": "CTI-CMM 1.3 - THREAT-2.d - Drive Detection Engineering Improvements and Strategy"
@@ -1322,11 +1322,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Drive Detection Engineering Improvements and Strategy",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "43b3abeb-8c3e-5246-8c49-d8146b1aac8b",
       "value": "CTI-CMM 1.3 - THREAT-2.e - Drive Detection Engineering Improvements and Strategy"
@@ -1368,11 +1368,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Threat Hunting",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "f8f628c9-662e-5245-9d3e-890e1bb00c6c",
       "value": "CTI-CMM 1.3 - THREAT-3.a - Enhance Threat Hunting"
@@ -1414,11 +1414,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Threat Hunting",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "350162ca-e98b-5145-b5f3-5531b819fcbe",
       "value": "CTI-CMM 1.3 - THREAT-3.b - Enhance Threat Hunting"
@@ -1460,11 +1460,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          27
+          "27"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Threat Hunting",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "8f0a7b2f-2b18-524f-9b63-00cf4aeb990e",
       "value": "CTI-CMM 1.3 - THREAT-3.c - Enhance Threat Hunting"
@@ -1506,11 +1506,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Threat Hunting",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "86ac3fa8-0bb4-52e5-a4da-6559eff736fd",
       "value": "CTI-CMM 1.3 - THREAT-3.d - Enhance Threat Hunting"
@@ -1552,11 +1552,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Enhance Threat Hunting",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "bcbc080d-1391-550d-ba57-16ee8f7dfb9c",
       "value": "CTI-CMM 1.3 - THREAT-3.e - Enhance Threat Hunting"
@@ -1598,11 +1598,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Inform Offensive Security Operations",
-        "use_case_number": 4
+        "use_case_number": "4"
       },
       "uuid": "661d1a55-1165-508e-a5ce-9cb5180e0a65",
       "value": "CTI-CMM 1.3 - THREAT-4.a - Inform Offensive Security Operations"
@@ -1644,11 +1644,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Inform Offensive Security Operations",
-        "use_case_number": 4
+        "use_case_number": "4"
       },
       "uuid": "0b837c89-6768-5c39-91b7-ff993af64fd7",
       "value": "CTI-CMM 1.3 - THREAT-4.b - Inform Offensive Security Operations"
@@ -1690,11 +1690,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Inform Offensive Security Operations",
-        "use_case_number": 4
+        "use_case_number": "4"
       },
       "uuid": "06b15893-03e6-5218-9f81-2462b4c28302",
       "value": "CTI-CMM 1.3 - THREAT-4.c - Inform Offensive Security Operations"
@@ -1736,11 +1736,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Inform Offensive Security Operations",
-        "use_case_number": 4
+        "use_case_number": "4"
       },
       "uuid": "06cf7bbb-ca64-52a2-8d02-4bcef76dfa12",
       "value": "CTI-CMM 1.3 - THREAT-4.d - Inform Offensive Security Operations"
@@ -1782,11 +1782,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Inform Offensive Security Operations",
-        "use_case_number": 4
+        "use_case_number": "4"
       },
       "uuid": "478a1d86-74fa-585f-b6d5-14fe99382028",
       "value": "CTI-CMM 1.3 - THREAT-4.e - Inform Offensive Security Operations"
@@ -1828,11 +1828,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Inform Offensive Security Operations",
-        "use_case_number": 4
+        "use_case_number": "4"
       },
       "uuid": "8ca0bcb3-762b-5569-8404-ad376dd069cb",
       "value": "CTI-CMM 1.3 - THREAT-4.f - Inform Offensive Security Operations"
@@ -1874,11 +1874,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Improve Patch Prioritization",
-        "use_case_number": 5
+        "use_case_number": "5"
       },
       "uuid": "7f52bd9d-5b99-5304-8af1-881eb3da1c7c",
       "value": "CTI-CMM 1.3 - THREAT-5.a - Improve Patch Prioritization"
@@ -1920,11 +1920,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Improve Patch Prioritization",
-        "use_case_number": 5
+        "use_case_number": "5"
       },
       "uuid": "0ab11a63-dfce-5817-8135-6aca75b888c3",
       "value": "CTI-CMM 1.3 - THREAT-5.b - Improve Patch Prioritization"
@@ -1966,11 +1966,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Improve Patch Prioritization",
-        "use_case_number": 5
+        "use_case_number": "5"
       },
       "uuid": "37422253-0483-5e2a-a2e5-9b61286031d7",
       "value": "CTI-CMM 1.3 - THREAT-5.c - Improve Patch Prioritization"
@@ -2012,11 +2012,11 @@
         ],
         "source_example": "CTI3 Leading Patch Prioritization and Purple Teaming",
         "source_pages": [
-          28
+          "28"
         ],
         "source_section": "6.2",
         "use_case": "Improve Patch Prioritization",
-        "use_case_number": 5
+        "use_case_number": "5"
       },
       "uuid": "ee8f2f06-0e38-59fb-8aa3-a42d296d9381",
       "value": "CTI-CMM 1.3 - THREAT-5.d - Improve Patch Prioritization"
@@ -2058,11 +2058,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          29
+          "29"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "5004a89d-7752-52a8-84a8-128d7fef5879",
       "value": "CTI-CMM 1.3 - RISK-1.a - Align CTI Practices to Risk Management Strategies"
@@ -2104,11 +2104,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          29
+          "29"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "ed5c7f2e-1e66-58ac-92a8-55b566309d9f",
       "value": "CTI-CMM 1.3 - RISK-1.b - Align CTI Practices to Risk Management Strategies"
@@ -2150,11 +2150,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          29
+          "29"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "bc9fe17e-9d49-5f1d-8877-45db8dbac0ee",
       "value": "CTI-CMM 1.3 - RISK-1.c - Align CTI Practices to Risk Management Strategies"
@@ -2196,11 +2196,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          29
+          "29"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "528b67b9-1853-54fa-b69b-b3ff05f35f50",
       "value": "CTI-CMM 1.3 - RISK-1.d - Align CTI Practices to Risk Management Strategies"
@@ -2242,11 +2242,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          29
+          "29"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "410abb18-5c7b-5dba-9240-4f580c407099",
       "value": "CTI-CMM 1.3 - RISK-1.e - Align CTI Practices to Risk Management Strategies"
@@ -2288,11 +2288,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          29
+          "29"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "103a4e2c-b238-565f-a478-7bc6268f79d0",
       "value": "CTI-CMM 1.3 - RISK-1.f - Align CTI Practices to Risk Management Strategies"
@@ -2337,11 +2337,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "0edc882c-96d3-5b0d-84a8-ecca1d16972f",
       "value": "CTI-CMM 1.3 - RISK-1.g - Align CTI Practices to Risk Management Strategies"
@@ -2386,11 +2386,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Align CTI Practices to Risk Management Strategies",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "9ca90094-2dfd-5424-8892-94f5c49cf41e",
       "value": "CTI-CMM 1.3 - RISK-1.h - Align CTI Practices to Risk Management Strategies"
@@ -2435,11 +2435,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "274ca4e9-db83-5056-8791-1528cdcd927f",
       "value": "CTI-CMM 1.3 - RISK-2.a - Improve Risk Decisions, Assessments, and Controls"
@@ -2481,11 +2481,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "48246ee8-d9a6-583f-a9ea-4295c8e67eef",
       "value": "CTI-CMM 1.3 - RISK-2.b - Improve Risk Decisions, Assessments, and Controls"
@@ -2527,11 +2527,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "a8891034-a311-5d00-a113-441684a64a93",
       "value": "CTI-CMM 1.3 - RISK-2.c - Improve Risk Decisions, Assessments, and Controls"
@@ -2573,11 +2573,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "6e0c374d-28ab-5222-9d6e-d2356c695d08",
       "value": "CTI-CMM 1.3 - RISK-2.d - Improve Risk Decisions, Assessments, and Controls"
@@ -2619,11 +2619,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "26a333a6-3601-58cd-b02a-0c9c6b82e337",
       "value": "CTI-CMM 1.3 - RISK-2.e - Improve Risk Decisions, Assessments, and Controls"
@@ -2665,11 +2665,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "31072977-7e7b-5a11-a1ba-b4f4fa4191de",
       "value": "CTI-CMM 1.3 - RISK-2.f - Improve Risk Decisions, Assessments, and Controls"
@@ -2714,11 +2714,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "a627793b-c260-5c07-a636-27c67936dffa",
       "value": "CTI-CMM 1.3 - RISK-2.g - Improve Risk Decisions, Assessments, and Controls"
@@ -2760,11 +2760,11 @@
         ],
         "source_example": "CTI3 Leading Risk Management",
         "source_pages": [
-          30
+          "30"
         ],
         "source_section": "6.3",
         "use_case": "Improve Risk Decisions, Assessments, and Controls",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "b705fab5-501e-59aa-801e-5a4bb8c0518f",
       "value": "CTI-CMM 1.3 - RISK-2.h - Improve Risk Decisions, Assessments, and Controls"
@@ -2802,11 +2802,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          31
+          "31"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "ebc20ce8-0cff-5c31-8be1-1861b486ab60",
       "value": "CTI-CMM 1.3 - ACCESS-1.a - Accelerate Remediation of Identity-Related Threats"
@@ -2847,11 +2847,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          31
+          "31"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "cdc338c3-408d-51a0-ae17-374791b3e80e",
       "value": "CTI-CMM 1.3 - ACCESS-1.b - Accelerate Remediation of Identity-Related Threats"
@@ -2889,11 +2889,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          31
+          "31"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "9833f023-b60b-5c69-9a33-68ca7af2c726",
       "value": "CTI-CMM 1.3 - ACCESS-1.c - Accelerate Remediation of Identity-Related Threats"
@@ -2931,11 +2931,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          31
+          "31"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "00df8ab3-a8ad-55d1-a933-b3a92c2023ab",
       "value": "CTI-CMM 1.3 - ACCESS-1.d - Accelerate Remediation of Identity-Related Threats"
@@ -2976,11 +2976,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          31
+          "31"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "90c49a3c-df4d-5462-8dbb-f6c5db7f08a0",
       "value": "CTI-CMM 1.3 - ACCESS-1.e - Accelerate Remediation of Identity-Related Threats"
@@ -3018,11 +3018,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          31
+          "31"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "416512b9-8b3d-5839-ab2e-1f7560798419",
       "value": "CTI-CMM 1.3 - ACCESS-1.f - Accelerate Remediation of Identity-Related Threats"
@@ -3060,11 +3060,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "b8e56554-8bcb-55ee-8d26-364f8c367cdc",
       "value": "CTI-CMM 1.3 - ACCESS-1.g - Accelerate Remediation of Identity-Related Threats"
@@ -3102,11 +3102,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "7a010110-a165-5bff-ad90-365f68138187",
       "value": "CTI-CMM 1.3 - ACCESS-1.h - Accelerate Remediation of Identity-Related Threats"
@@ -3144,11 +3144,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Accelerate Remediation of Identity-Related Threats",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "b8435ef0-676c-5eed-839a-05bc79eeb67f",
       "value": "CTI-CMM 1.3 - ACCESS-1.i - Accelerate Remediation of Identity-Related Threats"
@@ -3186,11 +3186,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "58efd62d-4cd0-5f18-84e2-f3afe41dcea3",
       "value": "CTI-CMM 1.3 - ACCESS-2.a - Fortify Identity and Access Protection"
@@ -3228,11 +3228,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "292a6a22-2e4e-5373-96c0-208096770566",
       "value": "CTI-CMM 1.3 - ACCESS-2.b - Fortify Identity and Access Protection"
@@ -3274,11 +3274,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "942293c3-ec20-5e39-8fcc-34dd4a13ea01",
       "value": "CTI-CMM 1.3 - ACCESS-2.c - Fortify Identity and Access Protection"
@@ -3316,11 +3316,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "4bb65d0a-e979-5031-a9cc-641bb644f2c0",
       "value": "CTI-CMM 1.3 - ACCESS-2.d - Fortify Identity and Access Protection"
@@ -3361,11 +3361,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "5700f1fc-6220-5996-a7dd-de02a7efc879",
       "value": "CTI-CMM 1.3 - ACCESS-2.e - Fortify Identity and Access Protection"
@@ -3406,11 +3406,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "c6b3152f-1593-537d-a1ca-df1d18721367",
       "value": "CTI-CMM 1.3 - ACCESS-2.f - Fortify Identity and Access Protection"
@@ -3451,11 +3451,11 @@
         ],
         "source_example": "CTI3 Leading Identity and Access Management",
         "source_pages": [
-          32
+          "32"
         ],
         "source_section": "6.4",
         "use_case": "Fortify Identity and Access Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "d358b552-f0f5-57a6-a508-31dcadf94f40",
       "value": "CTI-CMM 1.3 - ACCESS-2.g - Fortify Identity and Access Protection"
@@ -3495,11 +3495,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          33
+          "33"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "240bdc26-7b31-5192-a546-9cddcdc6e24b",
       "value": "CTI-CMM 1.3 - SITUATION-1.a - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3539,11 +3539,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          33
+          "33"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "febf468a-4cf6-5768-838e-bd33cdfb3878",
       "value": "CTI-CMM 1.3 - SITUATION-1.b - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3586,11 +3586,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          33
+          "33"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "6f5e92c3-734e-5df9-b360-a8142e7e1163",
       "value": "CTI-CMM 1.3 - SITUATION-1.c - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3633,11 +3633,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          33
+          "33"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "89dbdb5a-acd4-5d76-ad41-bed31f3d86ec",
       "value": "CTI-CMM 1.3 - SITUATION-1.d - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3677,11 +3677,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          33
+          "33"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "0d29dcfe-357c-5428-89d1-45385bb07337",
       "value": "CTI-CMM 1.3 - SITUATION-1.e - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3721,11 +3721,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          34
+          "34"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "8162c855-dba2-55f0-bd3d-02fd7ce542e9",
       "value": "CTI-CMM 1.3 - SITUATION-1.f - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3770,11 +3770,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          34
+          "34"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "74800491-f9fd-588f-8e0a-09eab76d5a81",
       "value": "CTI-CMM 1.3 - SITUATION-1.g - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3814,11 +3814,11 @@
         ],
         "source_example": "CTI3 Leading Situational Awareness",
         "source_pages": [
-          34
+          "34"
         ],
         "source_section": "6.5",
         "use_case": "Maintain Comprehensive Understanding of the Cyber Threat Landscape",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "7e6a0a79-fa78-5f60-b877-48cc9e33c828",
       "value": "CTI-CMM 1.3 - SITUATION-1.h - Maintain Comprehensive Understanding of the Cyber Threat Landscape"
@@ -3862,11 +3862,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          35
+          "35"
         ],
         "source_section": "6.6",
         "use_case": "Strengthen Pre-Incident Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "ef67d063-54f7-57c9-8ee9-30f3ec51f9bd",
       "value": "CTI-CMM 1.3 - RESPONSE-1.a - Strengthen Pre-Incident Preparedness"
@@ -3910,11 +3910,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          35
+          "35"
         ],
         "source_section": "6.6",
         "use_case": "Strengthen Pre-Incident Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "3010b24f-c060-5fda-9776-9bb507f088a0",
       "value": "CTI-CMM 1.3 - RESPONSE-1.b - Strengthen Pre-Incident Preparedness"
@@ -3958,11 +3958,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          35
+          "35"
         ],
         "source_section": "6.6",
         "use_case": "Strengthen Pre-Incident Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "912bbb91-fd0d-5d3b-bae7-f5fe81e0cc14",
       "value": "CTI-CMM 1.3 - RESPONSE-1.c - Strengthen Pre-Incident Preparedness"
@@ -4006,11 +4006,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          35
+          "35"
         ],
         "source_section": "6.6",
         "use_case": "Strengthen Pre-Incident Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "5f355d77-ecfe-5b36-96e6-d2b1de099852",
       "value": "CTI-CMM 1.3 - RESPONSE-1.d - Strengthen Pre-Incident Preparedness"
@@ -4057,11 +4057,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Strengthen Pre-Incident Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "2ae1c28d-0571-5129-9182-f9f0cc87dcbe",
       "value": "CTI-CMM 1.3 - RESPONSE-1.e - Strengthen Pre-Incident Preparedness"
@@ -4108,11 +4108,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Strengthen Pre-Incident Preparedness",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "fd8107c2-2f28-5476-864d-5f2c85bc4a54",
       "value": "CTI-CMM 1.3 - RESPONSE-1.f - Strengthen Pre-Incident Preparedness"
@@ -4156,11 +4156,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "67530f69-3af4-5b29-833a-2c6a93c25eda",
       "value": "CTI-CMM 1.3 - RESPONSE-2.a - Improve Incident Analysis and Response"
@@ -4204,11 +4204,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "b54c8c66-4e17-5b26-bb60-5b3ae165ab10",
       "value": "CTI-CMM 1.3 - RESPONSE-2.b - Improve Incident Analysis and Response"
@@ -4252,11 +4252,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "fc6fa1de-f514-5e24-ae3d-c11b41ba3be7",
       "value": "CTI-CMM 1.3 - RESPONSE-2.c - Improve Incident Analysis and Response"
@@ -4300,11 +4300,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "b061f226-6c51-5feb-a5ea-fce8ca088d5f",
       "value": "CTI-CMM 1.3 - RESPONSE-2.d - Improve Incident Analysis and Response"
@@ -4348,11 +4348,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "59c35998-d4f4-5542-bb00-fb0f1184541d",
       "value": "CTI-CMM 1.3 - RESPONSE-2.e - Improve Incident Analysis and Response"
@@ -4396,11 +4396,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "409e3f87-ded5-5945-b9ac-327e83d73c6e",
       "value": "CTI-CMM 1.3 - RESPONSE-2.f - Improve Incident Analysis and Response"
@@ -4444,11 +4444,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "45d3168f-37e9-5266-8270-d2b99f2fba29",
       "value": "CTI-CMM 1.3 - RESPONSE-2.g - Improve Incident Analysis and Response"
@@ -4495,11 +4495,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Improve Incident Analysis and Response",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "f74b9259-27b3-5999-9b80-d6f752a0f0fd",
       "value": "CTI-CMM 1.3 - RESPONSE-2.h - Improve Incident Analysis and Response"
@@ -4543,11 +4543,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "911bcd05-279a-5f41-8086-1dc8f321e502",
       "value": "CTI-CMM 1.3 - RESPONSE-3.a - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4591,11 +4591,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "09e5ca83-40d5-5dad-82a3-73c00c69aca2",
       "value": "CTI-CMM 1.3 - RESPONSE-3.b - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4642,11 +4642,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "97a92707-df09-5ce5-93bf-c522addbf2d2",
       "value": "CTI-CMM 1.3 - RESPONSE-3.c - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4690,11 +4690,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "c3801ba3-1902-5010-a6df-f0e47f22e92f",
       "value": "CTI-CMM 1.3 - RESPONSE-3.d - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4738,11 +4738,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "b072c028-cd54-5575-b378-c93f3403ae12",
       "value": "CTI-CMM 1.3 - RESPONSE-3.e - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4786,11 +4786,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          36
+          "36"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "02cef0ab-a959-51f6-a381-cbee526611ac",
       "value": "CTI-CMM 1.3 - RESPONSE-3.f - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4834,11 +4834,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          37
+          "37"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "94fbd476-69b7-5e43-955a-73b4b384101b",
       "value": "CTI-CMM 1.3 - RESPONSE-3.g - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4882,11 +4882,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          37
+          "37"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "c8cd4e03-3ced-537b-9d2a-9b2c85023619",
       "value": "CTI-CMM 1.3 - RESPONSE-3.h - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4933,11 +4933,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          37
+          "37"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "cd70028b-6208-5f77-9e73-5b0d767c166f",
       "value": "CTI-CMM 1.3 - RESPONSE-3.i - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -4981,11 +4981,11 @@
         ],
         "source_example": "CTI3 Leading Event and Incident Response, Continuity of Operations",
         "source_pages": [
-          37
+          "37"
         ],
         "source_section": "6.6",
         "use_case": "Enhance Post-Incident Recovery and Continuity of Operations",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "aef30f63-0f87-56ab-99de-b79ed278437c",
       "value": "CTI-CMM 1.3 - RESPONSE-3.j - Enhance Post-Incident Recovery and Continuity of Operations"
@@ -5028,11 +5028,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          38
+          "38"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "077dc059-715a-5bc6-9563-b54d3dcfc529",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.a - Assess Threats to Third Parties"
@@ -5075,11 +5075,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          38
+          "38"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "7a50d03b-64a6-5d6c-aa9c-4fcab8568757",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.b - Assess Threats to Third Parties"
@@ -5126,11 +5126,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          38
+          "38"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "05cbaef9-ba95-5889-9630-5d4dcfa421e9",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.c - Assess Threats to Third Parties"
@@ -5176,11 +5176,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          38
+          "38"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "ee952cd1-123b-5c38-ab64-89a7c04a1694",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.d - Assess Threats to Third Parties"
@@ -5223,11 +5223,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          38
+          "38"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "43ac3658-c303-5875-a7af-ab0bb878c4c0",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.e - Assess Threats to Third Parties"
@@ -5273,11 +5273,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          38
+          "38"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "27120372-8b61-5e4c-be06-b5732181dbf8",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.f - Assess Threats to Third Parties"
@@ -5323,11 +5323,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "0232e694-6623-5fd2-984b-26deb8db2514",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.g - Assess Threats to Third Parties"
@@ -5370,11 +5370,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "58d3e65e-8a4e-5f8b-a3f5-7d2ccd9eca5f",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.h - Assess Threats to Third Parties"
@@ -5420,11 +5420,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Assess Threats to Third Parties",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "05cc24da-640d-5216-bc0e-47c2478dbc7d",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-1.i - Assess Threats to Third Parties"
@@ -5467,11 +5467,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "2012832e-d144-59a7-98c2-370e0a0a52c0",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.a - Mitigate Third-Party Risk Exposure"
@@ -5514,11 +5514,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "3ee5df87-eb4e-5031-94de-b0e246692ef6",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.b - Mitigate Third-Party Risk Exposure"
@@ -5564,11 +5564,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "6fbef05c-d6a4-5db1-8d65-3fe101358968",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.c - Mitigate Third-Party Risk Exposure"
@@ -5611,11 +5611,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "0f56fb42-0b78-5cb5-9841-54e1041c2f0f",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.d - Mitigate Third-Party Risk Exposure"
@@ -5661,11 +5661,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "c9d9cbbc-3ccc-5325-b43d-29549ddfb052",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.e - Mitigate Third-Party Risk Exposure"
@@ -5708,11 +5708,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "557a486f-48cc-56b3-bcfe-f5a0575ca408",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.f - Mitigate Third-Party Risk Exposure"
@@ -5755,11 +5755,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "790451ec-82c9-5cfb-a284-fe8ed5ec25a6",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.g - Mitigate Third-Party Risk Exposure"
@@ -5805,11 +5805,11 @@
         ],
         "source_example": "CTI3 Leading Third-Party Risk Management",
         "source_pages": [
-          39
+          "39"
         ],
         "source_section": "6.7",
         "use_case": "Mitigate Third-Party Risk Exposure",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "c0ea4a7d-497b-5d71-bf6c-71a1bdd33c06",
       "value": "CTI-CMM 1.3 - THIRD-PARTIES-2.h - Mitigate Third-Party Risk Exposure"
@@ -5852,11 +5852,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          40
+          "40"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "3f3fed42-74a9-5029-8502-7bae3d7179aa",
       "value": "CTI-CMM 1.3 - FRAUD-1.a - Mitigate Financial Fraud"
@@ -5899,11 +5899,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "70d9f5f7-0596-50b3-b81b-2e6aaf50b614",
       "value": "CTI-CMM 1.3 - FRAUD-1.b - Mitigate Financial Fraud"
@@ -5946,11 +5946,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "8107df34-d254-5c13-aa26-2f92e6534269",
       "value": "CTI-CMM 1.3 - FRAUD-1.c - Mitigate Financial Fraud"
@@ -5993,11 +5993,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "82db8bc2-c4a6-573e-a73d-939717a87e68",
       "value": "CTI-CMM 1.3 - FRAUD-1.d - Mitigate Financial Fraud"
@@ -6040,11 +6040,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "c646385f-cf1a-516e-8b9d-b0c594741dde",
       "value": "CTI-CMM 1.3 - FRAUD-1.e - Mitigate Financial Fraud"
@@ -6087,11 +6087,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "db944fc2-5f0f-580a-be6e-e72af4c51ae3",
       "value": "CTI-CMM 1.3 - FRAUD-1.f - Mitigate Financial Fraud"
@@ -6134,11 +6134,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "badebdf9-db6f-5c83-816d-61a96efbd13b",
       "value": "CTI-CMM 1.3 - FRAUD-1.g - Mitigate Financial Fraud"
@@ -6184,11 +6184,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "f97c8d9b-23dc-55f1-9017-633c9d6cb3bd",
       "value": "CTI-CMM 1.3 - FRAUD-1.h - Mitigate Financial Fraud"
@@ -6231,11 +6231,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "7833f2bb-3e6a-50cc-94f0-6f879a2df5b6",
       "value": "CTI-CMM 1.3 - FRAUD-1.i - Mitigate Financial Fraud"
@@ -6278,11 +6278,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "d3e6c92a-ee0c-5d4d-a3b4-543dd3796b16",
       "value": "CTI-CMM 1.3 - FRAUD-1.j - Mitigate Financial Fraud"
@@ -6325,11 +6325,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "85bf8419-cf9b-5839-9b7f-9e2cbdd2ed03",
       "value": "CTI-CMM 1.3 - FRAUD-1.k - Mitigate Financial Fraud"
@@ -6372,11 +6372,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Mitigate Financial Fraud",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "509decb8-743d-5efe-8abd-52ee2b849fa9",
       "value": "CTI-CMM 1.3 - FRAUD-1.l - Mitigate Financial Fraud"
@@ -6419,11 +6419,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "72ce6b49-0db6-5d76-be73-defb8ef471bd",
       "value": "CTI-CMM 1.3 - FRAUD-2.a - Improve Brand Impersonation Protection"
@@ -6466,11 +6466,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "000692f0-3af2-5c50-bc2a-ba88d8c574cc",
       "value": "CTI-CMM 1.3 - FRAUD-2.b - Improve Brand Impersonation Protection"
@@ -6516,11 +6516,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "5ca8b088-735c-5dc7-acfb-2180dfbb5f48",
       "value": "CTI-CMM 1.3 - FRAUD-2.c - Improve Brand Impersonation Protection"
@@ -6563,11 +6563,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "db83e755-287a-579f-9a3b-b62c02c1614d",
       "value": "CTI-CMM 1.3 - FRAUD-2.d - Improve Brand Impersonation Protection"
@@ -6610,11 +6610,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "38aa23ea-be7f-5356-a972-95f865fbafa6",
       "value": "CTI-CMM 1.3 - FRAUD-2.e - Improve Brand Impersonation Protection"
@@ -6657,11 +6657,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "638b4549-4e14-5d5c-8bd4-ed92b2c6ab2a",
       "value": "CTI-CMM 1.3 - FRAUD-2.f - Improve Brand Impersonation Protection"
@@ -6707,11 +6707,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "7e3fe768-81dc-5f6b-8b48-19f8f9bd50af",
       "value": "CTI-CMM 1.3 - FRAUD-2.g - Improve Brand Impersonation Protection"
@@ -6754,11 +6754,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          41
+          "41"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "dd68bb6f-8fc1-540c-b29a-cbd9deb74d39",
       "value": "CTI-CMM 1.3 - FRAUD-2.h - Improve Brand Impersonation Protection"
@@ -6801,11 +6801,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Improve Brand Impersonation Protection",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "5dddb8ca-5268-5578-9cf3-f23473924742",
       "value": "CTI-CMM 1.3 - FRAUD-2.i - Improve Brand Impersonation Protection"
@@ -6848,11 +6848,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Enhance Account Takeover (ATO) Detection",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "3dc84fca-4146-51ea-8803-1954a3fc5e0f",
       "value": "CTI-CMM 1.3 - FRAUD-3.a - Enhance Account Takeover (ATO) Detection"
@@ -6895,11 +6895,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Enhance Account Takeover (ATO) Detection",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "c34dbbcc-8a9f-5824-8157-90dda9693e5a",
       "value": "CTI-CMM 1.3 - FRAUD-3.b - Enhance Account Takeover (ATO) Detection"
@@ -6942,11 +6942,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Enhance Account Takeover (ATO) Detection",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "cee8d929-31b8-57d9-94c0-37f6cfaa437e",
       "value": "CTI-CMM 1.3 - FRAUD-3.c - Enhance Account Takeover (ATO) Detection"
@@ -6989,11 +6989,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Enhance Account Takeover (ATO) Detection",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "88c4c470-2b64-5102-b2bd-041db78b0f13",
       "value": "CTI-CMM 1.3 - FRAUD-3.d - Enhance Account Takeover (ATO) Detection"
@@ -7036,11 +7036,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Enhance Account Takeover (ATO) Detection",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "aa0c4e9c-8fd3-5aa4-affa-64fc48b87dd7",
       "value": "CTI-CMM 1.3 - FRAUD-3.e - Enhance Account Takeover (ATO) Detection"
@@ -7083,11 +7083,11 @@
         ],
         "source_example": "CTI3 Leading Fraud and Abuse Management",
         "source_pages": [
-          42
+          "42"
         ],
         "source_section": "6.8",
         "use_case": "Enhance Account Takeover (ATO) Detection",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "b5cafb6b-e946-5016-bf4f-60d4820c5457",
       "value": "CTI-CMM 1.3 - FRAUD-3.f - Enhance Account Takeover (ATO) Detection"
@@ -7124,11 +7124,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          43
+          "43"
         ],
         "source_section": "6.9",
         "use_case": "Support and Safeguard Human Resources Practices",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "e8a6bab8-33cc-5eda-95f8-a30c63d12267",
       "value": "CTI-CMM 1.3 - WORKFORCE-1.a - Support and Safeguard Human Resources Practices"
@@ -7165,11 +7165,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          43
+          "43"
         ],
         "source_section": "6.9",
         "use_case": "Support and Safeguard Human Resources Practices",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "ee81da51-9b09-525e-bee4-17b4c4317861",
       "value": "CTI-CMM 1.3 - WORKFORCE-1.b - Support and Safeguard Human Resources Practices"
@@ -7206,11 +7206,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          43
+          "43"
         ],
         "source_section": "6.9",
         "use_case": "Support and Safeguard Human Resources Practices",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "b6c481b3-49f6-5fd2-ad4f-26ec87e22b23",
       "value": "CTI-CMM 1.3 - WORKFORCE-1.c - Support and Safeguard Human Resources Practices"
@@ -7247,11 +7247,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          43
+          "43"
         ],
         "source_section": "6.9",
         "use_case": "Support and Safeguard Human Resources Practices",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "a6723893-b627-5a2d-b345-cab8fb4a93fb",
       "value": "CTI-CMM 1.3 - WORKFORCE-1.d - Support and Safeguard Human Resources Practices"
@@ -7292,11 +7292,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          43
+          "43"
         ],
         "source_section": "6.9",
         "use_case": "Support and Safeguard Human Resources Practices",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "78be0b63-3e90-545e-9ffa-5e9e2491c416",
       "value": "CTI-CMM 1.3 - WORKFORCE-1.e - Support and Safeguard Human Resources Practices"
@@ -7333,11 +7333,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support and Safeguard Human Resources Practices",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "45b1e0a1-8688-5614-a201-889b7ecc61f6",
       "value": "CTI-CMM 1.3 - WORKFORCE-1.f - Support and Safeguard Human Resources Practices"
@@ -7374,11 +7374,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "af74b036-f1ab-5316-9144-28abf01256c1",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.a - Support Development of Training and Education Assets"
@@ -7415,11 +7415,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "de41453b-e9b2-5dfa-a393-91a5e0ea24c9",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.b - Support Development of Training and Education Assets"
@@ -7459,11 +7459,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "f5244dc2-f5b8-5cbb-b386-839d61622af9",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.c - Support Development of Training and Education Assets"
@@ -7500,11 +7500,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "7e891e1a-1d82-55c8-b171-3a1516f84e3d",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.d - Support Development of Training and Education Assets"
@@ -7541,11 +7541,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "b2ed1bc0-b762-51a4-9bf9-c77c57fdc8d0",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.e - Support Development of Training and Education Assets"
@@ -7582,11 +7582,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "995dfd0e-ba02-519e-b381-32cae64904ac",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.f - Support Development of Training and Education Assets"
@@ -7623,11 +7623,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "ed59417e-c432-5d4c-8a94-44c67bf1edd4",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.g - Support Development of Training and Education Assets"
@@ -7667,11 +7667,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "d01e769b-1a17-5a00-af4b-e0e895a6d58f",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.h - Support Development of Training and Education Assets"
@@ -7711,11 +7711,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "7b5a6e6c-0acb-50bb-bd3b-8136ca2bedb2",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.i - Support Development of Training and Education Assets"
@@ -7755,11 +7755,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "032125ea-721c-57eb-bbe8-433a35cfdac3",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.j - Support Development of Training and Education Assets"
@@ -7796,11 +7796,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Development of Training and Education Assets",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "a3992694-de16-5a7f-8847-5aeb9ee8333a",
       "value": "CTI-CMM 1.3 - WORKFORCE-2.k - Support Development of Training and Education Assets"
@@ -7837,11 +7837,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "6a209092-3bfe-5722-a837-c0dd45600fb7",
       "value": "CTI-CMM 1.3 - WORKFORCE-3.a - Support Cybersecurity Management in Workforce Development Efforts"
@@ -7878,11 +7878,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "d394181b-0b4c-509a-a11d-b2741724355a",
       "value": "CTI-CMM 1.3 - WORKFORCE-3.b - Support Cybersecurity Management in Workforce Development Efforts"
@@ -7919,11 +7919,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "c6e1a94f-8df4-51e7-abf9-13c3cbc00c56",
       "value": "CTI-CMM 1.3 - WORKFORCE-3.c - Support Cybersecurity Management in Workforce Development Efforts"
@@ -7960,11 +7960,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          44
+          "44"
         ],
         "source_section": "6.9",
         "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "a5697921-2f33-576e-aa20-6390460add51",
       "value": "CTI-CMM 1.3 - WORKFORCE-3.d - Support Cybersecurity Management in Workforce Development Efforts"
@@ -8001,11 +8001,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          45
+          "45"
         ],
         "source_section": "6.9",
         "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "e1268463-32c1-56f9-96a9-09cafc0c17e7",
       "value": "CTI-CMM 1.3 - WORKFORCE-3.e - Support Cybersecurity Management in Workforce Development Efforts"
@@ -8042,11 +8042,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Workforce Management",
         "source_pages": [
-          45
+          "45"
         ],
         "source_section": "6.9",
         "use_case": "Support Cybersecurity Management in Workforce Development Efforts",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "d7fad998-2025-5455-899e-1c801a8ce14b",
       "value": "CTI-CMM 1.3 - WORKFORCE-3.f - Support Cybersecurity Management in Workforce Development Efforts"
@@ -8083,11 +8083,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          46
+          "46"
         ],
         "source_section": "6.10",
         "use_case": "Support Strategy Development for the Cybersecurity Architecture",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "af3e830d-dce2-515e-b341-38ec57831840",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-1.a - Support Strategy Development for the Cybersecurity Architecture"
@@ -8127,11 +8127,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          46
+          "46"
         ],
         "source_section": "6.10",
         "use_case": "Support Strategy Development for the Cybersecurity Architecture",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "b447bf8f-eded-520c-8290-492559c9fae7",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-1.b - Support Strategy Development for the Cybersecurity Architecture"
@@ -8171,11 +8171,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          46
+          "46"
         ],
         "source_section": "6.10",
         "use_case": "Support Strategy Development for the Cybersecurity Architecture",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "94ec975f-bc50-512c-91cc-f663207ef3e1",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-1.c - Support Strategy Development for the Cybersecurity Architecture"
@@ -8212,11 +8212,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "3c4bd4c9-f78a-5ed5-9922-5dc174cc4f6a",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-2.a - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
@@ -8253,11 +8253,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "b63ced37-df24-5ae7-a240-d18a43a3c0a8",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-2.b - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
@@ -8294,11 +8294,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "2efdcedc-ea15-5ceb-adc6-1b428dcf0444",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-2.c - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
@@ -8335,11 +8335,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Continuous Threat Modeling",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "41e51ab1-dd43-5024-9a37-712f3efc8114",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-2.d - Support for Cybersecurity Architecture Through Continuous Threat Modeling"
@@ -8376,11 +8376,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "6b9b766c-32f2-5b60-8f7c-e3f92a8fdf72",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-3.a - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
@@ -8417,11 +8417,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "c9d2f59e-021b-501c-aa3f-f75b4bd97029",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-3.b - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
@@ -8458,11 +8458,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "9f9b53d4-2b50-5a49-b91f-de44b8de7981",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-3.c - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
@@ -8499,11 +8499,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "a72b8afc-3577-5f3d-82c8-0eb3d745c9ba",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-3.d - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
@@ -8540,11 +8540,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "601c6deb-d2c5-5eae-9ac1-78ff982b65c1",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-3.e - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
@@ -8581,11 +8581,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to Cybersecurity Architecture",
         "source_pages": [
-          47
+          "47"
         ],
         "source_section": "6.10",
         "use_case": "Support for Cybersecurity Architecture Through Policy & Compliance Alignment",
-        "use_case_number": 3
+        "use_case_number": "3"
       },
       "uuid": "4046557e-b6e6-517a-9298-238461201e04",
       "value": "CTI-CMM 1.3 - ARCHITECTURE-3.f - Support for Cybersecurity Architecture Through Policy & Compliance Alignment"
@@ -8624,11 +8624,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          48
+          "48"
         ],
         "source_section": "6.11",
         "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "e8f9141f-cc50-5822-96c7-31ae9b98cd91",
       "value": "CTI-CMM 1.3 - PROGRAM-1.a - Align CTI Program with Enterprise Cybersecurity Strategy"
@@ -8667,11 +8667,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          48
+          "48"
         ],
         "source_section": "6.11",
         "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "5655422d-090b-5709-972b-ac6727ee5580",
       "value": "CTI-CMM 1.3 - PROGRAM-1.b - Align CTI Program with Enterprise Cybersecurity Strategy"
@@ -8710,11 +8710,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          48
+          "48"
         ],
         "source_section": "6.11",
         "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "7f2bf9ad-2326-5228-be4e-56fc2eded5f3",
       "value": "CTI-CMM 1.3 - PROGRAM-1.c - Align CTI Program with Enterprise Cybersecurity Strategy"
@@ -8753,11 +8753,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          48
+          "48"
         ],
         "source_section": "6.11",
         "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "b91e5088-0c9b-54a6-b439-7522c12c230c",
       "value": "CTI-CMM 1.3 - PROGRAM-1.d - Align CTI Program with Enterprise Cybersecurity Strategy"
@@ -8796,11 +8796,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          48
+          "48"
         ],
         "source_section": "6.11",
         "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "53aba119-336b-58c4-8dcd-31e8524a7fac",
       "value": "CTI-CMM 1.3 - PROGRAM-1.e - Align CTI Program with Enterprise Cybersecurity Strategy"
@@ -8843,11 +8843,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          49
+          "49"
         ],
         "source_section": "6.11",
         "use_case": "Align CTI Program with Enterprise Cybersecurity Strategy",
-        "use_case_number": 1
+        "use_case_number": "1"
       },
       "uuid": "8e06c0f3-6b87-5923-b205-04b17c5d077b",
       "value": "CTI-CMM 1.3 - PROGRAM-1.f - Align CTI Program with Enterprise Cybersecurity Strategy"
@@ -8886,11 +8886,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          49
+          "49"
         ],
         "source_section": "6.11",
         "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "e2060a78-b059-5d07-b224-8e2c39dcfb2b",
       "value": "CTI-CMM 1.3 - PROGRAM-2.a - Support Maturation of the Enterprise Cybersecurity Program"
@@ -8929,11 +8929,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          49
+          "49"
         ],
         "source_section": "6.11",
         "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "7021ce89-c162-5f76-b718-3021003294ab",
       "value": "CTI-CMM 1.3 - PROGRAM-2.b - Support Maturation of the Enterprise Cybersecurity Program"
@@ -8972,11 +8972,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          49
+          "49"
         ],
         "source_section": "6.11",
         "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "0403e6af-b877-5234-96f1-c947ec8571f2",
       "value": "CTI-CMM 1.3 - PROGRAM-2.c - Support Maturation of the Enterprise Cybersecurity Program"
@@ -9015,11 +9015,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          49
+          "49"
         ],
         "source_section": "6.11",
         "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "f473e46a-13b6-5bf9-960d-cd5781845e76",
       "value": "CTI-CMM 1.3 - PROGRAM-2.d - Support Maturation of the Enterprise Cybersecurity Program"
@@ -9058,11 +9058,11 @@
         ],
         "source_example": "CTI3 Leading Program Support to the Cybersecurity Program",
         "source_pages": [
-          49
+          "49"
         ],
         "source_section": "6.11",
         "use_case": "Support Maturation of the Enterprise Cybersecurity Program",
-        "use_case_number": 2
+        "use_case_number": "2"
       },
       "uuid": "ab227f2b-3591-5d9e-8823-bdf987598649",
       "value": "CTI-CMM 1.3 - PROGRAM-2.e - Support Maturation of the Enterprise Cybersecurity Program"

--- a/galaxies/cti-cmm-1-3.json
+++ b/galaxies/cti-cmm-1-3.json
@@ -1,0 +1,24 @@
+{
+  "description": "Cyber Threat Intelligence Capability Maturity Model (CTI-CMM) version 1.3 maturity-indicator practices represented as a matrix-like galaxy by stakeholder domain.",
+  "icon": "map",
+  "kill_chain_order": {
+    "cti-cmm-1-3": [
+      "Asset, Change, and Configuration Management (ASSET)",
+      "Threat and Vulnerability Management (THREAT)",
+      "Risk Management (RISK)",
+      "Identity and Access Management (ACCESS)",
+      "Situational Awareness (SITUATION)",
+      "Event and Incident Response, Continuity of Operations (RESPONSE)",
+      "Third-Party Risk Management (THIRD-PARTIES)",
+      "Fraud and Abuse Management (FRAUD)",
+      "CTI Workforce Management (WORKFORCE)",
+      "Cybersecurity Architecture (ARCHITECTURE)",
+      "CTI Program Management (PROGRAM)"
+    ]
+  },
+  "name": "CTI-CMM 1.3",
+  "namespace": "cti-cmm",
+  "type": "cti-cmm-1-3",
+  "uuid": "d3b9d67d-4993-5949-b693-4f4ac7ba9228",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Represent CTI-CMM Version 1.3 as repo-native MISP galaxy/cluster JSON so CTI maturity practices can be used programmatically. 
- Provide a matrix-like, domain-keyed mapping of the model’s 11 stakeholder domains and their maturity-indicator practices.
- Preserve provenance, licensing, and cross-domain references from the original CTI-CMM PDF (CC BY-SA 4.0). 

### Description
- Add `galaxies/cti-cmm-1-3.json` defining the `cti-cmm-1-3` galaxy with the 11 CTI-CMM stakeholder domains in `kill_chain_order` and basic galaxy metadata. 
- Add `clusters/cti-cmm-1-3.json` containing 199 cluster `values` (one per CTI practice) with rich `meta` fields including `practice_id`, `maturity_level`, `maturity_level_name`, `domain`, `domain_code`, `domain_purpose`, `cti_mission`, `use_case`, `cti_data_sources`, `source_pages`, `refs`, `license`, `attribution`, `kill_chain`, and generated UUIDs. 
- Extracted and cleaned practice text from the CTI-CMM v1.3 PDF and preserved explicit cross-domain references as `related_domains` in metadata when the practice text points to other domains. 
- Updated `README.md` index to include the new CTI-CMM entry and element count. 

### Testing
- Validated new files against repository schemas with `jsonschema.validate(...)` for `schema_galaxies.json` and `schema_clusters.json`, both succeeded. 
- Confirmed JSON syntax with `jq` (`jq empty galaxies/cti-cmm-1-3.json clusters/cti-cmm-1-3.json`), which succeeded. 
- Checked for duplicate UUIDs among cluster entries and across galaxy/cluster files (no CTI-CMM UUID duplicates found). 
- Ran integrity assertions to verify `len(values) == 199`, `practice_id` appears in `value`, `use_case` appears in `value`, `kill_chain` entries and `source_pages` are present, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225233404c83248e64087c7bc08484)