### PR TITLE
[threat-actors] Add Fox Tempest

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Category: *threat-actor* - source: *https://www.publicsafety.gc.ca/cnt/_xml/lstd
 
 [Threat Actor](https://www.misp-galaxy.org/threat-actor) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign. threat-actor-classification meta can be used to clarify the understanding of the threat-actor if also considered as operation, campaign or activity group.
 
-Category: *actor* - source: *MISP Project* - total: *1028* elements
+Category: *actor* - source: *MISP Project* - total: *1029* elements
 
 [[HTML](https://www.misp-galaxy.org/threat-actor)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json)]
 

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -23875,7 +23875,19 @@
       },
       "uuid": "3ba33e02-c485-40dd-b9af-c4f9a7c46fd5",
       "value": "JadePuffer"
+    },
+    {
+      "description": "Fox Tempest is a financially motivated threat actor that operated a malware-signing-as-a-service (MSaaS) sold to other cybercriminals to sign malware, including ransomware, as trusted software and evade detection. The service, marketed through the domain signspace[.]cloud and a Telegram channel, abused Microsoft Artifact Signing to issue short-lived fraudulent code-signing certificates and offered signing plans priced between 5,000 and 9,000 USD, with higher tiers providing pre-configured virtual machines for signing malicious code. Microsoft tracked the operation from September 2025 and observed its certificates used to distribute malware families such as Oyster, Lumma Stealer, and Vidar and to support ransomware activity linked to Vanilla Tempest, Storm-0501, Storm-2561, and Storm-0249. In May 2026, Microsoft's Digital Crimes Unit disrupted the operation, seizing signspace[.]cloud, taking hundreds of signing virtual machines offline, and revoking more than 1,000 fraudulent certificates, and named Vanilla Tempest as a co-defendant in a case filed in the U.S. District Court for the Southern District of New York.",
+      "meta": {
+        "refs": [
+          "https://www.microsoft.com/en-us/security/blog/2026/05/19/exposing-fox-tempest-a-malware-signing-service-operation/",
+          "https://blogs.microsoft.com/on-the-issues/2026/05/19/disrupting-fox-tempest-a-cybercrime-service/",
+          "https://therecord.media/microsoft-disrupts-fox-tempest-malware-signing-service"
+        ]
+      },
+      "uuid": "56bc8e25-6915-4e2e-8d44-9d3b14aab9f6",
+      "value": "Fox Tempest"
     }
   ],
-  "version": 347
+  "version": 348
 }


### PR DESCRIPTION
Adds **Fox Tempest** to `clusters/threat-actor.json`.

Fox Tempest (Microsoft naming) is a financially motivated actor that operated a malware-signing-as-a-service, abusing Microsoft Artifact Signing to issue fraudulent short-lived code-signing certificates for ransomware operators. Microsoft's Digital Crimes Unit disrupted the operation (`signspace[.]cloud`) in May 2026, revoking 1,000+ certificates and naming Vanilla Tempest as a co-defendant in the SDNY.

**Entry**
- `value`: `Fox Tempest`
- `uuid`: `56bc8e25-6915-4e2e-8d44-9d3b14aab9f6` — fresh v4; `grep -r` confirms unique across `clusters/` and `galaxies/`

**References** (`meta.refs`)
- https://www.microsoft.com/en-us/security/blog/2026/05/19/exposing-fox-tempest-a-malware-signing-service-operation/ — Microsoft Security Blog (original naming + technical source)
- https://blogs.microsoft.com/on-the-issues/2026/05/19/disrupting-fox-tempest-a-cybercrime-service/ — Microsoft (disruption / legal action)
- https://therecord.media/microsoft-disrupts-fox-tempest-malware-signing-service — The Record / Recorded Future (independent corroboration)

**Cross-vendor identity / dedup check**
Microsoft is currently the only vendor to publicly name this actor; no cross-vendor aliases exist yet. Searched `clusters/` case-insensitively for `Fox Tempest`, `signspace`, `malware-signing`, and `MSaaS` — no existing entry represents this actor under any name. The downstream actors it serviced (`Vanilla Tempest`, `Storm-0501`, `Storm-2561`, `Storm-0249`) already exist as separate entries and are *consumers* of the service, not this actor; they are named in the description rather than duplicated. No `related` links added, consistent with recent single-entry additions.

**Housekeeping**
- `version` bumped 341 → 342
- `./jq_all_the_things.sh` applied; entry appended at end (insertion-order convention); `jsonschema` + `chk_empty_strings` pass.
