### PR TITLE
[threat-actors] Update Cyber Av3ngers

### DIFF
--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -13700,13 +13700,20 @@
       "value": "KromSec"
     },
     {
-      "description": "The hacktivist group ‘Cyber Av3ngers’ has historically claimed attacks on Israel’s critical infrastructures. It has been launching DDoS attacks and claiming breach of Israeli networks with supporting data leaks.",
+      "description": "Cyber Av3ngers is an Iranian IRGC Cyber-Electronic Command-affiliated threat actor that targets internet-exposed operational technology and industrial control systems. Public reporting documents disruptive targeting of Israeli-made Unitronics PLCs and HMIs, broader critical-infrastructure targeting, and use of the IOCONTROL malware against IoT and OT devices.",
       "meta": {
         "country": "IR",
         "refs": [
-          "https://securelist.com/a-hack-in-hand-is-worth-two-in-the-bush/110794/",
+          "https://claroty.com/team82/research/inside-a-new-ot-iot-cyber-weapon-iocontrol",
           "https://cyberwarzone.com/cyber-av3ngers-claims-infiltration-of-israeli-water-treatment-stations-amid-ongoing-conflict/",
-          "https://cyberwarzone.com/hacking-group-cyber-av3ngers-claims-responsibility-for-yavne-power-outages-what-you-need-to-know/"
+          "https://cyberwarzone.com/hacking-group-cyber-av3ngers-claims-responsibility-for-yavne-power-outages-what-you-need-to-know/",
+          "https://securelist.com/a-hack-in-hand-is-worth-two-in-the-bush/110794/",
+          "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-335a",
+          "https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-097a"
+        ],
+        "synonyms": [
+          "CyberAv3ngers",
+          "Shahid Kaveh Group"
         ]
       },
       "uuid": "286db62d-859d-48e2-9601-1b7abde9f3c3",


### PR DESCRIPTION
Updates the Cyber Av3ngers threat-actor entry using current authoritative reporting.

Changes:
- Updates the description to reflect IRGC Cyber-Electronic Command affiliation and OT/ICS targeting
- Adds the CyberAv3ngers and Shahid Kaveh Group synonyms
- Adds CISA AA23-335A, CISA AA26-097A, and Claroty IOCONTROL references

Validation:
- `python3 -m jsonschema -i clusters/threat-actor.json schema_clusters.json`
- `python3 -m tools.chk_empty_strings`
- `jq empty clusters/threat-actor.json`
- `git diff --check`

`jq_all_the_things.sh` JSON validation completed, but its formatting phase requires the optional `sponge` utility, unavailable in this environment. The current `tools/chk_dup.py` also fails against upstream main with an `AttributeError` while loading cluster JSON.