### PR TITLE
Add `name-attribution` mappings to threat actors; add Secureworks and MITRE producers

### DIFF
--- a/clusters/producer.json
+++ b/clusters/producer.json
@@ -2970,7 +2970,51 @@
       },
       "uuid": "58958484-3b8d-42c1-85af-b39a9df9496f",
       "value": "Meta"
+    },
+    {
+      "description": "Secureworks is a cybersecurity company that provides threat intelligence, managed detection and response, incident response, and security consulting services. Its Counter Threat Unit (CTU) research team maintains threat group profiles and a threat actor naming system.",
+      "meta": {
+        "company-type": [
+          "Cyber Security Vendor"
+        ],
+        "country": "US",
+        "official-refs": [
+          "https://www.secureworks.com/"
+        ],
+        "refs": [
+          "https://www.secureworks.com/research/threat-profiles"
+        ],
+        "synonyms": [
+          "SecureWorks",
+          "Dell SecureWorks",
+          "Secureworks Counter Threat Unit",
+          "Secureworks CTU"
+        ]
+      },
+      "uuid": "a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+      "value": "Secureworks"
+    },
+    {
+      "description": "MITRE is a not-for-profit organization that operates federally funded research and development centers. MITRE maintains ATT&CK, a knowledge base of adversary tactics and techniques that assigns group identifiers to tracked intrusion sets.",
+      "meta": {
+        "company-type": [
+          "Not-for-profit organization"
+        ],
+        "country": "US",
+        "official-refs": [
+          "https://www.mitre.org/"
+        ],
+        "refs": [
+          "https://attack.mitre.org/groups/"
+        ],
+        "synonyms": [
+          "The MITRE Corporation",
+          "MITRE ATT&CK"
+        ]
+      },
+      "uuid": "a1ad5090-2487-46d2-8237-6151a2dd5063",
+      "value": "MITRE"
     }
   ],
-  "version": 24
+  "version": 25
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -41,6 +41,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT1:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "COMMENT PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Comment Group:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TG-8223:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0006:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://en.wikipedia.org/wiki/PLA_Unit_61398",
           "http://intelreport.mandiant.com/Mandiant_APT1_Report.pdf",
@@ -105,6 +112,9 @@
     {
       "description": "Threat actors behind the Operation Dust Storm have been active since at least 2010, the hackers targeted several organizations in Japan, South Korea, the US, Europe, and other Asian countries.",
       "meta": {
+        "name-attribution": [
+          "G0031:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.cylance.com/content/dam/cylance/pdfs/reports/Op_Dust_Storm_Report.pdf",
           "https://web.archive.org/web/20140816135909/https://www.symantec.com/connect/blogs/inside-back-door-attack",
@@ -147,6 +157,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "WET PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://go.crowdstrike.com/rs/281-OBQ-266/images/ReportGlobalThreatIntelligence.pdf"
         ],
@@ -162,6 +175,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "FOXY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.sans.org/cyber-security-summit/archives/file/summit-archive-1492182276.pdf"
         ],
@@ -177,6 +193,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "PREDATOR PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://go.crowdstrike.com/rs/281-OBQ-266/images/ReportGlobalThreatIntelligence.pdf"
         ]
@@ -188,6 +207,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "UNION PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://dokumen.tips/documents/detecting-and-responding-pandas-and-bears.html"
         ]
@@ -199,6 +221,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "SPICY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://go.crowdstrike.com/rs/281-OBQ-266/images/ReportGlobalThreatIntelligence.pdf"
         ]
@@ -210,6 +235,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "ELOQUENT PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://dokumen.tips/documents/detecting-and-responding-pandas-and-bears.html"
         ]
@@ -219,6 +247,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "DIZZY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "synonyms": [
           "LadyBoyle"
         ]
@@ -243,6 +274,9 @@
           "Information technology"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Grayling:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/grayling-taiwan-cyber-attacks"
         ]
@@ -264,6 +298,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT2:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "PUTTER PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TG-6952:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0024:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "http://cdn0.vox-cdn.com/assets/4589853/crowdstrike-intelligence-report-putter-panda.original.pdf",
           "https://www.cfr.org/interactive/cyber-operations/putter-panda",
@@ -309,6 +349,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT3:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "GOTHIC PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Brocade Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TG-0110:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "BRONZE MAYFAIR:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE MAYFAIR": "Secureworks",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2015/06/operation-clandestine-wolf-adobe-flash-zero-day.html",
@@ -350,6 +397,9 @@
       "description": "The group Microsoft tracks as Storm-2603 is assessed with medium confidence to be a China-based threat actor. Microsoft has not identified links between Storm-2603 and other known Chinese threat actors. Microsoft tracks this threat actor in association with attempts to steal MachineKeys via the on-premises SharePoint vulnerabilities. Although Microsoft has observed this threat actor deploying Warlock and Lockbit ransomware in the past, Microsoft is currently unable to confidently assess the threat actor’s objectives.  Additional actors may use these exploits to target unpatched on-premises SharePoint systems, further emphasizing the need for organizations to implement mitigations and security updates immediately.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Storm-2603:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-2603": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/07/22/disrupting-active-exploitation-of-on-premises-sharepoint-vulnerabilities/"
@@ -375,6 +425,11 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "KR",
+        "name-attribution": [
+          "DUBNIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TUNGSTEN BRIDGE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0012:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-06": "QiAnXin",
         "refs": [
           "https://securelist.com/blog/research/71713/darkhotels-attacks-in-2015/",
@@ -449,6 +504,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT12:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "NUMBERED PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Hexagon Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TG-2754:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "BRONZE GLOBE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE GLOBE": "Secureworks",
         "refs": [
           "http://www.crowdstrike.com/blog/whois-numbered-panda/",
@@ -497,6 +559,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT16:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0023:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2015/12/the_eps_awakens.html",
           "https://www.cfr.org/interactive/cyber-operations/apt-16",
@@ -537,6 +603,15 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT17:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "AURORA PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Hidden Lynx:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Heart Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE KEYSTONE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0025:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "G0001:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE KEYSTONE": "Secureworks",
         "refs": [
           "https://web.archive.org/web/20130924130243/https://www.fireeye.com/blog/technical/cyber-exploits/2013/09/operation-deputydog-zero-day-cve-2013-3893-attack-against-japanese-targets.html",
@@ -617,6 +692,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT18:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "DYNAMITE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Satin Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TG-0416:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0026:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://threatpost.com/apt-gang-branches-out-to-medical-espionage-in-community-health-breach/107828",
           "https://www.cfr.org/interactive/cyber-operations/apt-18",
@@ -673,6 +755,15 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT19:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "DEEP PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Black Vine:0904b30c-a86b-402b-9a14-87bbc44648aa",
+          "Checkered Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE FIRESTONE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0009:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "G0073:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE FIRESTONE": "Secureworks",
         "origin:TEMP.Avengers": "FireEye",
         "refs": [
@@ -775,6 +866,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Naikon:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "OVERRIDE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "BRONZE GENEVA:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0019:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "BRONZE STERLING:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0013:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE GENEVA": "Secureworks",
         "origin:BRONZE STERLING": "Secureworks",
         "refs": [
@@ -847,6 +946,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT30:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0013:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://attack.mitre.org/wiki/Group/G0013",
           "https://www2.fireeye.com/rs/fireye/images/rpt-apt30.pdf",
@@ -887,6 +990,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "LOTUS PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Spring Dragon:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Lotus BLossom:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Lotus Blossom:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "BRONZE ELGIN:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0030:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE ELGIN": "Secureworks",
         "refs": [
           "https://securelist.com/blog/research/70726/the-spring-dragon-apt/",
@@ -944,6 +1055,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "HURRICANE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.crowdstrike.com/blog/cyber-deterrence-in-action-a-story-of-one-long-hurricane-panda-campaign/",
           "https://www.crowdstrike.com/blog/crowdstrike-discovers-use-64-bit-zero-day-privilege-escalation-exploit-cve-2014-4113-hurricane-panda/",
@@ -986,6 +1100,17 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT27:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "EMISSARY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Lucky Mouse:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Iron Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Circle Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Linen Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TG-3390:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "BRONZE UNION:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0027:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE UNION": "Secureworks",
         "origin:Earth Smilodon": "Trend Micro",
         "origin:TEMP.Hippo": "FireEye",
@@ -1077,6 +1202,17 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT10:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "STONE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Cloud Hopper:9f2ba728-8b29-48f9-badf-4f4cefb929f0",
+          "Granite Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "TA429:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Cicada:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "Purple Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE RIVERSIDE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0045:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE RIVERSIDE": "Secureworks",
         "refs": [
           "https://unit42.paloaltonetworks.com/unit42-menupass-returns-new-malware-new-attacks-japanese-academics-organizations/",
@@ -1147,6 +1283,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Hellsing:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/hellsing",
           "https://securelist.com/the-chronicles-of-the-hellsing-apt-the-empire-strikes-back/69567/"
@@ -1163,6 +1302,10 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "Night Dragon:b8ca0932-c4cb-45c0-b7b1-88b9685ba24b",
+          "G0014:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://kc.mcafee.com/corporate/index?page=content&id=KB71150",
           "https://securingtomorrow.mcafee.com/wp-content/uploads/2011/02/McAfee_NightDragon_wp_draft_to_customersv1-1.pdf",
@@ -1200,6 +1343,16 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT15:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "VIXEN PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Nylon Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Mirage:ac46bac7-e7b5-4efe-8f32-b79e9015ab86",
+          "BRONZE PALACE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "BRONZE DAVENPORT:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "BRONZE IDLEWOOD:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0004:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE DAVENPORT": "Secureworks",
         "origin:BRONZE IDLEWOOD": "Secureworks",
         "origin:BRONZE PALACE": "Secureworks",
@@ -1271,6 +1424,10 @@
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
         "motive": "Espionage",
+        "name-attribution": [
+          "APT14:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "ANCHOR PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.crowdstrike.com/blog/whois-anchor-panda/",
           "https://www.cfr.org/interactive/cyber-operations/anchor-panda",
@@ -1358,6 +1515,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT21:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "HAMMER PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:TEMP.Zhenbao": "FireEye",
         "refs": [
           "https://securelist.com/blog/research/35936/nettraveler-is-running-red-star-apt-attacks-compromise-high-profile-victims/",
@@ -1396,6 +1557,11 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "DAGGER PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "IceFog:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "UAT-7290:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://securelist.com/the-icefog-apt-a-tale-of-cloak-and-three-daggers/57331/",
           "https://securelist.com/the-icefog-apt-hits-us-targets-with-java-backdoor/58209/",
@@ -1430,6 +1596,11 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "APT24:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "PITTY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "G0011:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "http://blog.airbuscybersecurity.com/post/2014/07/The-Eye-of-the-Tiger2",
           "http://blog.cassidiancybersecurity.com/post/2014/07/The-Eye-of-the-Tiger2",
@@ -1459,6 +1630,10 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "Roaming Tiger:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "BRONZE WOODLAND:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE WOODLAND": "Secureworks",
         "refs": [
           "https://unit42.paloaltonetworks.com/bbsrat-attacks-targeting-russian-organizations-linked-to-roaming-tiger/",
@@ -1495,6 +1670,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "SNEAKY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "G0066:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/sneaky-panda",
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=3b0d679a-3707-4075-a2a9-37d1af16d411&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
@@ -1524,6 +1703,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "RADIO PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "synonyms": [
           "Shrouded Crossbow"
         ]
@@ -1557,6 +1739,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "SAMURAI PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.crowdstrike.com/blog/whois-samurai-panda/"
         ],
@@ -1587,7 +1772,10 @@
     {
       "meta": {
         "attribution-confidence": "50",
-        "country": "CN"
+        "country": "CN",
+        "name-attribution": [
+          "IMPERSONATING PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ]
       },
       "uuid": "b56ecbda-6b2a-4aa9-b592-d9a0bc810ec1",
       "value": "IMPERSONATING PANDA"
@@ -1597,6 +1785,12 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "APT20:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "VIOLIN PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TH3Bug:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Crawling Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "http://researchcenter.paloaltonetworks.com/2014/09/recent-watering-hole-attacks-attributed-apt-group-th3bug-using-poison-ivy/",
           "https://www.fox-it.com/nl/actueel/whitepapers/operation-wocao-shining-a-light-on-one-of-chinas-hidden-hacking-groups/",
@@ -1618,6 +1812,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "TOXIC PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf"
         ]
@@ -1641,6 +1838,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "TEMPER PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "G0018:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2013/10/know-your-enemy-tracking-a-rapidly-evolving-apt-actor.html",
           "https://www.fireeye.com/blog/threat-research/2015/11/china-based-threat.html",
@@ -1678,6 +1879,13 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "APT23:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "PIRATE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "KeyBoy:adc57f66-9910-4500-a16b-311cd4f08409",
+          "BRONZE HOBART:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0081:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE HOBART": "Secureworks",
         "origin:Earth Centaur": "Trend Micro",
         "refs": [
@@ -1727,6 +1935,11 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "Flying Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "SaffronRose:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Saffron Rose:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://www.fireeye.com/content/dam/fireeye-www/global/en/current-threats/pdfs/rpt-operation-saffron-rose.pdf",
           "https://www.crowdstrike.com/blog/cat-scratch-fever-crowdstrike-tracks-newly-reported-iranian-actor-flying-kitten/",
@@ -1838,6 +2051,9 @@
           "Denial of service"
         ],
         "country": "IR",
+        "name-attribution": [
+          "Cutting Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/itsecteam",
           "https://www.justice.gov/usao-sdny/file/835061/download"
@@ -1867,6 +2083,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "Charming Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "CharmingCypress:c2f76813-f24c-450e-abfd-0db4495ab68e",
+          "Mint Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0058:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://en.wikipedia.org/wiki/Operation_Newscaster",
           "https://iranthreats.github.io/resources/macdownloader-macos-malware/",
@@ -2007,6 +2229,15 @@
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
         "mode-of-operation": "IT network limited, information gathering against industrial orgs",
+        "name-attribution": [
+          "APT33:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Elfin:0904b30c-a86b-402b-9a14-87bbc44648aa",
+          "Refined Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Peach Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA451:cae79680-67a6-4411-903c-f824dbcc813f",
+          "COBALT TRINITY:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0064:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2017/09/apt33-insights-into-iranian-cyber-espionage.html",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/more-than-a-dozen-obfuscated-apt33-botnets-used-for-extreme-narrow-targeting/",
@@ -2072,6 +2303,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "IR",
+        "name-attribution": [
+          "Magic Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://web.archive.org/web/20161020180305/http://www.scmagazineuk.com/iran-and-russia-blamed-for-state-sponsored-espionage/article/330401/",
           "https://carnegieendowment.org/2018/01/04/iran-s-cyber-ecosystem-who-are-threat-actors-pub-75140"
@@ -2117,6 +2351,11 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "Rocket Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Operation Woolen Goldfish:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Operation Woolen-Goldfish:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:TEMP.Beanie": "FireEye",
         "refs": [
           "https://www.trendmicro.com/vinfo/us/security/news/cyber-attacks/operation-woolen-goldfish-when-kittens-go-phishing",
@@ -2241,6 +2480,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "TG-2889:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0003:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.secureworks.com/research/the-curious-case-of-mia-ash",
           "https://www.cfr.org/interactive/cyber-operations/operation-cleaver",
@@ -2365,6 +2608,9 @@
         "cfr-type-of-incident": "Defacement",
         "country": "TN",
         "motive": "Hacktivists-Nationalists",
+        "name-attribution": [
+          "Rebel Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "synonyms": [
           "FallagaTeam"
         ]
@@ -2376,6 +2622,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "AE",
+        "name-attribution": [
+          "Viking Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "synonyms": [
           "Vikingdom"
         ]
@@ -2422,6 +2671,17 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "APT28:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Pawn Storm:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Sednit:3a43aca5-6366-4168-b182-a8afec4550b5",
+          "STRONTIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Fighting Ursa:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "TA422:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Forest Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TG-4127:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0007:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-20": "QiAnXin",
         "refs": [
           "https://attack.mitre.org/groups/G0007/",
@@ -2578,6 +2838,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "APT29:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "The Dukes:d597f230-4f70-43cb-817e-c745efd4fe35",
+          "Cloaked Ursa:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "TA421:cae79680-67a6-4411-903c-f824dbcc813f",
+          "IRON HEMLOCK:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0016:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://labsblog.f-secure.com/2015/09/17/the-dukes-7-years-of-russian-cyber-espionage/",
           "https://www2.fireeye.com/rs/848-DID-242/images/rpt-apt29-hammertoss.pdf",
@@ -2691,6 +2959,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "Waterbug:0904b30c-a86b-402b-9a14-87bbc44648aa",
+          "SUMMIT:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "UNC4210:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Secret Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "IRON HUNTER:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0010:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:UNC4210": "Mandiant",
         "refs": [
           "https://www.circl.lu/pub/tr-25/",
@@ -2815,6 +3091,15 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "ENERGETIC BEAR:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Dragonfly:0904b30c-a86b-402b-9a14-87bbc44648aa",
+          "Crouching Yeti:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Ghost Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TG-4192:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "IRON LIBERTY:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0035:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.gov.uk/government/publications/russias-fsb-malign-cyber-activity-factsheet/russias-fsb-malign-activity-factsheet",
           "https://web.archive.org/web/20161020180305/http://www.scmagazineuk.com/iran-and-russia-blamed-for-state-sponsored-espionage/article/330401/",
@@ -2902,6 +3187,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "Sandworm:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TeleBots:3a43aca5-6366-4168-b182-a8afec4550b5",
+          "UAC-0113:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "Seashell Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "APT44:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0034:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:TEMP.Noble": "FireEye",
         "refs": [
           "https://dragos.com/blog/crashoverride/CrashOverride-01.pdf",
@@ -3012,6 +3305,16 @@
         "cfr-type-of-incident": "Financial Theft",
         "country": "RU",
         "motive": "Cybercrime",
+        "name-attribution": [
+          "FIN7:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "CARBON SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Carbanak:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Sangria Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Carbon Spider:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD NIAGARA:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0046:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "G0008:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:FIN7": "Mandiant",
         "origin:GOLD NIAGARA": "Secureworks",
         "refs": [
@@ -3103,6 +3406,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "TeamSpy Crew:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "TeamSpy:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/blog/incidents/35520/the-teamspy-crew-attacks-abusing-teamviewer-for-cyberespionage-8/",
           "https://www.cfr.org/interactive/cyber-operations/team-spy-crew",
@@ -3163,6 +3470,11 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "RO",
+        "name-attribution": [
+          "WOLF SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "FIN4:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0085:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:FIN4": "Mandiant",
         "refs": [
           "https://www.reuters.com/article/2015/06/23/us-hackers-insidertrading-idUSKBN0P31M720150623",
@@ -3198,6 +3510,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "RU",
+        "name-attribution": [
+          "SHARK SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "targeted-sector": [
           "Bank"
         ]
@@ -3210,6 +3525,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "RU",
+        "name-attribution": [
+          "UNION SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf"
         ],
@@ -3226,6 +3544,10 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "KP",
+        "name-attribution": [
+          "Silent Chollima:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Onyx Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf",
           "https://www.microsoft.com/en-us/security/blog/2023/10/18/multiple-north-korean-threat-actors-exploiting-the-teamcity-cve-2023-42793-vulnerability/"
@@ -3279,6 +3601,26 @@
           "Sabotage"
         ],
         "country": "KP",
+        "name-attribution": [
+          "Hidden Cobra:b8ca0932-c4cb-45c0-b7b1-88b9685ba24b",
+          "Labyrinth Chollima:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Operation Troy:b8ca0932-c4cb-45c0-b7b1-88b9685ba24b",
+          "Operation GhostSecret:b8ca0932-c4cb-45c0-b7b1-88b9685ba24b",
+          "Operation AppleJeus:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "APT38:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "APT 38:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Stardust Chollima:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Citrine Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0139:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-1222:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Diamond Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Sapphire Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA404:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Moonstone Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "NICKEL GLADSTONE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0032:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "G0082:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-26": "QiAnXin",
         "origin:DEV-0139": "Microsoft",
         "origin:DEV-1222": "Microsoft",
@@ -3472,6 +3814,9 @@
           "Germany"
         ],
         "country": "IN",
+        "name-attribution": [
+          "VICEROY TIGER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:APT-C-35": "QiAnXin",
         "refs": [
           "https://github.com/jack8daniels2/threat-INTel/blob/master/2013/Unveiling-an-Indian-Cyberattack-Infrastructure-appendixes.pdf",
@@ -3515,6 +3860,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "US",
+        "name-attribution": [
+          "PIZZO SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/double-trouble-ransomware-data-leak-extortion-part-1/"
         ],
@@ -3530,6 +3878,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "TN",
+        "name-attribution": [
+          "Corsair Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://web.archive.org/web/20160315044507/https://www.crowdstrike.com/blog/regional-conflict-and-cyber-blowback/"
         ],
@@ -3591,6 +3942,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "SY",
+        "name-attribution": [
+          "Deadeye Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://en.wikipedia.org/wiki/Syrian_Electronic_Army"
         ],
@@ -3621,6 +3975,16 @@
           "Government"
         ],
         "country": "PK",
+        "name-attribution": [
+          "C-Major:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Mythic Leopard:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "ProjectM:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "APT36:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "APT 36:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Earth Karkaddan:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Storm-0156:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "COPPER FIELDSTONE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:Earth Karkaddan": "Trend Micro",
         "origin:Storm-0156": "Microsoft",
         "refs": [
@@ -3692,6 +4056,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "AE",
+        "name-attribution": [
+          "G0038:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://citizenlab.ca/2016/05/stealth-falcon/",
           "https://www.cfr.org/interactive/cyber-operations/stealth-falcon",
@@ -3726,6 +4093,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "HummingBad:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "http://blog.checkpoint.com/wp-content/uploads/2016/07/HummingBad-Research-report_FINAL-62916.pdf"
         ]
@@ -3749,6 +4119,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IN",
+        "name-attribution": [
+          "Dropping Elephant:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Thirsty Gemini:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "ZINC EMERSON:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0040:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-09": "QiAnXin",
         "refs": [
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=09308982-77bd-41e0-8269-f2cc9ce3266e&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
@@ -3814,6 +4190,11 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "Scarlet Mimic:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Golfing Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "G0029:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://attack.mitre.org/wiki/Groups",
           "https://unit42.paloaltonetworks.com/scarlet-mimic-years-long-espionage-targets-minority-activists/",
@@ -3845,6 +4226,10 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "BR",
+        "name-attribution": [
+          "Poseidon Group:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "G0033:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://securelist.com/poseidon-group-a-targeted-attack-boutique-specializing-in-global-cyber-espionage/73673/",
           "https://attack.mitre.org/wiki/Groups",
@@ -3879,6 +4264,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "DragonOK:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Shallow Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "BRONZE OVERBROOK:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0017:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "G0002:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE OVERBROOK": "Secureworks",
         "refs": [
           "https://www.fireeye.com/content/dam/fireeye-www/global/en/current-threats/pdfs/wp-operation-quantum-entanglement.pdf",
@@ -3940,6 +4332,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "US",
+        "name-attribution": [
+          "ProjectSauron:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Sauron:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Project Sauron:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "G0041:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://securelist.com/analysis/publications/75533/faq-the-projectsauron-apt/",
           "https://www.cfr.org/interactive/cyber-operations/project-sauron",
@@ -3981,6 +4379,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "TA530:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/uk/threat-insight/post/august-in-december-new-information-stealer-hits-the-scene"
         ]
@@ -3993,6 +4394,10 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "RU",
+        "name-attribution": [
+          "GCMAN:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "G0036:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://securelist.com/apt-style-bank-robberies-increase-with-metel-gcman-and-carbanak-2-0-attacks/73638/",
           "https://attack.mitre.org/groups/G0036/"
@@ -4021,6 +4426,11 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "APT22:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0039:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "BRONZE OLIVE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE OLIVE": "Secureworks",
         "refs": [
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=62e325ae-f551-4855-b9cf-28a7d52d1534&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
@@ -4053,6 +4463,15 @@
     {
       "description": "FIN is a group targeting financial assets including assets able to do financial transaction including PoS.",
       "meta": {
+        "name-attribution": [
+          "FIN6:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "SKELETON SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Camouflage Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA4557:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Storm-0538:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "GOLD FRANKLIN:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0037:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:FIN6": "Mandiant",
         "origin:GOLD FRANKLIN": "Secureworks",
         "origin:Storm-0538": "Microsoft",
@@ -4120,6 +4539,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "TeamXRat:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/blog/research/76153/teamxrat-brazilian-cybercrime-meets-ransomware/"
         ],
@@ -4153,6 +4575,19 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "OilRig:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Twisted Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Helix Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "APT 34:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "APT34:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Evasive Serpens:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Hazel Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA452:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Earth Simnavaz:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Cobalt Gypsy:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0049:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:Earth Simnavaz": "Trend Micro",
         "refs": [
           "https://blog.morphisec.com/iranian-fileless-cyberattack-on-israel-word-vulnerability",
@@ -4325,6 +4760,9 @@
       "description": "Beginning in late 2012, a carefully orchestrated attack campaign we call Volatile Cedar has been targeting individuals, companies and institutions worldwide. This campaign, led by a persistent attacker group, has successfully penetrated a large number of targets using various attack techniques, and specifically, a custom-made malware implant codenamed Explosive.",
       "meta": {
         "country": "LB",
+        "name-attribution": [
+          "DeftTorero:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://blog.checkpoint.com/2015/03/31/volatilecedar/",
           "https://blog.checkpoint.com/2015/06/09/new-data-volatile-cedar/",
@@ -4422,6 +4860,15 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "PS",
+        "name-attribution": [
+          "Molerats:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Gaza cybergang:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Gaza Cybergang:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Operation Molerats:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Extreme Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "ALUMINUM SARATOGA:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0021:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2013/08/operation-molerats-middle-east-cyber-attacks-using-poison-ivy.html",
           "https://ti.360.net/blog/articles/suspected-molerats-new-attack-in-the-middle-east/",
@@ -4468,6 +4915,10 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "TR",
+        "name-attribution": [
+          "PROMETHIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0056:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.microsoft.com/security/blog/2016/12/14/twin-zero-day-attacks-promethium-and-neodymium-target-individuals-in-europe/",
           "https://www.virusbulletin.com/conference/vb2016/abstracts/last-minute-paper-strongpity-waterhole-attacks-targeting-italian-and-belgian-encryption-users",
@@ -4501,6 +4952,10 @@
     {
       "description": "NEODYMIUM is an activity group that is known to use a backdoor malware detected by Microsoft as Wingbird. This backdoor’s characteristics closely match FinFisher, a government-grade commercial surveillance package. Data about Wingbird activity indicate that it is typically used to attack individual computers instead of networks.",
       "meta": {
+        "name-attribution": [
+          "NEODYMIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0055:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://blogs.technet.microsoft.com/mmpc/2016/12/14/twin-zero-day-attacks-promethium-and-neodymium-target-individuals-in-europe/",
           "https://attack.mitre.org/groups/G0055/"
@@ -4655,6 +5110,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "US",
+        "name-attribution": [
+          "G0020:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://en.wikipedia.org/wiki/Equation_Group",
           "https://www.cfr.org/interactive/cyber-operations/equation-group",
@@ -4729,6 +5187,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "IR",
+        "name-attribution": [
+          "Greenbug:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://web.archive.org/web/20190331181353/https://www.symantec.com/connect/blogs/greenbug-cyberespionage-group-targeting-middle-east-possible-links-shamoon",
           "https://unit42.paloaltonetworks.com/unit42-oilrig-uses-ismdoor-variant-possibly-linked-greenbug-threat-group/",
@@ -4773,6 +5234,16 @@
           "Government"
         ],
         "country": "RU",
+        "name-attribution": [
+          "ACTINIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0157:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "PRIMITIVE BEAR:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Shuckworm:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "Trident Ursa:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Aqua Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Actinium:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0047:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:DEV-0157": "Microsoft",
         "refs": [
           "http://researchcenter.paloaltonetworks.com/2017/02/unit-42-title-gamaredon-group-toolset-evolution",
@@ -4912,6 +5383,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Blue Termite:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/blog/research/71876/new-activity-of-the-blue-termite-apt/",
           "https://www.cfr.org/interactive/cyber-operations/blue-termite"
@@ -4929,6 +5403,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "UA",
+        "name-attribution": [
+          "Groundbait:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "http://www.welivesecurity.com/2016/05/18/groundbait"
         ],
@@ -4953,6 +5430,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "US",
+        "name-attribution": [
+          "PLATINUM TERMINAL:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:APT-C-39": "QiAnXin",
         "refs": [
           "https://community.broadcom.com/symantecenterprise/communities/community-home/librarydocuments/viewdocument?DocumentKey=7ca2e331-2209-46a8-9e60-4cb83f9602de&CommunityKey=1ecf5f55-9545-44d6-b0f4-4e4a7f5f5e68&tab=librarydocuments",
@@ -4993,6 +5473,16 @@
       "description": "The Callisto Group is an advanced threat actor whose known targets include military personnel, government officials, think tanks, and journalists in Europe and the South Caucasus. Their primary interest appears to be gathering intelligence related to foreign and security policy in the Eastern Europe and South Caucasus regions.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Callisto:9f2ba728-8b29-48f9-badf-4f4cefb929f0",
+          "SEABORGIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA446:cae79680-67a6-4411-903c-f824dbcc813f",
+          "BlueCharlie:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "Star Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TAG-53:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "UNC4057:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Blue Callisto:9f2ba728-8b29-48f9-badf-4f4cefb929f0"
+        ],
         "origin:UNC4057": "Mandiant",
         "refs": [
           "https://web.archive.org/web/20170417102235/https://www.f-secure.com/documents/996508/1030745/callisto-group",
@@ -5075,6 +5565,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "VN",
+        "name-attribution": [
+          "APT32:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "APT-32:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "APT 32:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Ocean Buffalo:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TIN WOODLAWN:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0050:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-00": "QiAnXin",
         "refs": [
           "https://attack.mitre.org/groups/G0050/",
@@ -5153,6 +5651,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "NG",
+        "name-attribution": [
+          "SilverTerrier:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/pdf/reports/Unit_42/silverterrier-next-evolution-in-nigerian-cybercrime.pdf"
         ]
@@ -5163,6 +5664,10 @@
     {
       "description": "A corporate espionage group has compromised a string of major corporations over the past three years in order to steal confidential information and intellectual property. The gang, which Symantec calls Butterfly, is not-state sponsored, rather financially motivated. It has attacked multi-billion dollar companies operating in the internet, IT software, pharmaceutical, and commodities sectors. Twitter, Facebook, Apple, and Microsoft are among the companies who have publicly acknowledged attacks.\n Butterfly is technically proficient and well resourced. The group has developed a suite of custom malware tools capable of attacking both Windows and Apple computers, and appears to have used at least one zero-day vulnerability in its attacks. It keeps a low profile and maintains good operational security. After successfully compromising a target organization, it cleans up after itself before moving on to its next target.\n This group operates at a much higher level than the average cybercrime gang. It is not interested in stealing credit card details or customer databases and is instead focused on high-level corporate information. Butterfly may be selling this information to the highest bidder or may be operating as hackers for hire. Stolen information could also be used for insider-trading purposes.",
       "meta": {
+        "name-attribution": [
+          "WildNeutron:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Butterfly:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://www.symantec.com/connect/blogs/butterfly-profiting-high-level-corporate-attacks",
           "https://securelist.com/wild-neutron-economic-espionage-threat-actor-returns-with-new-tricks/71275/",
@@ -5184,6 +5689,10 @@
     {
       "description": "PLATINUM has been targeting its victims since at least as early as 2009, and may have been active for several years prior. Its activities are distinctly different not only from those typically seen in untargeted attacks, but from many targeted attacks as well. A large share of targeted attacks can be characterized as opportunistic: the activity group changes its target profiles and attack geographies based on geopolitical seasons, and may attack institutions all over the world. Like many such groups, PLATINUM seeks to steal sensitive intellectual property related to government interests, but its range of preferred targets is consistently limited to specific governmental organizations, defense institutes, intelligence agencies, diplomatic institutions, and telecommunication providers in South and Southeast Asia. The group’s persistent use of spear phishing tactics (phishing attempts aimed at specific individuals) and access to previously undiscovered zero-day exploits have made it a highly resilient threat.",
       "meta": {
+        "name-attribution": [
+          "PLATINUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0068:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "http://download.microsoft.com/download/2/2/5/225BFE3E-E1DE-4F5B-A77B-71200928D209/Platinum%20feature%20article%20-%20Targeted%20attacks%20in%20South%20and%20Southeast%20Asia%20April%202016.pdf",
           "https://blogs.technet.microsoft.com/mmpc/2016/04/26/digging-deep-for-platinum/",
@@ -5224,6 +5733,11 @@
     {
       "description": "Dragos has identified a new activity group targeting access operations in the electric utility sector. We call this activity group RASPITE.  Analysis of RASPITE tactics, techniques, and procedures (TTPs) indicate the group has been active in some form since early- to mid-2017. RASPITE targeting includes entities in the US, Middle East, Europe, and East Asia. Operations against electric utility organizations appear limited to the US at this time.  RASPITE leverages strategic website compromise to gain initial access to target networks. RASPITE uses the same methodology as DYMALLOY and ALLANITE in embedding a link to a resource to prompt an SMB connection, from which it harvests Windows credentials. The group then deploys install scripts for a malicious service to beacon back to RASPITE-controlled infrastructure, allowing the adversary to remotely access the victim machine.",
       "meta": {
+        "name-attribution": [
+          "RASPITE:e4ed3168-7830-490f-9eed-d1b3ef2daccd",
+          "LeafMiner:0904b30c-a86b-402b-9a14-87bbc44648aa",
+          "Raspite:e4ed3168-7830-490f-9eed-d1b3ef2daccd"
+        ],
         "refs": [
           "https://dragos.com/blog/20180802Raspite.html",
           "https://symantec-blogs.broadcom.com/blogs/threat-intelligence/leafminer-espionage-middle-east",
@@ -5245,6 +5759,10 @@
     {
       "description": "FIN8 is a financially motivated group targeting the retail, hospitality and entertainment industries. The actor had previously conducted several tailored spearphishing campaigns using the downloader PUNCHBUGGY and POS malware PUNCHTRACK.",
       "meta": {
+        "name-attribution": [
+          "FIN8:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0061:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:FIN8": "Mandiant",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2016/05/windows-zero-day-payment-cards.html",
@@ -5303,6 +5821,11 @@
           "Government"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "El Machete:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Machete:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "G0095:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-43": "QiAnXin",
         "refs": [
           "https://attack.mitre.org/groups/G0095/",
@@ -5334,6 +5857,14 @@
     {
       "description": "A criminal group dubbed Cobalt is behind synchronized ATM heists that saw machines across Europe, CIS countries (including Russia), and Malaysia being raided simultaneously, in the span of a few hours. The group has been active since June 2016, and their latest attacks happened in July and August.",
       "meta": {
+        "name-attribution": [
+          "Cobalt Group:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Cobalt Gang:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "COBALT SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Mule Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "GOLD KINGSWOOD:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0080:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:GOLD KINGSWOOD": "Secureworks",
         "refs": [
           "https://www.helpnetsecurity.com/2016/11/22/cobalt-hackers-synchronized-atm-heists/",
@@ -5370,6 +5901,10 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "TA459:cae79680-67a6-4411-903c-f824dbcc813f",
+          "G0062:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/threat-insight/post/apt-targets-financial-analysts",
           "https://attack.mitre.org/groups/G0062/"
@@ -5419,6 +5954,12 @@
           "Private sector"
         ],
         "country": "CN",
+        "name-attribution": [
+          "CactusPete:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "KARMA PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "BRONZE HUNTLEY:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0131:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE HUNTLEY": "Secureworks",
         "origin:Earth Akhlut": "Trend Micro",
         "refs": [
@@ -5462,6 +6003,12 @@
       "description": "We have observed one APT group, which we call APT5, particularly focused on telecommunications and technology companies. More than half of the organizations we have observed being targeted or breached by APT5 operate in these sectors. Several times, APT5 has targeted organizations and personnel based in Southeast Asia. APT5 has been active since at least 2007. It appears to be a large threat group that consists of several subgroups, often with distinct tactics and infrastructure. APT5 has targeted or breached organizations across multiple industries, but its focus appears to be on telecommunications and technology companies, especially information about satellite communications. \nAPT5 targeted the network of an electronics firm that sells products for both industrial and military applications. The group subsequently stole communications related to the firm’s business relationship with a national military, including inventories and memoranda about specific products they provided. \nIn one case in late 2014, APT5 breached the network of an international telecommunications company. The group used malware with keylogging capabilities to monitor the computer of an executive who manages the company’s relationships with other telecommunications companies",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "APT5:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "KEYHOLE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Mulberry Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE FLEETWOOD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE FLEETWOOD": "Secureworks",
         "origin:TEMP.Bottle": "FireEye",
         "refs": [
@@ -5514,6 +6061,15 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "BRONZE BUTLER:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "REDBALDKNIGHT:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "STALKER PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Stalker Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Swirl Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE BUTLER:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0060:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE BUTLER": "Secureworks",
         "refs": [
           "https://wikileaks.org/vault7/document/2015-08-20150814-256-CSIR-15005-Stalker-Panda/2015-08-20150814-256-CSIR-15005-Stalker-Panda.pdf",
@@ -5566,6 +6122,12 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "APT26:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TURBINE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Taffeta Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE EXPRESS:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE EXPRESS": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/bronze-express",
@@ -5603,6 +6165,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "SABRE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://go.crowdstrike.com/rs/281-OBQ-266/images/ReportGlobalThreatIntelligence.pdf"
         ]
@@ -5614,6 +6179,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "BIG PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.darkreading.com/attacks-and-breaches/crowdstrike-falcon-traces-attacks-back-to-hackers/d/d-id/1110402?"
         ]
@@ -5625,6 +6193,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "POISONUS PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.sans.org/cyber-security-summit/archives/file/summit-archive-1492182276.pdf"
         ]
@@ -5634,6 +6205,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "Ghost Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf"
         ]
@@ -5672,6 +6246,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Mofang:4c94ea8e-6bbd-4638-b7ba-34354cfa2281",
+          "BRONZE WALKER:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE WALKER": "Secureworks",
         "refs": [
           "https://blog.fox-it.com/2016/06/15/mofang-a-politically-motivated-information-stealing-adversary/",
@@ -5705,6 +6283,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "Slayer Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "G0052:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://s3-eu-west-1.amazonaws.com/minervaresearchpublic/CopyKittens/CopyKittens.pdf",
           "https://www.domaintools.com/resources/blog/case-study-hunting-campaign-indicators-on-privacy-protected-attack-infrastr",
@@ -5744,6 +6326,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "TEST PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.slideshare.net/CrowdStrike/crowd-casts-monthly-you-have-an-adversary-problem"
         ]
@@ -5790,6 +6375,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "ELECTRIC PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.slideshare.net/CrowdStrike/crowd-casts-monthly-you-have-an-adversary-problem"
         ]
@@ -5812,6 +6400,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT4:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "MAVERICK PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Salmon Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE EDISON:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE EDISON": "Secureworks",
         "refs": [
           "https://www.alienvault.com/open-threat-exchange/blog/new-sykipot-developments",
@@ -5849,6 +6443,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "KP",
+        "name-attribution": [
+          "Velvet Chollima:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "APT43:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Emerald Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Springtail:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "G0086:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://securelist.com/the-kimsuky-operation-a-north-korean-apt/57915/",
           "https://www.cfr.org/interactive/cyber-operations/kimsuky",
@@ -6096,6 +6697,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "ES",
+        "name-attribution": [
+          "Careto:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/the-caretomask-apt-frequently-asked-questions/58254/",
           "https://www.cfr.org/interactive/cyber-operations/careto",
@@ -6114,6 +6718,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "GIBBERISH PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.slideshare.net/CrowdStrike/crowd-casts-monthly-you-have-an-adversary-problem"
         ]
@@ -6147,6 +6754,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "IR",
+        "name-attribution": [
+          "Clever Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://www.crowdstrike.com/blog/whois-clever-kitten/"
         ],
@@ -6231,6 +6841,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "ANDROMEDA SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf"
         ]
@@ -6259,6 +6872,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "RU",
+        "name-attribution": [
+          "MAGNETIC SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://go.crowdstrike.com/rs/281-OBQ-266/images/ReportGlobalThreatIntelligence.pdf"
         ]
@@ -6268,6 +6884,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "SINGING SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf"
         ]
@@ -6279,6 +6898,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "IR",
+        "name-attribution": [
+          "Fraternal Jackal:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://pastebin.com/u/QassamCyberFighters",
           "http://ddanchev.blogspot.com.es/2012/09/dissecting-operation-ababil-osint.html"
@@ -6295,6 +6917,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "APT6:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://threatpost.com/fbi-quietly-admits-to-multi-year-apt-attack-sensitive-data-stolen/117267/"
         ],
@@ -6333,6 +6958,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "PS",
+        "name-attribution": [
+          "Desert Falcon:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "origin:APT-C-23": "QiAnXin",
         "refs": [
           "http://www.trendmicro.com/cloud-content/us/pdfs/security-intelligence/white-papers/wp-operation-arid-viper.pdf",
@@ -6360,6 +6988,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "DEXTOROUS SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://docs.huihoo.com/rsaconference/usa-2014/anf-t07b-the-art-of-attribution-identifying-and-pursuing-your-cyber-adversaries-final.pdf"
         ]
@@ -6412,6 +7043,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "White Bear:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/introducing-whitebear/81638/",
           "https://www.cfr.org/interactive/cyber-operations/whitebear"
@@ -6427,6 +7061,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "CN",
+        "name-attribution": [
+          "PALE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "http://go.crowdstrike.com/rs/281-OBQ-266/images/ReportGlobalThreatIntelligence.pdf"
         ]
@@ -6462,6 +7099,10 @@
           "Government"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "Sowbug:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "G0054:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.symantec.com/connect/blogs/sowbug-cyber-espionage-group-targets-south-american-and-southeast-asian-governments",
           "https://www.cfr.org/interactive/cyber-operations/sowbug",
@@ -6504,6 +7145,17 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "Static Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Seedworm:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "MERCURY:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Boggy Serpens:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Mango Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA450:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Earth Vetala:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "COBALT ULSTER:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0069:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:Earth Vetala": "Trend Micro",
         "origin:TEMP.Zagros": "FireEye",
         "refs": [
@@ -6561,6 +7213,9 @@
     {
       "description": "In less than two years, this group has conducted over 20 successful attacks on financial institutions and legal firms in the USA, UK and Russia. The group has primarily been targeting card processing systems, including the AWS CBR (Russian Interbank System) and purportedly SWIFT (US). Given the wide usage of STAR in LATAM, financial institutions in LATAM could have particular exposure to a potential interest from the MoneyTaker group.",
       "meta": {
+        "name-attribution": [
+          "MoneyTaker:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.bleepingcomputer.com/news/security/moneytaker-hacker-group-steals-millions-from-us-and-russian-banks/",
           "https://www.group-ib.com/blog/moneytaker"
@@ -6574,6 +7229,9 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "LB",
+        "name-attribution": [
+          "G0070:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://info.lookout.com/rs/051-ESQ-475/images/Lookout_Dark-Caracal_srr_20180118_us_v.1.0.pdf",
           "https://research.checkpoint.com/2020/bandook-signed-delivered",
@@ -6611,6 +7269,16 @@
           "Private sector"
         ],
         "country": "KP",
+        "name-attribution": [
+          "APT37:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "APT 37:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "InkySquid:c2f76813-f24c-450e-abfd-0db4495ab68e",
+          "Operation Daybreak:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Ricochet Chollima:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "ScarCruft:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Moldy Pisces:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "G0067:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:APT-C-28": "QiAnXin",
         "refs": [
           "https://www.volexity.com/blog/2021/08/17/north-korean-apt-inkysquid-infects-victims-using-browser-exploits/",
@@ -6700,6 +7368,17 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "APT40:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TEMP.Periscope:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "Leviathan:cae79680-67a6-4411-903c-f824dbcc813f",
+          "GADOLINIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "KRYPTONITE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TA423:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Gingham Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE MOHAWK:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0065:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:BRONZE MOHAWK": "Secureworks",
         "origin:TEMP.Jumper": "FireEye",
         "origin:TEMP.Periscope": "FireEye",
@@ -6789,6 +7468,15 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "IR",
+        "name-attribution": [
+          "APT35:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Magic Hound:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Phosphorus:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Mint Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TunnelVision:996c48de-7bb8-414d-b6fe-ec94abb5f461",
+          "G0059:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "COBALT MIRAGE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "refs": [
           "https://www.fireeye.com/content/dam/collateral/en/mtrends-2018.pdf",
           "https://attack.mitre.org/groups/G0059/",
@@ -6840,6 +7528,9 @@
     {
       "description": "Symantec has identified a previously unknown group called Orangeworm that has been observed installing a custom backdoor called Trojan.Kwampirs within large international corporations that operate within the healthcare sector in the United States, Europe, and Asia.\nFirst identified in January 2015, Orangeworm has also conducted targeted attacks against organizations in related industries as part of a larger supply-chain attack in order to reach their intended victims. Known victims include healthcare providers, pharmaceuticals, IT solution providers for healthcare and equipment manufacturers that serve the healthcare industry, likely for the purpose of corporate espionage.",
       "meta": {
+        "name-attribution": [
+          "Orangeworm:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://www.symantec.com/blogs/threat-intelligence/orangeworm-targets-healthcare-us-europe-asia",
           "https://attack.mitre.org/groups/G0071/"
@@ -6853,6 +7544,10 @@
       "meta": {
         "capabilities": "Powershell scripts, THC Hydra, SecretsDump, Inveigh, PSExec",
         "mode-of-operation": "Watering-hole and phishing leading to ICS recon and screenshot collection",
+        "name-attribution": [
+          "ALLANITE:e4ed3168-7830-490f-9eed-d1b3ef2daccd",
+          "Allanite:e4ed3168-7830-490f-9eed-d1b3ef2daccd"
+        ],
         "refs": [
           "https://dragos.com/adversaries.html",
           "https://dragos.com/blog/20180510Allanite.html"
@@ -7026,6 +7721,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "RANCOR:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Rancor:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Rancor Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "G0075:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/unit42-rancor-targeted-attacks-south-east-asia-using-plaintee-ddkong-malware-families/",
           "https://www.cfr.org/interactive/cyber-operations/rancor",
@@ -7057,6 +7758,12 @@
     {
       "description": "Unit 42 researchers have been tracking Subaat, an attacker, since 2017. Recently Subaat drew our attention due to renewed targeted attack activity. Part of monitoring Subaat included realizing the actor was possibly part of a larger crew of individuals responsible for carrying out targeted attacks against worldwide governmental organizations. Technical analysis on some of the attacks as well as attribution links with Pakistan actors have been already depicted by 360 and Tuisec, in which they found interesting connections to a larger group of attackers Unit 42 researchers have been tracking, which we are calling Gorgon Group.",
       "meta": {
+        "name-attribution": [
+          "Gorgon Group:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Subaat:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Pasty Gemini:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "G0078:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/unit42-gorgon-group-slithering-nation-state-cybercrime/",
           "https://unit42.paloaltonetworks.com/unit42-tracking-subaat-targeted-phishing-attacks-point-leader-threat-actors-repository/",
@@ -7078,6 +7785,11 @@
     {
       "description": "In July 2018, Unit 42 analyzed a targeted attack using a novel file type against at least one government agency in the Middle East. It was carried out by a previously unpublished threat group we track as DarkHydrus. Based on our telemetry, we were able to uncover additional artifacts leading us to believe this adversary group has been in operation with their current playbook since early 2016. This attack diverged from previous attacks we observed from this group as it involved spear-phishing emails sent to targeted organizations with password protected RAR archive attachments that contained malicious Excel Web Query files (.iqy).",
       "meta": {
+        "name-attribution": [
+          "DarkHydrus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Obscure Serpens:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "G0079:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://researchcenter.paloaltonetworks.com/2018/07/unit42-new-threat-actor-group-darkhydrus-targets-middle-east-government/",
           "https://mobile.twitter.com/360TIC/status/1083289987339042817",
@@ -7173,6 +7885,9 @@
           "Civil society"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "Operation Parliament:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/operation-parliament",
           "https://securelist.com/operation-parliament-who-is-doing-what/85237/",
@@ -7216,6 +7931,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "RU",
+        "name-attribution": [
+          "Inception Framework:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "Clean Ursa:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Cloud Atlas:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "G0100:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/inception-framework",
           "https://web.archive.org/web/20160710180729/https://www.bluecoat.com/security-blog/2014-12-09/blue-coat-exposes-%E2%80%9C-inception-framework%E2%80%9D-very-sophisticated-layered-malware",
@@ -7285,6 +8006,14 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "MUSTANG PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Earth Preta:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "TA416:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Stately Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Twill Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE PRESIDENT:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE PRESIDENT": "Secureworks",
         "origin:Earth Preta": "Trend Micro",
         "origin:TEMP.HEX": "FireEye",
@@ -7345,6 +8074,10 @@
           "Private sector"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "Thrip:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "G0076:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.cfr.org/interactive/cyber-operations/thrip",
           "https://www.symantec.com/blogs/threat-intelligence/thrip-hits-satellite-telecoms-defense-targets",
@@ -7492,6 +8225,10 @@
       "description": "An extensive surveillance operation targets specific groups of individuals with malicious mobile apps that collect sensitive information on the device along with surrounding voice recordings. Researchers with CheckPoint discovered the attack and named it Domestic Kitten. The targets are Kurdish and Turkish natives, and ISIS supporters, all Iranian citizens.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Domestic Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Bouncing Golf:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:APT-C-50": "QiAnXin",
         "refs": [
           "https://www.bleepingcomputer.com/news/security/domestic-kitten-apt-operates-in-silence-since-2016/",
@@ -7532,6 +8269,9 @@
     {
       "description": "ESET research reveals a successor to the infamous BlackEnergy APT group targeting critical infrastructure, quite possibly in preparation for damaging attacks",
       "meta": {
+        "name-attribution": [
+          "GreyEnergy:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.eset.com/int/greyenergy-exposed/",
           "https://www.welivesecurity.com/2018/10/17/greyenergy-updated-arsenal-dangerous-threat-actors/"
@@ -7603,6 +8343,10 @@
       "description": "INDRIK SPIDER is a sophisticated eCrime group that has been operating Dridex since June 2014. In 2015 and 2016, Dridex was one of the most prolific eCrime banking trojans on the market and, since 2014, those efforts are thought to have netted INDRIK SPIDER millions of dollars in criminal profits. Throughout its years of operation, Dridex has received multiple updates with new modules developed and new anti-analysis features added to the malware.\nIn August 2017, a new ransomware variant identified as BitPaymer was reported to have ransomed the U.K.’s National Health Service (NHS), with a high ransom demand of 53 BTC (approximately $200,000 USD). The targeting of an organization rather than individuals, and the high ransom demands, made BitPaymer stand out from other contemporary ransomware at the time. Though the encryption and ransom functionality of BitPaymer was not technically sophisticated, the malware contained multiple anti-analysis features that overlapped with Dridex. Later technical analysis of BitPaymer indicated that it had been developed by INDRIK SPIDER, suggesting the group had expanded its criminal operation to include ransomware as a monetization strategy.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "INDRIK SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Manatee Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/big-game-hunting-the-evolution-of-indrik-spider-from-dridex-wire-fraud-to-bitpaymer-targeted-ransomware/"
         ],
@@ -7632,6 +8376,10 @@
     {
       "description": "Cisco Talos recently discovered a new campaign targeting Lebanon and the United Arab Emirates (UAE) affecting .gov domains, as well as a private Lebanese airline company. Based on our research, it's clear that this adversary spent time understanding the victims' network infrastructure in order to remain under the radar and act as inconspicuous as possible during their attacks.\nBased on this actor's infrastructure and TTPs, we haven't been able to connect them with any other campaign or actor that's been observed recently. This particular campaign utilizes two fake, malicious websites containing job postings that are used to compromise targets via malicious Microsoft Office documents with embedded macros. The malware utilized by this actor, which we are calling \"DNSpionage,\" supports HTTP and DNS communication with the attackers.\nIn a separate campaign, the attackers used the same IP to redirect the DNS of legitimate .gov and private company domains. During each DNS compromise, the actor carefully generated Let's Encrypt certificates for the redirected domains. These certificates provide X.509 certificates for TLS free of charge to the user. We don't know at this time if the DNS redirections were successful.\nIn this post, we will break down the attackers' methods and show how they used malicious documents to attempt to trick users into opening malicious websites that are disguised as \"help wanted\" sites for job seekers. Additionally, we will describe the malicious DNS redirection and the timeline of the events.",
       "meta": {
+        "name-attribution": [
+          "DNSpionage:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7",
+          "COBALT EDGEWATER:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/2018/11/dnspionage-campaign-targets-middle-east.html",
           "https://blog.talosintelligence.com/2019/04/dnspionage-brings-out-karkoff.html",
@@ -7718,6 +8466,9 @@
     {
       "description": "The McAfee Advanced Threat Research team and McAfee Labs Malware Operations Group have discovered a new global campaign targeting nuclear, defense, energy, and financial companies, based on McAfee® Global Threat Intelligence. This campaign, Operation Sharpshooter, leverages an in-memory implant to download and retrieve a second-stage implant—which we call Rising Sun—for further exploitation. According to our analysis, the Rising Sun implant uses source code from the Lazarus Group’s 2015 backdoor Trojan Duuzer in a new framework to infiltrate these key industries.\nOperation Sharpshooter’s numerous technical links to the Lazarus Group seem too obvious to immediately draw the conclusion that they are responsible for the attacks, and instead indicate a potential for false flags. Our research focuses on how this actor operates, the global impact, and how to detect the attack. We shall leave attribution to the broader security community.",
       "meta": {
+        "name-attribution": [
+          "Operation Sharpshooter:b8ca0932-c4cb-45c0-b7b1-88b9685ba24b"
+        ],
         "refs": [
           "https://securingtomorrow.mcafee.com/other-blogs/mcafee-labs/operation-sharpshooter-targets-global-defense-critical-infrastructure/",
           "https://www.bleepingcomputer.com/news/security/op-sharpshooter-connected-to-north-koreas-lazarus-group/"
@@ -7764,6 +8515,13 @@
           "Hospitality"
         ],
         "country": "RU",
+        "name-attribution": [
+          "TA505:cae79680-67a6-4411-903c-f824dbcc813f",
+          "GRACEFUL SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Spandex Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "GOLD TAHOE:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0092:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:GOLD TAHOE": "Secureworks",
         "refs": [
           "https://www.bleepingcomputer.com/news/security/ta505-group-adopts-new-servhelper-backdoor-and-flawedgrace-rat/",
@@ -7828,6 +8586,10 @@
     {
       "description": "GRIM SPIDER is a sophisticated eCrime group that has been operating the Ryuk ransomware since August 2018, targeting large organizations for a high-ransom return. This methodology, known as “big game hunting,” signals a shift in operations for WIZARD SPIDER, a criminal enterprise of which GRIM SPIDER appears to be a cell. The WIZARD SPIDER threat group, known as the Russia-based operator of the TrickBot banking malware, had focused primarily on wire fraud in the past.\nSimilar to Samas and BitPaymer, Ryuk is specifically used to target enterprise environments. Code comparison between versions of Ryuk and Hermes ransomware indicates that Ryuk was derived from the Hermes source code and has been under steady development since its release. Hermes is commodity ransomware that has been observed for sale on forums and used by multiple threat actors. However, Ryuk is only used by GRIM SPIDER and, unlike Hermes, Ryuk has only been used to target enterprise environments. Since Ryuk’s appearance in August, the threat actors operating it have netted over 705.80 BTC across 52 transactions for a total current value of $3,701,893.98 USD.\nGrim Spider is reportedly associated with Lunar Spider and Wizard Spider.",
       "meta": {
+        "name-attribution": [
+          "GRIM SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD ULRICK:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD ULRICK": "Secureworks",
         "refs": [
           "https://www.crowdstrike.com/blog/big-game-hunting-with-ryuk-another-lucrative-targeted-ransomware/",
@@ -7872,6 +8634,18 @@
           "Telecommunications"
         ],
         "country": "RU",
+        "name-attribution": [
+          "WIZARD SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "FIN12:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Periwinkle Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0193:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Storm-0193:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UNC2053:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Pistachio Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0237:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Storm-0230:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "GOLD BLACKBURN:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:DEV-0193": "Microsoft",
         "origin:DEV-0237": "Microsoft",
         "origin:FIN12": "Mandiant",
@@ -7934,6 +8708,11 @@
     {
       "description": "MUMMY SPIDER is a criminal entity linked to the core development of the malware most commonly known as Emotet or Geodo. First observed in mid-2014, this malware shared code with the Bugat (aka Feodo) banking Trojan. However, MUMMY SPIDER swiftly developed the malware’s capabilities to include an RSA key exchange for command and control (C2) communication and a modular architecture.\nMUMMY SPIDER does not follow typical criminal behavioral patterns. In particular, MUMMY SPIDER usually conducts attacks for a few months before ceasing operations for a period of between three and 12 months, before returning with a new variant or version.\nAfter a 10 month hiatus, MUMMY SPIDER returned Emotet to operation in December 2016 but the latest variant is not deploying a banking Trojan module with web injects, it is currently acting as a ‘loader’ delivering other malware packages. The primary modules perform reconnaissance on victim machines, drop freeware tools for credential collection from web browsers and mail clients and a spam plugin for self-propagation. The malware is also issuing commands to download and execute other malware families such as the banking Trojans Dridex and Qakbot.\n MUMMY SPIDER advertised Emotet on underground forums until 2015, at which time it became private. Therefore, it is highly likely that Emotet is operate",
       "meta": {
+        "name-attribution": [
+          "MUMMY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TA542:cae79680-67a6-4411-903c-f824dbcc813f",
+          "GOLD CRESTWOOD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD CRESTWOOD": "Secureworks",
         "refs": [
           "https://www.crowdstrike.com/blog/big-game-hunting-with-ryuk-another-lucrative-targeted-ransomware/",
@@ -7953,6 +8732,10 @@
     {
       "description": "Open-source reporting has claimed that the Hermes ransomware was developed by the North Korean group STARDUST CHOLLIMA (activities of which have been public reported as part of the “Lazarus Group”), because Hermes was executed on a host during the SWIFT compromise of FEIB in October 2017. ",
       "meta": {
+        "name-attribution": [
+          "STARDUST CHOLLIMA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Sapphire Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/big-game-hunting-with-ryuk-another-lucrative-targeted-ransomware/"
         ],
@@ -7989,6 +8772,9 @@
     {
       "description": "a relatively new threat actor that’s been operating since mid-2016\nGroup-IB has exposed the attacks committed by Silence cybercriminal group. While the gang had previously targeted Russian banks, Group-IB experts also have discovered evidence of the group's activity in more than 25 countries worldwide. Group-IB has published its first detailed report on tactics and tools employed by Silence. Group-IB security analysts' hypothesis is that at least one of the gang members appears to be a former or current employee of a cyber security company. The confirmed damage from Silence activity is estimated at 800 000 USD.\nSilence is a group of Russian-speaking hackers, based on their commands language, the location of infrastructure they used, and the geography of their targets (Russia, Ukraine, Belarus, Azerbaijan, Poland, and Kazakhstan). Although phishing emails were also sent to bank employees in Central and Western Europe, Africa, and Asia). Furthermore, Silence used Russian words typed on an English keyboard layout for the commands of the employed backdoor. The hackers also used Russian-language web hosting services.",
       "meta": {
+        "name-attribution": [
+          "WHISPER SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://reaqta.com/2019/01/silence-group-targeting-russian-banks/",
           "https://www.group-ib.com/blog/silence",
@@ -8010,6 +8796,15 @@
       "meta": {
         "attribution-confidence": "50",
         "country": "IR",
+        "name-attribution": [
+          "APT39:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "REMIX KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Radio Serpens:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "TA454:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Burgundy Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "COBALT HICKMAN:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0087:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2019/01/apt39-iranian-cyber-espionage-group-focused-on-personal-information.html",
           "https://www.symantec.com/blogs/threat-intelligence/chafer-latest-attacks-reveal-heightened-ambitions",
@@ -8039,6 +8834,9 @@
     {
       "description": "FireEye recently looked deeper into the activity discussed in TrendMicro’s blog and dubbed the “Siesta” campaign. The tools, modus operandi, and infrastructure used in the campaign present two possibilities: either the Chinese cyber-espionage unit APT1 is perpetrating this activity, or another group is using the same tactics and tools as the legacy APT1.\nThe Siesta campaign reinforces the fact that analysts and network defenders should remain on the lookout for known, public indicators and for shared attributes that allow security experts to detect multiple actors with one signature.",
       "meta": {
+        "name-attribution": [
+          "Siesta:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2014/03/a-detailed-examination-of-the-siesta-campaign.html"
         ]
@@ -8049,6 +8847,9 @@
     {
       "description": "Symantec researchers have uncovered a previously unknown attack group that is targeting government and military targets, including several overseas embassies of an Eastern European country, and military and defense targets in the Middle East. This group eschews custom malware and uses living off the land (LotL) tactics and publicly available hack tools to carry out activities that bear all the hallmarks of a cyber espionage campaign.\nThe group, which we have given the name Gallmaker, has been operating since at least December 2017, with its most recent activity observed in June 2018.",
       "meta": {
+        "name-attribution": [
+          "Gallmaker:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://www.symantec.com/blogs/threat-intelligence/gallmaker-attack-group"
         ]
@@ -8059,6 +8860,10 @@
     {
       "description": "Throughout 2018, CrowdStrike Intelligence tracked BOSS SPIDER as it regularly updated Samas ransomware and received payments to known Bitcoin (BTC) addresses. This consistent pace of activity came to an abrupt halt at the end of November 2018 when the U.S. DoJ released an indictment for Iran-based individuals Faramarz Shahi Savandi and Mohammad Mehdi Shah Mansouri, alleged members of the group.",
       "meta": {
+        "name-attribution": [
+          "BOSS SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD LOWELL:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD LOWELL": "Secureworks",
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/",
@@ -8078,6 +8883,9 @@
     {
       "description": "First observed in January 2018, GandCrab ransomware quickly began to proliferate and receive regular updates from its developer, PINCHY SPIDER, which over the course of the year established a RaaS operation with a dedicated set of affiliates.\nCrowdStrike Intelligence has recently observed PINCHY SPIDER affiliates deploying GandCrab ransomware in enterprise environments, using lateral movement techniques and tooling commonly associated with nation-state adversary groups and penetration testing teams. This change in tactics makes PINCHY SPIDER and its affiliates the latest eCrime adversaries to join the growing trend of targeted, low-volume/high-return ransomware deployments known as “big game hunting.”\n PINCHY SPIDER is the criminal group behind the development of the ransomware most commonly known as GandCrab, which has been active since January 2018. PINCHY SPIDER sells access to use GandCrab ransomware under a partnership program with a limited number of accounts. The program is operated with a 60-40 split in profits (60 percent to the customer), as is common among eCrime actors, but PINCHY SPIDER is also willing to negotiate up to a 70-30 split for “sophisticated” customers.",
       "meta": {
+        "name-attribution": [
+          "PINCHY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/",
           "https://www.crowdstrike.com/blog/pinchy-spider-adopts-big-game-hunting/",
@@ -8090,6 +8898,9 @@
     {
       "description": "Early in 2018, CrowdStrike Intelligence observed GURU SPIDER supporting the distribution of multiple crimeware families through its flagship malware loader, Quant Loader.",
       "meta": {
+        "name-attribution": [
+          "GURU SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
         ]
@@ -8100,6 +8911,9 @@
     {
       "description": "Beginning in January 2018 and persisting through the first half of the year, CrowdStrike Intelligence observed SALTY SPIDER, developer and operator of the long-running Sality botnet, distribute malware designed to target cryptocurrency users.",
       "meta": {
+        "name-attribution": [
+          "SALTY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/",
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
@@ -8111,6 +8925,9 @@
     {
       "description": "In the first quarter of 2018, CrowdStrike Intelligence identified NOMAD PANDA activity targeting Central Asian nations with exploit documents built with the 8.t tool.",
       "meta": {
+        "name-attribution": [
+          "NOMAD PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
         ]
@@ -8121,6 +8938,9 @@
     {
       "description": "This suspected Iran-based adversary conducted long-running SWC campaigns from December 2016 until public disclosure in July 2018. Like other Iran-based actors, the target scope for FLASH KITTEN appears to be focused on the MENA region.",
       "meta": {
+        "name-attribution": [
+          "Flash Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
         ]
@@ -8131,6 +8951,9 @@
     {
       "description": "According to CrowdStrike, this actor is using TinyLoader and TinyPOS, potentially buying access through Dridex infections.",
       "meta": {
+        "name-attribution": [
+          "TINY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
         ]
@@ -8141,6 +8964,10 @@
     {
       "description": "According to CrowdStrike, this actor is using BokBok/IcedID, potentially buying distribution through Emotet infections.\nOn March 17, 2019, CrowdStrike Intelligence observed the use of a new BokBot (developed and operated by LUNAR SPIDER) proxy module in conjunction with TrickBot (developed and operated by WIZARD SPIDER), which may provide WIZARD SPIDER with additional tools to steal sensitive information and conduct fraudulent wire transfers. This activity also provides further evidence to support the existence of a flourishing relationship between these two actors.\nLunar Spider is reportedly associated withGrim Spider and Wizard Spider.",
       "meta": {
+        "name-attribution": [
+          "LUNAR SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD SWATHMORE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD SWATHMORE": "Secureworks",
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/",
@@ -8158,6 +8985,9 @@
     {
       "description": "In July 2018, the source code of Pegasus, RATPAK SPIDER’s malware framework, was anonymously leaked. This malware has been linked to the targeting of Russia’s financial sector. Associated malware, Buhtrap, which has been leaked previously, was observed this year in connection with SWC campaigns that also targeted Russian users.",
       "meta": {
+        "name-attribution": [
+          "RATPAK SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/"
         ]
@@ -8246,6 +9076,9 @@
     {
       "description": "Operation Comando is a pure cybercrime campaign, possibly with Brazilian origin, with a concrete and persistent focus on the hospitality sector, which proves how a threat actor can be successful in pursuing its objectives while maintaining a cheap budget. The use of DDNS services, publicly available remote access tools, and having a minimum knowledge on software development (in this case VB.NET) has been enough for running a campaign lasting month, and potentially gathering credit card information and other possible data. ",
       "meta": {
+        "name-attribution": [
+          "Operation Comando:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/operation-comando-or-how-to-run-a-cheap-and-effective-credit-card-business/"
         ]
@@ -8280,6 +9113,9 @@
     {
       "description": "Newly discovered supply chain attack that leveraged ASUS Live Update software.\nThe goal of the attack was to surgically target an unknown pool of users, which were identified by their network adapters’ MAC addresses. To achieve this, the attackers had hardcoded a list of MAC addresses in the trojanized samples and this list was used to identify the actual intended targets of this massive operation. We were able to extract more than 600 unique MAC addresses from over 200 samples used in this attack. Of course, there might be other samples out there with different MAC addresses in their list.",
       "meta": {
+        "name-attribution": [
+          "Operation ShadowHammer:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/operation-shadowhammer/89992/"
         ]
@@ -8290,6 +9126,9 @@
     {
       "description": "In July 2018, an attack on Singapore’s largest public health organization, SingHealth, resulted in a reported 1.5 million patient records being stolen. Until now, nothing was known about who was responsible for this attack. Symantec researchers have discovered that this attack group, which we call Whitefly, has been operating since at least 2017, has targeted organizations based mostly in Singapore across a wide variety of sectors, and is primarily interested in stealing large amounts of sensitive information.",
       "meta": {
+        "name-attribution": [
+          "Whitefly:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://www.symantec.com/blogs/threat-intelligence/whitefly-espionage-singapore",
           "https://www.reuters.com/article/us-singapore-cyberattack/cyberattack-on-singapore-health-database-steals-details-of-1-5-million-including-pm-idUSKBN1KA14J"
@@ -8305,6 +9144,10 @@
           "Germany"
         ],
         "country": "TR",
+        "name-attribution": [
+          "Sea Turtle:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7",
+          "UNC1326:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC1326": "Mandiant",
         "refs": [
           "https://blog.talosintelligence.com/2019/04/seaturtle.html",
@@ -8347,6 +9190,12 @@
       "description": "Last Friday, Deputy Attorney General Rod Rosenstein announced the indictment of nine Iranians who worked for an organization named the Mabna Institute. According to prosecutors, the defendants stole more than 31 terabytes of data from universities, companies, and government agencies around the world. The cost to the universities alone reportedly amounted to approximately $3.4 billion. The information stolen from these universities was used by the Islamic Revolutionary Guard Corps (IRGC) or sold for profit inside Iran. PhishLabs has been tracking this same threat group since late-2017, designating them Silent Librarian. Since discovery, we have been working with the FBI, ISAC partners, and other international law enforcement agencies to help understand and mitigate these attacks.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Silent Librarian:cae79680-67a6-4411-903c-f824dbcc813f",
+          "TA407:cae79680-67a6-4411-903c-f824dbcc813f",
+          "TA4900:cae79680-67a6-4411-903c-f824dbcc813f",
+          "COBALT DICKENS:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:TA4900": "Proofpoint",
         "refs": [
           "https://info.phishlabs.com/blog/silent-librarian-more-to-the-story-of-the-iranian-mabna-institute-indictment",
@@ -8377,6 +9226,13 @@
       "description": "FireEye characterizes APT31 as an actor specialized on intellectual property theft, focusing on data and projects that make a particular organization competetive in its field. Based on available data (April 2016), FireEye assesses that APT31 conducts network operations at the behest of the Chinese Government. Also according to Crowdstrike, this adversary is suspected of continuing to target upstream providers (e.g., law firms and managed service providers) to support additional intrusions against high-profile assets. In 2018, CrowdStrike observed this adversary using spear-phishing, URL “web bugs” and scheduled tasks to automate credential harvesting.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "APT31:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "JUDGMENT PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Violet Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA412:cae79680-67a6-4411-903c-f824dbcc813f",
+          "BRONZE VINEWOOD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE VINEWOOD": "Secureworks",
         "refs": [
           "https://www.microsoft.com/security/blog/2017/03/27/detecting-and-mitigating-elevation-of-privilege-exploit-for-cve-2017-0005/",
@@ -8455,6 +9311,10 @@
       "description": "BLACKGEAR is an espionage campaign which has targeted users in Taiwan for many years. Multiple papers and talks have been released covering this campaign, which used the ELIRKS backdoor when it was first discovered in 2012. It is known for using blogs and microblogging services to hide the location of its actual command-and-control (C&C) servers. This allows an attacker to change the C&C server used quickly by changing the information in these posts.\nLike most campaigns, BLACKGEAR has evolved over time. Our research indicates that it has started targeting Japanese users. Two things led us to this conclusion: first, the fake documents that are used as part of its infection routines are now in Japanese. Secondly, it is now using blogging sites and microblogging services based in Japan for its C&C activity.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Blackgear:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "BLACKGEAR:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://blog.trendmicro.com/trendlabs-security-intelligence/blackgear-espionage-campaign-evolves-adds-japan-target-list/",
           "https://blog.trendmicro.com/trendlabs-security-intelligence/blackgear-cyberespionage-campaign-resurfaces-abuses-social-media-for-cc-communication/"
@@ -8471,6 +9331,10 @@
     {
       "description": "BlackOasis is a Middle Eastern threat group that is believed to be a customer of Gamma Group. The group has shown interest in prominent figures in the United Nations, as well as opposition bloggers, activists, regional news correspondents, and think tanks. A group known by Microsoft as NEODYMIUM is reportedly associated closely with BlackOasis operations, but evidence that the group names are aliases has not been identified.",
       "meta": {
+        "name-attribution": [
+          "BlackOasis:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "G0063:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://securelist.com/blackoasis-apt-and-new-targeted-attacks-leveraging-zero-day-exploit/82732/",
           "https://www.fireeye.com/blog/threat-research/2017/09/zero-day-used-to-distribute-finspy.html",
@@ -8487,6 +9351,14 @@
       "description": "BlackTech is a cyber espionage group operating against targets in East Asia, particularly Taiwan, and occasionally, Japan and Hong Kong. Based on the mutexes and domain names of some of their C&C servers, BlackTech’s campaigns are likely designed to steal their target’s technology.\nFollowing their activities and evolving tactics and techniques helped us uncover the proverbial red string of fate that connected three seemingly disparate campaigns: PLEAD, Shrouded Crossbow, and of late, Waterbear.\nPLEAD is an information theft campaign with a penchant for confidential documents. Active since 2012, it has so far targeted Taiwanese government agencies and private organizations. PLEAD’s toolset includes the self-named PLEAD backdoor and the DRIGO exfiltration tool. PLEAD uses spear-phishing emails to deliver and install their backdoor, either as an attachment or through links to cloud storage services. Some of the cloud storage accounts used to deliver PLEAD are also used as drop off points for exfiltrated documents stolen by DRIGO.\nPLEAD actors use a router scanner tool to scan for vulnerable routers, after which the attackers will enable the router’s VPN feature then register a machine as virtual server. This virtual server will be used either as a C&C server or an HTTP server that delivers PLEAD malware to their targets.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "CIRCUIT PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Palmerworm:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "Manga Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Earth Hundun:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Canary Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0098:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:Earth Hundun": "Trend Micro",
         "refs": [
           "https://blog.trendmicro.com/trendlabs-security-intelligence/following-trail-blacktech-cyber-espionage-campaigns/",
@@ -8521,6 +9393,10 @@
     {
       "description": "FIN5 is a financially motivated threat group that has targeted personally identifiable information and payment card information. The group has been active since at least 2008 and has targeted the restaurant, gaming, and hotel industries. The group is made up of actors who likely speak Russian.",
       "meta": {
+        "name-attribution": [
+          "FIN5:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0053:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:FIN5": "Mandiant",
         "refs": [
           "https://www.darkreading.com/analytics/prolific-cybercrime-gang-favors-legit-login-credentials/d/d-id/1322645?",
@@ -8537,6 +9413,9 @@
       "description": "FireEye first identified this activity during a recent investigation at an organization in the financial industry. They identified the presence of a financially motivated threat group that they track as FIN1, whose activity at the organization dated back several years. The threat group deployed numerous malicious files and utilities, all of which were part of a malware ecosystem referred to as ‘Nemesis’ by the malware developer(s), and used this malware to access the victim environment and steal cardholder data. FIN1, which may be located in Russia or a Russian-speaking country based on language settings in many of their custom tools, is known for stealing data that is easily monetized from financial services organizations such as banks, credit unions, ATM operations, and financial transaction processing and financial business services companies.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "FIN1:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:FIN1": "Mandiant",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2015/12/fin1-targets-boot-record.html"
@@ -8548,6 +9427,10 @@
     {
       "description": "FireEye has observed multiple targeted intrusions occurring in North America — predominately in Canada — dating back to at least 2013 and continuing through at least 2016, in which the attacker(s) have compromised organizations’ networks and sought to monetize this illicit access by exfiltrating sensitive data and extorting victim organizations. In some cases, when the extortion demand was not met, the attacker(s) destroyed production Windows systems by deleting critical operating system files and then shutting down the impacted systems. Based on near parallel TTPs used by the attacker(s) across these targeted intrusions, we believe these clusters of activity are linked to a single, previously unobserved actor or group that we have dubbed FIN10.",
       "meta": {
+        "name-attribution": [
+          "FIN10:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "G0051:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:FIN10": "Mandiant",
         "refs": [
           "https://www2.fireeye.com/rs/848-DID-242/images/rpt-fin10.pdf",
@@ -8591,6 +9474,9 @@
     {
       "description": "A threat actor using Iranian-language tools, Iranian hosting companies, operating from the Iranian IP space at times was observed targeting the Syrian opposition in an elaborately staged malware operation, Citizen Lab researchers reveal.\nThe operation was first noticed in late 2015, when a member of the Syrian opposition flagged a suspicious email containing a PowerPoint slideshow, which led researchers to a watering hole website with malicious programs, malicious PowerPoint files, and Android malware.\nThe threat actor was targeting Windows and Android devices of well-connected individuals in the Syrian opposition, researchers discovered. They called the actor Group5, because it targets Syrian opposition after regime-linked malware groups, the Syrian Electronic Army, ISIS (also known as the Islamic State or ISIL), and a group linked to Lebanon did the same in the past",
       "meta": {
+        "name-attribution": [
+          "G0043:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.securityweek.com/iranian-actor-group5-targeting-syrian-opposition",
           "https://attack.mitre.org/groups/G0043/"
@@ -8605,6 +9491,10 @@
     {
       "description": "McAfee Advanced Threat Research analysts have discovered a new operation targeting humanitarian aid organizations and using North Korean political topics as bait to lure victims into opening malicious Microsoft Word documents. Our analysts have named this Operation Honeybee, based on the names of the malicious documents used in the attacks.\nAdvanced Threat Research analysts have also discovered malicious documents authored by the same actor that indicate a tactical shift. These documents do not contain the typical lures by this actor, instead using Word compatibility messages to entice victims into opening them.\nThe Advanced Threat Research team also observed a heavy concentration of the implant in Vietnam from January 15–17.",
       "meta": {
+        "name-attribution": [
+          "Honeybee:b8ca0932-c4cb-45c0-b7b1-88b9685ba24b",
+          "G0072:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://securingtomorrow.mcafee.com/other-blogs/mcafee-labs/mcafee-uncovers-operation-honeybee-malicious-document-campaign-targeting-humanitarian-aid-groups/",
           "https://attack.mitre.org/groups/G0072/"
@@ -8619,6 +9509,9 @@
     {
       "description": "A series of attacks, targeting both Indian military research and south Asian shipping organizations, demonstrate the minimum level of effort required to successfully compromise a target and steal sensitive information. The attackers use very simple malware, which required little development time or skills, in conjunction with freely available Web hosting, to implement a highly effective attack. It is a case of the attackers obtaining a maximum return on their investment. The attack shows how an intelligent attacker does not need to be particularly technically skilled in order to steal the information they are after. The attack begins, as is often the case, with an email sent to the victim. A malicious document is attached to the email, which, when loaded, activates the malware. The attackers use tailored emails to encourage the victim to open the email. For example, one email sent to an academic claimed to be a call for papers for a conference (CFP).\nThe vast majority of the victims were based in India, with some in Malaysia. The victim industry was mostly military research and also shipping based in the Arabian and South China seas. In some instances the attackers appeared to have a clear goal, whereby specific files were retrieved from certain compromised computers. In other cases, the attackers used more of a ‘shotgun’ like approach, copying every file from a computer. Military technologies were obviously the focus of one particular attack with what appeared to be source code stolen. 45 different attacker IP addresses were observed. Out of those, 43 were within the same IP address range based in Sichuan province, China. The remaining two were based in South Korea. The pattern of attacker connections implies that the IP addresses are being used as a VPN, probably in an attempt to render the attackers anonymous.ænThe attacks have been active from at least April 2011 up to February 2012. The attackers are intelligent and focused, employing the minimum amount of work necessary for the maximum gain. They do not use zero day exploits or complicated threats, instead they rely on effective social engineering and lax security measures on the part of the victims.",
       "meta": {
+        "name-attribution": [
+          "TA413:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://vx-underground.org/papers/luckycat-hackers-12-en.pdf",
           "https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp_luckycat_redux.pdf",
@@ -8636,6 +9529,9 @@
     {
       "description": "There are several groups actively and profitably targeting businesses in Russia. A trend that we have seen unfold before our eyes lately is these cybercriminals’ use of simple backdoors to gain a foothold in their targets’ networks. Once they have this access, a lot of the work is done manually, slowly getting to understand the network layout and deploying custom tools the criminals can use to steal funds from these entities. Some of the groups that best exemplify these trends are Buhtrap, Cobalt and Corkow.\nThe group discussed in this white paper is part of this new trend. We call this new group RTM; it uses custom malware, written in Delphi, that we cover in detail in later sections. The first trace of this tool in our telemetry data dates back to late 2015. The group also makes use of several different modules that they deploy where appropriate to their targets. They are interested in users of remote banking systems (RBS), mainly in Russia and neighboring countries.",
       "meta": {
+        "name-attribution": [
+          "G0048:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://www.welivesecurity.com/wp-content/uploads/2017/02/Read-The-Manual.pdf",
           "https://attack.mitre.org/groups/G0048/"
@@ -8660,6 +9556,9 @@
     {
       "description": "While analysing an incident which involved a suspected keylogger, we identified a malicious library able to interact with a virtual file system, which is usually the sign of an advanced APT actor. This turned out to be a malicious loader internally named ‘Slingshot’, part of a new, and highly sophisticated attack platform that rivals Project Sauron and Regin in complexity.\nWhile for most victims the infection vector for Slingshot remains unknown, we were able to find several cases where the attackers got access to MikroTik routers and placed a component downloaded by Winbox Loader, a management suite for MikroTik routers. In turn, this infected the administrator of the router.\nWe believe this cluster of activity started in at least 2012 and was still active at the time of this analysis (February 2018).",
       "meta": {
+        "name-attribution": [
+          "Slingshot:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/apt-slingshot/84312/"
         ]
@@ -8670,6 +9569,10 @@
     {
       "description": "The Taidoor attackers have been actively engaging in targeted attacks since at least March 4, 2009. Despite some exceptions, the Taidoor campaign often used Taiwanese IP addresses as C&C servers and email addresses to send out socially engineered emails with malware as attachments. One of the primary targets of the Taidoor campaign appeared to be the Taiwanese government. The attackers spoofed Taiwanese government email addresses to send out socially engineered emails in the Chinese language that typically leveraged Taiwan-themed issues. The attackers actively sent out malicious documents and maintained several IP addresses for command and control.\nAs part of their social engineering ploy, the Taidoor attackers attach a decoy document to their emails that, when opened, displays the contents of a legitimate document but executes a malicious payload in the background.\nWe were only able to gather a limited amount of information regarding the Taidoor attackers’ activities after they have compromised a target. We did, however, find that the Taidoor malware allowed attackers to operate an interactive shell on compromised computers and to upload and download files. In order to determine the operational capabilities of the attackers behind the Taidoor campaign, we monitored a compromised honeypot. The attackers issued out some basic commands in an attempt to map out the extent of the network compromise but quickly realized that the honeypot was not an intended targeted and so promptly disabled the Taidoor malware running on it. This indicated that while Taidoor malware were more widely distributed compared with those tied to other targeted campaigns, the attackers could quickly assess their targets and distinguish these from inadvertently compromised computers and honeypots.",
       "meta": {
+        "name-attribution": [
+          "Earth Aughisky:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "G0015:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:Earth Aughisky": "Trend Micro",
         "refs": [
           "https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp_the_taidoor_campaign.pdf",
@@ -8690,6 +9593,10 @@
       "meta": {
         "capabilities": "TRISIS, custom credential harvesting",
         "mode-of-operation": "Focused on physical destruction and long-term persistence",
+        "name-attribution": [
+          "Xenotime:e4ed3168-7830-490f-9eed-d1b3ef2daccd",
+          "G0088:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:TEMP.Veles": "FireEye",
         "refs": [
           "https://dragos.com/resource/trisis-analyzing-safety-system-targeting-malware/",
@@ -8712,6 +9619,10 @@
     {
       "description": "In August of 2018, DarkMatter released a report entitled “In the Trails of WINDSHIFT APT”, which unveiled a threat actor with TTPs very similar to those of Bahamut. Subsequently, two additional articles were released by Objective-See which provide an analysis of some validated WINDSHIFT samples targeting OSX systems. Pivoting on specific file attributes and infrastructure indicators, Unit 42 was able to identify and correlate additional attacker activity and can now provide specific details on a targeted WINDSHIFT attack as it unfolded at a Middle Eastern government agency.",
       "meta": {
+        "name-attribution": [
+          "WindShift:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Windy Phoenix:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/shifting-in-the-wind-windshift-attacks-target-middle-eastern-governments/",
           "https://gsec.hitb.org/materials/sg2018/D1%20COMMSEC%20-%20In%20the%20Trails%20of%20WINDSHIFT%20APT%20-%20Taha%20Karim.pdf",
@@ -8737,6 +9648,9 @@
     {
       "description": "DUNGEON SPIDER is a criminal group operating the ransomware most commonly known as Locky, which has been active since February 2016 and was last observed in late 2017. Locky is a ransomware tool that encrypts files using a combination of cryptographic algorithms: RSA with a key size of 2,048 bits, and AES with a key size of 128 bits. Locky targets a large number of file extensions and is able to encrypt data on shared network drives. In an attempt to further impact victims and prevent file recovery, Locky deletes all of the Shadow Volume Copies on the machine.\nDUNGEON SPIDER primarily relies on broad spam campaigns with malicious attachments for distribution. Locky is the community/industry name associated with this actor.",
       "meta": {
+        "name-attribution": [
+          "DUNGEON SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-october-dungeon-spider/"
         ]
@@ -8771,6 +9685,9 @@
     {
       "description": "The many 0-days that had been collected by Hacking Team and which became publicly available during the breach of their organization in 2015, have been used by several APT groups since.\nSince being founded in 2003, the Italian spyware vendor Hacking Team gained notoriety for selling surveillance tools to governments and their agencies across the world.\nThe capabilities of its flagship product, the Remote Control System (RCS), include extracting files from a targeted device, intercepting emails and instant messaging, as well as remotely activating a device’s webcam and microphone. The company has been criticized for selling these capabilities to authoritarian governments – an allegation it has consistently denied.\nWhen the tables turned in July 2015, with Hacking Team itself suffering a damaging hack, the reported use of RCS by oppressive regimes was confirmed. With 400GB of internal data – including the once-secret list of customers, internal communications, and spyware source code – leaked online, Hacking Team was forced to request its customers to suspend all use of RCS, and was left facing an uncertain future.\nFollowing the hack, the security community has been keeping a close eye on the company’s efforts to get back on its feet. The first reports suggesting Hacking Team’s resumed operations came six months later – a new sample of Hacking Team’s Mac spyware was apparently in the wild. A year after the breach, an investment by a company named Tablem Limited brought changes to Hacking Team’s shareholder structure, with Tablem Limited taking 20% of Hacking Team’s shareholding. Tablem Limited is officially based in Cyprus; however, recent news suggests it has ties to Saudi Arabia.",
       "meta": {
+        "name-attribution": [
+          "Hacking Team:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2018/03/09/new-traces-hacking-team-wild/",
           "https://en.wikipedia.org/wiki/Hacking_Team",
@@ -8783,6 +9700,9 @@
     {
       "description": "OurMine is known for celebrity internet accounts, often causing cyber vandalism, to advertise their commercial services.\n(Trend Micro) In light of the recent report detailing its willingness to pay US$250,000 in exchange for the 1.5 terabytes’ worth of data swiped by hackers from its servers, HBO finds itself dealing with yet another security breach.\nKnown for hijacking prominent social media accounts, the self-styled white hat hacking group OurMine took over a number of verified Twitter and Facebook accounts belonging to the cable network. These include accounts for HBO shows, such as “Game of Thrones,” “Girls,” and “Ballers.”\nThis is not the first time that OurMine has claimed responsibility for hacking high- profile social networking accounts. Last year, the group victimized Marvel, The New York Times, and even the heads of some of the biggest technology companies in the world. Mark Zuckerberg, Jack Dorsey, Sundar Pichai, and Daniel Ek — the CEOs of Facebook, Twitter, Google and Spotify, respectively — have also fallen victim to the hackers, dispelling the notion that a career in software and technology exempts one from being compromised.",
       "meta": {
+        "name-attribution": [
+          "OurMine:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/hbo-twitter-and-facebook-accounts-hacked-by-ourmine",
           "https://gizmodo.com/welp-vevo-just-got-hacked-1813390834",
@@ -8796,6 +9716,9 @@
     {
       "description": "Antd is a miner found in the wild on September 18, 2018. Recently we discovered that the authors from Antd are actively delivering newer campaigns deploying a broad number of components, most of them completely undetected and operating within compromised third party Linux servers. Furthermore, we have observed that some of the techniques implemented by this group are unconventional, and there is an element of sophistication to them. We believe the authors behind this malware are from Chinese origin. We have labeled the undetected Linux.Antd variants, Linux.GreedyAntd and classified the threat actor as Pacha Group.",
       "meta": {
+        "name-attribution": [
+          "Pacha Group:ac46bac7-e7b5-4efe-8f32-b79e9015ab86"
+        ],
         "refs": [
           "https://www.intezer.com/blog-technical-analysis-pacha-group/",
           "https://www.intezer.com/blog-technical-analysis-cryptocurrency-mining-war-on-the-cloud/"
@@ -8807,6 +9730,9 @@
     {
       "description": "This threat actor initially came to our attention in April 2018, leveraging both Western and Chinese Git repositories to deliver malware to honeypot systems vulnerable to an Apache Struts vulnerability.\nIn late July, we became aware that the same actor was engaged in another similar campaign. Through our investigation into this new campaign, we were able to uncover more details about the actor.",
       "meta": {
+        "name-attribution": [
+          "Aged Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/2018/08/rocke-champion-of-monero-miners.html",
           "https://unit42.paloaltonetworks.com/malware-used-by-rocke-group-evolves-to-evade-detection-by-cloud-security-products/",
@@ -8834,6 +9760,9 @@
     {
       "description": "On April 7, 2017, Pytor Levashov — who predominantly used the alias Severa or Peter Severa and whom Falcon Intelligence tracks as ZOMBIE SPIDER — was arrested in an international law enforcement operation led by the FBI. ZOMBIE SPIDER’s specialty was large-scale spam distribution, a fundamental component of cybercrime operations. Levashov was the primary threat actor behind a botnet known as Kelihos and its predecessors, Waledac and Storm. In addition to Levashov’s arrest, there was a technical operation conducted by Falcon Intelligence to seize control of the Kelihos botnet.",
       "meta": {
+        "name-attribution": [
+          "ZOMBIE SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/farewell-to-kelihos-and-zombie-spider/",
           "https://www.crowdstrike.com/blog/inside-the-takedown-of-zombie-spider-and-the-kelihos-botnet/",
@@ -8847,6 +9776,9 @@
     {
       "description": "In May 2018, we discovered a campaign targeting dozens of mobile Android devices belonging to Israeli citizens. Kaspersky spyware sensors caught the signal of an attack from the device of one of the victims; and a hash of the APK involved (Android application) was tagged in our sample feed for inspection. Once we looked into the file, we quickly found out that the inner-workings of the APK included a malicious payload, embedded in the original code of the application. This was an original spyware program, designed to exfiltrate almost all accessible information.\nDuring the course of our research, we noticed that we were not the only ones to have found the operation. Researchers from Bitdefender also released an analysis of one of the samples in a blogpost. Although something had already been published, we decided to do something different with the data we acquired. The following month, we released a private report on our Threat Intelligence Portal to alert our clients about this newly discovered operation and began writing YARA rules in order to catch more samples. We decided to call the operation “ViceLeaker”, because of strings and variables in its code.",
       "meta": {
+        "name-attribution": [
+          "ViceLeaker:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/fanning-the-flames-viceleaker-operation/90877/"
         ]
@@ -8857,6 +9789,9 @@
     {
       "description": "Cisco Talos recently identified a large number of ongoing malware distribution campaigns linked to a threat actor we're calling \"SWEED,\" including such notable malware as Formbook, Lokibot and Agent Tesla. Based on our research, SWEED — which has been operating since at least 2017 — primarily targets their victims with stealers and remote access trojans.\nSWEED remains consistent across most of their campaigns in their use of spear-phishing emails with malicious attachments. While these campaigns have featured a myriad of different types of malicious documents, the actor primarily tries to infect its victims with a packed version of Agent Tesla — an information stealer that's been around since at least 2014. The version of Agent Tesla that SWEED is using differs slightly from what we've seen in the past in the way that it is packed, as well as how it infects the system. In this post, we'll run down each campaign we're able to connect to SWEED, and talk about some of the actor's tactics, techniques and procedures (TTPs).",
       "meta": {
+        "name-attribution": [
+          "SWEED:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/2019/07/sweed-agent-tesla.html"
         ]
@@ -8868,6 +9803,11 @@
       "description": "Proofpoint researchers have identified a targeted APT campaign that utilized malicious RTF documents to deliver custom malware to unsuspecting victims. We dubbed this campaign “Operation LagTime IT” based on entities that were targeted and the distinctive domains registered to C&C IP infrastructure. Beginning in early 2019, these threat actors targeted a number of government agencies in East Asia overseeing government information technology, domestic affairs, foreign affairs, economic development, and political processes. We determined that the infection vector observed in this campaign was spear phishing, with emails originating from both free email accounts and compromised user accounts. Attackers relied on Microsoft Equation Editor exploit CVE-2018-0798 to deliver a custom malware that Proofpoint researchers have dubbed Cotx RAT. Additionally, this APT group utilizes Poison Ivy payloads that share overlapping command and control (C&C) infrastructure with the newly identified Cotx campaigns. Based on infrastructure overlaps, post-exploitation techniques, and historic TTPs utilized in this operation, Proofpoint analysts attribute this activity to the Chinese APT group tracked internally as TA428. Researchers believe that this activity has an operational and tactical resemblance to the Maudi Surveillance Operation which was previously reported in 2013.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "TA428:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Colourful Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "BRONZE DUDLEY:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE DUDLEY": "Secureworks",
         "refs": [
           "https://www.proofpoint.com/us/threat-insight/post/chinese-apt-operation-lagtime-it-targets-government-information-technology",
@@ -8909,6 +9849,13 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "UNC1530:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Chrono Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Storm-0133:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "LYCEUM:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "COBALT LYCEUM:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:Storm-0133": "Microsoft",
         "origin:UNC1530": "Mandiant",
         "refs": [
@@ -8974,6 +9921,20 @@
           "Travel"
         ],
         "country": "CN",
+        "name-attribution": [
+          "APT41:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TA415:cae79680-67a6-4411-903c-f824dbcc813f",
+          "WICKED SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "WICKED PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Brass Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Double Dragon:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Leopard Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "G0096:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "BRONZE ATLAS:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "BRONZE EXPORT:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0044:a1ad5090-2487-46d2-8237-6151a2dd5063",
+          "TG-2633:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE ATLAS": "Secureworks",
         "origin:BRONZE EXPORT": "Secureworks",
         "origin:Earth Baku": "Trend Micro",
@@ -9111,6 +10072,16 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "Tortoiseshell:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "IMPERIAL KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Yellow Liderc:9f2ba728-8b29-48f9-badf-4f4cefb929f0",
+          "Imperial Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TA456:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Crimson Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Cuboid Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Smoke Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.symantec.com/blogs/threat-intelligence/tortoiseshell-apt-supply-chain",
           "https://www.darkreading.com/threat-intelligence/iranian-government-hackers-target-us-veterans/d/d-id/1335897",
@@ -9147,6 +10118,9 @@
     {
       "description": "Between November 2018 and May 2019, senior members of Tibetan groups received malicious links in individually tailored WhatsApp text exchanges with operators posing as NGO workers, journalists, and other fake personas. The links led to code designed to exploit web browser vulnerabilities to install spyware on iOS and Android devices, and in some cases to OAuth phishing pages. This campaign was carried out by what appears to be a single operator that we call POISON CARP.",
       "meta": {
+        "name-attribution": [
+          "Earth Empusa:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Empusa": "Trend Micro",
         "refs": [
           "https://citizenlab.ca/2019/09/poison-carp-tibetan-groups-targeted-with-1-click-mobile-exploits/",
@@ -9165,6 +10139,9 @@
     {
       "description": "Early in August 2019, Proofpoint described what appeared to be state-sponsored activity targeting the US utilities sector with malware that we dubbed “Lookback”. Between August 21 and August 29, 2019, several spear phishing emails were identified targeting additional US companies in the utilities sector. The phishing emails originated from what appears to be an actor-controlled domain: globalenergycertification[.]net. This domain, like those used in previous campaigns, impersonated a licensing body related to the utilities sector. In this case, it masqueraded as the legitimate domain for Global Energy Certification (“GEC”). The emails include a GEC examination-themed body and a malicious Microsoft Word attachment that uses macros to install and run LookBack. (Note confusion between Malware, Campaign and ThreatActor)",
       "meta": {
+        "name-attribution": [
+          "TA410:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/threat-insight/post/lookback-forges-ahead-continued-targeting-united-states-utilities-sector-reveals",
           "https://www.proofpoint.com/us/threat-insight/post/lookback-malware-targets-united-states-utilities-sector-phishing-attacks",
@@ -9206,6 +10183,9 @@
     {
       "description": "We are calling these attacks Operation WizardOpium. So far, we have been unable to establish a definitive link with any known threat actors. There are certain very weak code similarities with Lazarus attacks, although these could very well be a false flag. The profile of the targeted website is more in line with earlier DarkHotel attacks that have recently deployed similar false flag attacks.",
       "meta": {
+        "name-attribution": [
+          "Operation WizardOpium:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/chrome-0-day-exploit-cve-2019-13720-used-in-operation-wizardopium/94866/"
         ],
@@ -9220,6 +10200,10 @@
       "description": "For the first time, the activity of the Calypso group was detected by specialists of PT Expert Security Center in March 2019, during the work to detect cyber threats. As a result, many malware samples of this group were obtained, affected organizations and control servers of intruders were identified. According to our data, the group has been active since at least September 2016. The main goal of the group is to steal confidential data, the main victims are government agencies from Brazil, India, Kazakhstan, Russia, Thailand, Turkey. Our data suggest that the group has Asian roots. Description translated from Russian.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Red Lamassu:9f2ba728-8b29-48f9-badf-4f4cefb929f0",
+          "BRONZE MEDLEY:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE MEDLEY": "Secureworks",
         "refs": [
           "https://www.ptsecurity.com/upload/corporate/ru-ru/analytics/calypso-apt-2019-rus.pdf",
@@ -9241,6 +10225,15 @@
       "description": "Proofpoint researchers detected campaigns from a relatively new actor, tracked internally as TA2101, targeting German companies and organizations to deliver and install backdoor malware. The actor initiated their campaigns impersonating the Bundeszentralamt fur Steuern, the German Federal Ministry of Finance, with lookalike domains, verbiage, and stolen branding in the emails. For their campaigns in Germany, the actor chose Cobalt Strike, a commercially licensed software tool that is generally used for penetration testing and emulates the type of backdoor framework used by Metasploit, a similar penetration testing tool. Proofpoint researchers have also observed this actor distributing Maze ransomware, employing similar social engineering techniques to those it uses for Cobalt Strike, while also targeting organizations in Italy and impersonating the Agenzia Delle Entrate, the Italian Revenue Agency. We have also recently observed the actor targeting organizations in the United States using the IcedID banking Trojan while impersonating the United States Postal Service (USPS).",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "TA2101:cae79680-67a6-4411-903c-f824dbcc813f",
+          "TWISTED SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Storm-0216:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0216:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UNC2198:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TUNNEL SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD VILLAGE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:DEV-0216": "Microsoft",
         "origin:GOLD VILLAGE": "Secureworks",
         "origin:Storm-0216": "Microsoft",
@@ -9354,6 +10347,9 @@
     {
       "description": "Operation Wocao (我操, “Wǒ cāo”, used as “shit” or “damn”) is the name that Fox-IT uses to describe the hacking activities of a Chinese based hacking group.\nThis report details the profile of a publicly underreported threat actor that Fox-IT has dealt with over the past two years. Fox-IT assesses with high confidence that the actor is a Chinese group and that they are likely working to support the interests of the Chinese government and are tasked with obtaining information for espionage purposes. With medium confidence, Fox-IT assesses that the tools, techniques and procedures are those of the actor referred to as APT20 by industry partners. We have identified victims of this actor in more than 10 countries, in government entities, managed service providers and across a wide variety of industries, including Energy, Health Care and High-Tech.",
       "meta": {
+        "name-attribution": [
+          "Operation Wocao:4c94ea8e-6bbd-4638-b7ba-34354cfa2281"
+        ],
         "refs": [
           "https://www.fox-it.com/nl/actueel/whitepapers/operation-wocao-shining-a-light-on-one-of-chinas-hidden-hacking-groups/"
         ]
@@ -9386,6 +10382,9 @@
           "Government"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "Attor:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2019/10/10/eset-discovers-attor-spy-platform"
         ]
@@ -9429,6 +10428,9 @@
           "Government"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "InvisiMole:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2018/06/07/invisimole-equipped-spyware-undercover/",
           "https://www.welivesecurity.com/2020/06/18/digging-up-invisimole-hidden-arsenal/"
@@ -9440,6 +10442,9 @@
     {
       "description": "Publicly known as 'EmpireMonkey', ANTHROPOID SPIDER conducted phishing campaigns in February and March 2019, spoofing French, Norwegian and Belizean financial regulators and institutions. These campaigns used macro-enabled Microsoft documents to deliver the PowerShell Empire post-exploitation framework. ANTHROPOID SPIDER likely enabled a breach that allegedly involved fraudulent transfers over the SWIFT network.",
       "meta": {
+        "name-attribution": [
+          "ANTHROPOID SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
           "https://www.kaspersky.com/about/press-releases/2019_fin7-hacking-group-targets-more-than-130-companies-after-leaders-arrest",
@@ -9459,6 +10464,9 @@
     {
       "description": "Opportunistic actor that installs custom root certificate on victim to support man-in-the-middle network monitoring.",
       "meta": {
+        "name-attribution": [
+          "CLOCKWORK SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
           "https://na.eventscloud.com/file_uploads/6568237bca6dc156e5c5557c5989e97c_CrowdStrikeFal.Con2019_ThroughEyesOfAdversary_J.Ayers.pdf"
@@ -9470,6 +10478,10 @@
     {
       "description": "In June 2019, CrowdStrike Intelligence observed a source code fork of BitPaymer and began tracking the new ransomware strain as DoppelPaymer. Further technical analysis revealed an increasing divergence between two versions of Dridex, with the new version dubbed DoppelDridex. Based on this evidence, CrowdStrike Intelligence assessed with high confidence that a new group split off from INDRIK SPIDER to form the adversary DOPPEL SPIDER. Following DOPPEL SPIDER’s inception, CrowdStrike Intelligence observed multiple BGH incidents attributed to the group, with the largest known ransomware demand being 250 BTC. Other demands were not nearly as high, suggesting that the group conducts network reconnaissance to determine the value of the victim organization.",
       "meta": {
+        "name-attribution": [
+          "DOPPEL SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD HERON:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD HERON": "Secureworks",
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
@@ -9485,6 +10497,10 @@
     {
       "description": "Spambots continued to decline in 2019, with MONTY SPIDER’s CraP2P spambot falling silent in April.",
       "meta": {
+        "name-attribution": [
+          "MONTY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Spandex Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
         ],
@@ -9507,6 +10523,12 @@
     {
       "description": "NARWHAL SPIDER’s operation of Cutwail v2 was limited to country-specific spam campaigns, although late in 2019 there appeared to be an effort to expand by bringing in INDRIK SPIDER as a customer.",
       "meta": {
+        "name-attribution": [
+          "NARWHAL SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "TA544:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Storm-0302:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "GOLD ESSEX:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD ESSEX": "Secureworks",
         "origin:Storm-0302": "Microsoft",
         "refs": [
@@ -9530,6 +10552,9 @@
     {
       "description": "Mentioned as MaaS operator in CrowdStrike's 2020 Report.",
       "meta": {
+        "name-attribution": [
+          "NOCTURNAL SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
         ]
@@ -9540,6 +10565,9 @@
     {
       "description": "Mentioned as operator of DanaBot in CrowdStrike's 2020 Report.",
       "meta": {
+        "name-attribution": [
+          "SCULLY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
         ]
@@ -9550,6 +10578,9 @@
     {
       "description": "Mentioned as operator of SmokeLoader in CrowdStrike's 2020 Report.",
       "meta": {
+        "name-attribution": [
+          "SMOKY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf"
         ]
@@ -9560,6 +10591,9 @@
     {
       "description": "VENOM SPIDER is the developer of a large toolset that includes SKID, VenomKit and Taurus Loader. Under the moniker 'badbullzvenom', the adversary has been an active member of Russian underground forums since at least 2012, specializing in the identification of vulnerabilities and the subsequent development of tools for exploitation, as well as for gaining and maintaining access to victim machines and carding services. Recent advertisements for the malware indicate that VENOM SPIDER limits the sale and use of its tools, selling modules only to trusted affiliates. This preference can be seen in the fact that adversaries observed using the tools include the targeted criminal adversary COBALT SPIDER and BGH adversaries WIZARD SPIDER and PINCHY SPIDER.",
       "meta": {
+        "name-attribution": [
+          "VENOM SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020CrowdStrikeGlobalThreatReport.pdf",
           "https://www.esentire.com/web-native-pages/the-hunt-for-venom-spider-part-2"
@@ -9604,6 +10638,9 @@
     {
       "description": "ItaDuke is an actor known since 2013. It used PDF exploits for dropping malware and Twitter accounts to store C2 server urls. On 2018, an actor named DarkUniverse, which was active between 2009 to 2017, was attributed to this ItaDuke by Kaspersky.",
       "meta": {
+        "name-attribution": [
+          "DarkUniverse:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/darkuniverse-the-mysterious-apt-framework-27/94897/",
           "https://www.fireeye.com/blog/threat-research/2013/02/the-number-of-the-beast.html",
@@ -9648,6 +10685,9 @@
           "Government"
         ],
         "country": "KR",
+        "name-attribution": [
+          "Higaisa:f063b54b-293c-4713-87c1-92ff760ee4ba"
+        ],
         "refs": [
           "https://s.tencent.com/research/report/836.html",
           "https://blog.malwarebytes.com/threat-analysis/2020/06/higaisa/"
@@ -9659,6 +10699,10 @@
     {
       "description": "COBALT JUNO has operated since at least 2013 and focused on targets located in the Middle East including Iran, Jordan, Egypt & Lebanon. COBALT JUNO custom spyware families SABER1 and SABER2, include surveillance functionality and masquerade as legitimate software utilities such as Adobe Updater, StickyNote and ASKDownloader. CTU researchers assess with moderate confidence that COBALT JUNO operated the ZooPark Android spyware since at least mid-2015. ZooPark was publicly exposed in 2018 in both vendor reporting and a high profile leak of C2 server data. COBALT JUNO is linked to a private security company in Iran and outsources aspects of tool development work to commercial software developers. CTU researchers have observed the group using strategic web compromises to deliver malware. CTU researchers’ discovery of new C2 domains in 2019 suggest the group is still actively performing operations.",
       "meta": {
+        "name-attribution": [
+          "COBALT JUNO:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "TG-2884 (SCWX CTU):a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:APT-C-38 (QiAnXin)": "QiAnXin",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/cobalt-juno"
@@ -9675,6 +10719,10 @@
     {
       "description": "COBALT KATANA has been active since at least March 2018, and it focuses many of its operations on organizations based in or associated with Kuwait. The group has targeted government, logistics, and shipping organizations. The threat actors gain initial access to targets using DNS hijacking, strategic web compromise with SMB forced authentication, and password brute force attacks. COBALT KATANA operates a custom platform referred to as the Sakabota Framework, also referred to as Sakabota Core, with a complimentary set of modular backdoors and accessory tools including Gon, Hisoka, Hisoka Netero, Killua, Diezen, and Eye. The group has implemented DNS tunnelling in its malware and malicious scripts and also operates the HyphenShell web shell to strengthen post-intrusion access. CTU researchers assess with moderate confidence that COBALT KATANA operates on behalf of Iran, and elements of its operations such as overlapping infrastructure, use of DNS hijacking, implementation of DNS-based C2 channels in malware and web shell security mechanisms suggest connections to COBALT GYPSY and COBALT EDGEWATER.",
       "meta": {
+        "name-attribution": [
+          "Hunter Serpens:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "COBALT KATANA:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/cobalt-katana",
           "https://unit42.paloaltonetworks.com/atoms/hunter-serpens/"
@@ -9704,6 +10752,12 @@
       "description": "GALLIUM, is a threat actor believed to be targeting telecommunication providers over the world, mostly South-East Asia, Europe and Africa. To compromise targeted networks, GALLIUM target unpatched internet-facing services using publicly available exploits and have been known to target vulnerabilities in WildFly/JBoss.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "GALLIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Alloy Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Granite Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "PHANTOM PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.microsoft.com/security/blog/2019/12/12/gallium-targeting-global-telecom/",
           "https://www.youtube.com/watch?v=fBFm2fiEPTg",
@@ -9747,6 +10801,11 @@
     {
       "description": "ESET has analyzed the operations of Evilnum, the APT group behind the Evilnum malware previously seen in attacks against financial technology companies. While said malware has been seen in the wild since at least 2018 and documented previously, little has been published about the group behind it and how it operates. The group’s targets remain fintech companies, but its toolset and infrastructure have evolved and now consist of a mix of custom, homemade malware combined with tools purchased from Golden Chickens, a Malware-as-a-Service (MaaS) provider whose infamous customers include FIN6 and Cobalt Group.",
       "meta": {
+        "name-attribution": [
+          "DeathStalker:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "TA4563:cae79680-67a6-4411-903c-f824dbcc813f",
+          "KNOCKOUT SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:TA4563": "Proofpoint",
         "refs": [
           "https://www.welivesecurity.com/2020/07/09/more-evil-deep-look-evilnum-toolset/",
@@ -9774,6 +10833,13 @@
       "description": "PIONEER KITTEN is an Iran-based adversary that has been active since at least 2017 and has a suspected nexus to the Iranian government. This adversary appears to be primarily focused on gaining and maintaining access to entities possessing sensitive information of likely intelligence interest to the Iranian government. According to DRAGOS, they also targeted ICS-related entities using known VPN vulnerabilities. They are widely known to use open source penetration testing tools for reconnaissance and to establish encrypted communications.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Fox Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "PIONEER KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "PARISITE:e4ed3168-7830-490f-9eed-d1b3ef2daccd",
+          "UNC757:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Lemon Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:UNC757": "Mandiant",
         "refs": [
           "https://youtu.be/pBDu8EGWRC4?t=2492",
@@ -9809,6 +10875,9 @@
     {
       "description": "Rare is the APT group that goes largely undetected for nine years, but XDSpy is just that; a previously undocumented espionage group that has been active since 2011. It has attracted very little public attention, with the exception of an advisory from the Belarusian CERT in February 2020. In the interim, the group has compromised many government agencies and private companies in Eastern Europe and the Balkans.",
       "meta": {
+        "name-attribution": [
+          "XDSpy:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2020/10/02/xdspy-stealing-government-secrets-since-2011/",
           "https://vblocalhost.com/uploads/VB2020-Faou-Labelle.pdf",
@@ -9824,6 +10893,9 @@
     {
       "description": "Evil Corp is an internaltional cybercrime network. In December of 2019 the US Federal Government offered a $5M bounty for information leading to the arrest and conviction of Maksim V. Yakubets for allegedly orchestrating Evil Corp operations.  Responsible for stealing over $100M from businesses and consumers.  The Evil Corp organization is known for utilizing custom strains of malware such as JabberZeus, Bugat and Dridex to steal banking credentials.",
       "meta": {
+        "name-attribution": [
+          "GOLD DRAKE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD DRAKE": "Secureworks",
         "refs": [
           "https://krebsonsecurity.com/2019/12/inside-evil-corp-a-100m-cybercrime-menace/",
@@ -9843,6 +10915,9 @@
       "description": "In April 2020, Crowstrike Falcon OverWatch discovered Iran-based adversary TRACER KITTEN conducting malicious interactive activity against multiple hosts at a telecommunications company in the Europe, Middle East and Africa (EMEA) region. The actor was found operating under valid user accounts, using custom backdoors in combination with SSH tunnels for C2. The adversary leveraged their foothold to conduct a variety of reconnaissance activities, undertake credential harvesting and prepare for data exfiltration.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "TRACER KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2020OverWatchNowheretoHide.pdf"
         ],
@@ -9856,6 +10931,10 @@
     {
       "description": "FIN11 is a well-established financial crime group that has recently focused its operations on ransomware and extortion. The group has been active since 2017 and has been tracked under UNC902 and later on as TEMP.Warlok. In some ways, FIN11 is reminiscent of APT1; they are notable not for their sophistication, but for their sheer volume of activity.(FireEye) Mandiant has also responded to numerous FIN11 intrusions, but we’ve only observed the group successfully monetize access in few instances. This could suggest that the actors cast a wide net during their phishing operations, then choose which victims to further exploit based on characteristics such as sector, geolocation or perceived security posture. Recently, FIN11 has deployed CLOP ransomware and threatened to publish exfiltrated data to pressure victims into paying ransom demands. The group’s shifting monetization methods—from point-of-sale (POS) malware in 2018, to ransomware in 2019, and hybrid extortion in 2020—is part of a larger trend in which criminal actors have increasingly focused on post-compromise ransomware deployment and data theft extortion. Notably, FIN11 includes a subset of the activity security researchers call TA505, Graceful Spider, Gold Evergreen, but we do not attribute TA505’s early operations to FIN11 and caution against using the names interchangeably. Attribution of both historic TA505 activity and more recent FIN11 activity is complicated by the actors’ use of criminal service providers. Like most financially motivated actors, FIN11 doesn’t operate in a vacuum. We believe that the group has used services that provide anonymous domain registration, bulletproof hosting, code signing certificates, and private or semi-private malware. Outsourcing work to these criminal service providers likely enables FIN11 to increase the scale and sophistication of their operations.",
       "meta": {
+        "name-attribution": [
+          "FIN11:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "UNC902:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:FIN11": "Mandiant",
         "origin:TEMP.Warlock": "FireEye",
         "origin:UNC902": "Mandiant",
@@ -9884,6 +10963,9 @@
     {
       "description": "UNC1878 is a financially motivated threat actor that monetizes network access via the deployment of RYUK ransomware. Earlier this year, Mandiant published a blog on a fast-moving adversary deploying RYUK ransomware, UNC1878. Shortly after its release, there was a significant decrease in observed UNC1878 intrusions and RYUK activity overall almost completely vanishing over the summer. But beginning in early fall, Mandiant has seen a resurgence of RYUK along with TTP overlaps indicating that UNC1878 has returned from the grave and resumed their operations.",
       "meta": {
+        "name-attribution": [
+          "UNC1878:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC1878": "Mandiant",
         "refs": [
           "https://twitter.com/anthomsec/status/1321865315513520128",
@@ -9915,6 +10997,12 @@
       "meta": {
         "attribution-confidence": "100",
         "country": "RU",
+        "name-attribution": [
+          "UNC2452:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "NOBELIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Solar Phoenix:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Midnight Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:UNC2452": "Mandiant",
         "refs": [
           "https://medium.com/mitre-attack/identifying-unc2452-related-techniques-9f7b6c7f3714",
@@ -9987,6 +11075,9 @@
     {
       "description": "In early Febuary, 2021 TeamTNT launched a new campaign against Docker and Kubernetes environments. Using a collection of container images that are hosted in Docker Hub, the attackers are targeting misconfigured docker daemons, Kubeflow dashboards, and Weave Scope, exploiting these environments in order to steal cloud credentials, open backdoors, mine cryptocurrency, and launch a worm that is looking for the next victim.\nThey're linked to the First Crypto-Mining Worm to Steal AWS Credentials and Hildegard Cryptojacking malware.\nTeamTNT is a relatively recent addition to a growing number of threats targeting the cloud. While they employ some of the same tactics as similar groups, TeamTNT stands out with their social media presence and penchant for self-promotion. Tweets from the TeamTNT’s account are in both English and German although it is unknown if they are located in Germany.",
       "meta": {
+        "name-attribution": [
+          "Adept Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/hildegard-malware-teamtnt/",
           "https://malpedia.caad.fkie.fraunhofer.de/details/elf.teamtnt",
@@ -10011,6 +11102,11 @@
       "meta": {
         "attribution-confidence": "100",
         "country": "CN",
+        "name-attribution": [
+          "Silk Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "MURKY PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "G0125:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "refs": [
           "https://attack.mitre.org/groups/G0125/",
           "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",
@@ -10069,6 +11165,9 @@
     {
       "description": "RedEcho: The group made heavy use of AXIOMATICASYMPTOTE — a term we use to track infrastructure that comprises ShadowPad C2s, which is shared between several Chinese threat activity groups",
       "meta": {
+        "name-attribution": [
+          "RedEcho:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/redecho-targeting-indian-power-sector/",
           "https://therecord.media/redecho-group-parks-domains-after-public-exposure/"
@@ -10093,6 +11192,13 @@
           "Government"
         ],
         "country": "BY",
+        "name-attribution": [
+          "Ghostwriter:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "UNC1151:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TA445:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Storm-0257:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0257:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0257": "Microsoft",
         "origin:Storm-0257": "Microsoft",
         "origin:UNC1151": "Mandiant",
@@ -10136,6 +11242,9 @@
           "South Korea",
           "Japan"
         ],
+        "name-attribution": [
+          "Yanbian Gang:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.riskiq.com/blog/external-threat-management/yanbian-gang-malware-distribution/",
           "https://www.trendmicro.com/en_us/research/18/k/a-look-into-the-connection-between-xloader-and-fakespy-and-their-possible-ties-with-the-yanbian-gang.html",
@@ -10150,6 +11259,9 @@
     {
       "description": "Crowdstrike Tracks the criminal developer of Nemty ransomware as TRAVELING SPIDER. The actor has been observed to take advantage of single-factor authentication to gain access to victim organizations through Citrix Gateway and send extortion-related emails using the victim’s own Microsoft Office 365 instance.",
       "meta": {
+        "name-attribution": [
+          "TRAVELING SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.cyberscoop.com/coronavirus-hacking-disinformation-ransomware-spearphishing/",
           "https://www.crowdstrike.com/blog/ransomware-preparedness-a-call-to-action/",
@@ -10162,6 +11274,10 @@
     {
       "description": "Crowdstrike tarcks the operators behind the Qbot as MALLARD SPIDER",
       "meta": {
+        "name-attribution": [
+          "MALLARD SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD LAGOON:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD LAGOON": "Secureworks",
         "refs": [
           "https://www.crowdstrike.com/blog/duck-hunting-with-falcon-complete-analyzing-a-fowl-banking-trojan-part-1/",
@@ -10177,6 +11293,9 @@
     {
       "description": "According to Crowdstrike, RIDDLE SPIDER is the operator behind the avaddon ransomware",
       "meta": {
+        "name-attribution": [
+          "RIDDLE SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2021GTR.pdf"
         ]
@@ -10187,6 +11306,10 @@
     {
       "description": "GOLD DUPONT is a financially motivated cybercriminal threat group that specializes in post-intrusion ransomware attacks using 777 (aka Defray777 or RansomExx) malware. Active since November 2018, GOLD DUPONT establishes initial access into victim networks using stolen credentials to remote access services like virtual desktop infrastructure (VDI) or virtual private networks (VPN). From October 2019 to early 2020 the group used GOLD BLACKBURN's TrickBot malware as an initial access vector (IAV) during some intrusions. Since July 2020, the group has also used GOLD SWATHMORE's IcedID (Bokbot) malware as an IAV in some intrusions.",
       "meta": {
+        "name-attribution": [
+          "SPRITE SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD DUPONT:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD DUPONT": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/gold-dupont",
@@ -10203,6 +11326,9 @@
     {
       "description": "SOLAR SPIDER’s phishing campaigns deliver the JSOutProx RAT to financial institutions across Africa, the Middle East, South Asia and Southeast Asia.",
       "meta": {
+        "name-attribution": [
+          "SOLAR SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2021GTR.pdf"
         ],
@@ -10216,6 +11342,9 @@
     {
       "description": "VIKING SPIDER is the criminal group behind the development and distribution of Ragnar Locker ransomware. While public reporting indicates the group began threatening to leak victim data in February 2020, a DLS was not observed until April 2020. The DLS is hosted on Tor, and similar to other actors, proof of data exfiltration is provided before the stolen data is fully leaked. It was also noted that On Dec. 22, 2020, a new post made to MountLocker ransomware’s Tor-hosted DLS was titled 'Cartel News' and included details of a victim of VIKING SPIDER’s Ragnar Locker",
       "meta": {
+        "name-attribution": [
+          "VIKING SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2021GTR.pdf",
           "https://www.crowdstrike.com/blog/double-trouble-ransomware-data-leak-extortion-part-1/",
@@ -10231,6 +11360,9 @@
       "description": "According to Crowdstrike, the NetWalker ransomware is being developed and maintained by a Russian-speaking actor designated as CIRCUS SPIDER. Initially discovered in September 2019and havinga compilation timestamp dating back to 28 August 2019, NetWalker has been found to be used in Big Game Hunting (BGH)-style operations while also being distributed via spam. CIRCUS SPIDER is advertising NetWalkeras being a closed-affiliate program,and verifies applicants before they are being accepted as an affiliate. The requirements rangefrom providing proof of previous revenue in similar affiliates programs, experience in the field and what type of industry the applicantis targeting.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "CIRCUS SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/ransomware-preparedness-a-call-to-action/",
           "https://www.crowdstrike.com/blog/analysis-of-ecrime-menu-style-toolkits/",
@@ -10243,6 +11375,9 @@
     {
       "description": "GOLD EVERGREEN was a financially motivated cybercriminal threat group that operated the Gameover Zeus (aka Mapp, P2P Zeus) botnet until June 2014. It encompasses an expansive and long running criminal conspiracy operated by a confederation of individuals calling themselves The Business Club from the mid 2000s until 2014. GOLD EVERGREEN's technical operation was facilitated primarily through botnets using the Zeus, JabberZeus, and eventually Gameover Zeus malware families. These malware families were designed and maintained by a Russian national Evgeniy Bogachev (aka 'slavik') who was indicted by the U.S. DOJ in 2014 and remains a fugitive.",
       "meta": {
+        "name-attribution": [
+          "GOLD EVERGREEN:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD EVERGREEN": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-evergreen",
@@ -10255,6 +11390,9 @@
     {
       "description": "Crowdstrike tracks the developer of Panda Zeus as BAMBOO SPIDER",
       "meta": {
+        "name-attribution": [
+          "BAMBOO SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2018GlobalThreatReport.pdf",
           "https://www.crowdstrike.com/blog/cutwail-spam-campaign-uses-steganography-to-distribute-urlzone/"
@@ -10266,6 +11404,9 @@
     {
       "description": "BOSON SPIDER is a cyber criminal group, which was first identified in 2015, recently and inexplicably went dark in the spring of 2016, appears to be a tightly knit group operating out of Eastern Europe. They have used a variety of distribution mechanisms such as the infamous (and now defunct) angler exploit kit, and obfuscated JavaScript to reduce the detection by antivirus solutions.",
       "meta": {
+        "name-attribution": [
+          "BOSON SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report_BosonSpider.pdf",
           "https://www.crowdstrike.com/blog/ecrime-ecosystem/"
@@ -10277,6 +11418,9 @@
     {
       "description": "OVERLORD SPIDER, aka The Dark Overlord. Similar to ransomware operators today, OVERLORD SPIDER likely purchased RDP access to compromised servers on underground forums in order to exfiltrate data from corporate networks. The actor was known to attempt to “sell back” the data to the respective victims, threatening to sell the data to interested parties should the victim refuse to pay. There was at least one identified instance of OVERLORD SPIDER successfully selling victim data on an underground market.",
       "meta": {
+        "name-attribution": [
+          "OVERLORD SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/double-trouble-ransomware-data-leak-extortion-part-1"
         ]
@@ -10287,6 +11431,9 @@
     {
       "description": "On May 7, 2019, Mayor Bernard “Jack” Young confirmed that the network for the U.S. City of Baltimore (CoB) was infected with ransomware, which was announced via Twitter1. This infection was later confirmed to be conducted by OUTLAW SPIDER, which is the actor behind the RobbinHood ransomware. The actor demanded to be paid 3 BTC (approximately $17,600 USD at the time) per infected system, or 13 BTC (approximately $76,500 USD at the time) for all infected systems to recover the city’s files.",
       "meta": {
+        "name-attribution": [
+          "OUTLAW SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://statescoop.com/baltimore-ransomware-crowdstrike-extortion/",
           "https://www.crowdstrike.com/blog/double-trouble-ransomware-data-leak-extortion-part-1",
@@ -10303,6 +11450,9 @@
     {
       "description": "MIMIC SPIDER is mentioned in two summary reports only",
       "meta": {
+        "name-attribution": [
+          "MIMIC SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://conferences.law.stanford.edu/cyberday/wp-content/uploads/sites/10/2016/10/2a_15GlobalThreatReport_Extracted.pdf",
           "https://www.crowdstrike.com/blog/double-trouble-ransomware-data-leak-extortion-part-1/"
@@ -10314,6 +11464,9 @@
     {
       "description": "According to Crowdstrike, HOUND SPIDER affiliates arrested in Romania on December,2017",
       "meta": {
+        "name-attribution": [
+          "HOUND SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://go.crowdstrike.com/rs/281-OBQ-266/images/Report2018GlobalThreatReport.pdf"
         ]
@@ -10326,6 +11479,10 @@
       "meta": {
         "cfr-target-category": [
           "Healthcare"
+        ],
+        "name-attribution": [
+          "CYBORG SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD BURLAP:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
         ],
         "origin:GOLD BURLAP": "Secureworks",
         "refs": [
@@ -10358,6 +11515,12 @@
     {
       "description": "GOLD CABIN is a financially motivated cybercriminal threat group operating a malware distribution service on behalf of numerous customers since 2018. GOLD CABIN uses malicious documents, often contained in password-protected archives, delivered through email to download and execute payloads. The second-stage payloads are most frequently Gozi ISFB (Ursnif) or IcedID (Bokbot), sometimes using intermediary malware like Valak. GOLD CABIN infrastructure relies on artificial appearing and frequently changing URLs created with a domain generation algorithm (DGA). The URLs host a PHP object that returns the malware as a DLL file.",
       "meta": {
+        "name-attribution": [
+          "TA551:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Monster Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "GOLD CABIN:a7119872-bc6b-494b-9f7a-8c50faaf53a9",
+          "G0127:a1ad5090-2487-46d2-8237-6151a2dd5063"
+        ],
         "origin:GOLD CABIN": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/gold-cabin",
@@ -10378,6 +11541,9 @@
     {
       "description": "GOLD FAIRFAX is a financially motivated cybercriminal threat group responsible for the creation, distribution, and operation of the Ramnit botnet. Ramnit, the phonetic spelling of RMNet, the internal name of the core module, began operation in April 2010 and became widespread in July 2010. A particularly virulent file-infecting component of early Ramnit variants that spreads by modifying executables and HTML files has resulted in the continued prevalence of those early variants. Currently, Ramnit remains an actively maintained and distributed threat. The intent of Ramnit is to intercept and manipulate online financial transactions through modification of web browser behavior ('man-in-the-browser').",
       "meta": {
+        "name-attribution": [
+          "GOLD FAIRFAX:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD FAIRFAX": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-fairfax"
@@ -10389,6 +11555,9 @@
     {
       "description": "GOLD FLANDERS is a financially motivated group responsible for distributed denial of service (DDOS) attacks linked to extortion emails demanding between 5 and 30 bitcoins. The attacks consist mostly of fragmented UDP packets (DNS and NTP reflection) as well as other traffic that can vary per victim. The arrival of the extortion email is timed to coincide with a DDOS attack consisting of traffic between 20 Gbps and 200 Gbps and 12-15 million packets per second, lasting between 20 and 70 minutes targeted at a particular Autonomous System Number (ASN) or group of IP addresses. In some cases victim organisations have replied to these extortion emails and received personal replies from GOLD FLANDERS operators within 20 minutes. ",
       "meta": {
+        "name-attribution": [
+          "GOLD FLANDERS:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD FLANDERS": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-flanders"
@@ -10400,6 +11569,9 @@
     {
       "description": "GOLD GALLEON is a financially motivated cybercriminal threat group comprised of at least 20 criminal associates that collectively carry out business email compromise (BEC) and spoofing (BES) campaigns. The group appears to specifically target maritime organizations and their customers. CTU researchers have observed GOLD GALLEON targeting firms in South Korea, Japan, Singapore, Philippines, Norway, U.S., Egypt, Saudi Arabia, and Colombia. The threat actors leverage tools, tactics, and procedures that are similar to those used by other BEC/BES groups CTU researchers have previously investigated, such as GOLD SKYLINE. The groups have used the same caliber of publicly available malware (inexpensive and commodity remote access trojans), crypters, and email lures.",
       "meta": {
+        "name-attribution": [
+          "GOLD GALLEON:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD GALLEON": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/gold-galleon-how-a-nigerian-cyber-crew-plunders-the-shipping-industry",
@@ -10412,6 +11584,9 @@
     {
       "description": "GOLD GARDEN was a financially motivated cybercriminal threat group that authored and operated the GandCrab ransomware from January 2018 through May 2019. GandCrab was operated as a ransomware-as-a-service operation whereby numerous affiliates distributed the malware and split ransom payments with the core operators. GOLD GARDEN maintained exclusive control of the development of GandCrab and associated command and control (C2) infrastructure. Individual affiliates, of which there were frequently more than a dozen in operation simultaneously, coordinated the distribution of GandCrab through spam emails, web exploit kits, pay-per-install botnets, and scan-and-exploit style attacks. On May 31, 2019 the operators announced they have halted operations with no intent to resume for unknown reasons. In April 2019 the operators of GOLD GARDEN transferred the source code of GandCrab to GOLD SOUTHFIELD who used it as the foundation of the REvil ransomware operation. GOLD SOUTHFIELD operates a similar affiliate program comprised largely of former GandCrab users and other groups recruited from underground forums.",
       "meta": {
+        "name-attribution": [
+          "GOLD GARDEN:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD GARDEN": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-garden"
@@ -10423,6 +11598,9 @@
     {
       "description": "GOLD MANSARD is a financially motivated cybercriminal threat group that operated the Nemty ransomware from August 2019. The threat actor behind Nemty is known on Russian underground forums as 'jsworm'. Nemty was operated as a ransomware as a service (RaaS) affiliate program and featured a 'name and shame' website where exfiltrated victim data was leaked. In April 2020, jsworm appeared to acquire new partners and retired the Nemty ransomware. This was followed by the introduction of Nefilim ransomware, which does not operate as an affiliate model. Nefilim has been used in post-intrusion ransomware attacks against organizations in logistics, telecommunications, energy and other sectors.",
       "meta": {
+        "name-attribution": [
+          "GOLD MANSARD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD MANSARD": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-mansard"
@@ -10434,6 +11612,9 @@
     {
       "description": "Operational since at least October 2020, GOLD NORTHFIELD is a financially motivated cybercriminal threat group that leverages GOLD SOUTHFIELD's REvil ransomware in their attacks. To do this, the threat actors replace the configuration of the REvil ransomware binary with their own in an effort to repurpose the ransomware for their operations. GOLD NORTHFIELD has given this modified REvil ransomware variant the name 'LV ransomware'.",
       "meta": {
+        "name-attribution": [
+          "GOLD NORTHFIELD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD NORTHFIELD": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-northfield",
@@ -10446,6 +11627,9 @@
     {
       "description": "GOLD RIVERVIEW was a financially motivated cybercriminal group that facilitated the distribution of malware- and scam-laden spam email on behalf of its customers. This threat group authored and sold the Necurs rootkit beginning in early 2014, including to GOLD EVERGREEN who integrated it into Gameover Zeus. GOLD RIVERVIEW also operated a global botnet that was colloquially known as Necurs (CraP2P) and was a major source of spam email from 2016 through 2018. Necurs distributed malware such as GOLD DRAKE's Dridex (Bugat v5), GOLD BLACKBURN's TrickBot, and other families like Locky and FlawedAmmy. Necurs also distributed a large volume of email pushing securities 'pump and dump' scams, rogue pharmacies, and fraudulent dating sites. On March 4, 2019 all three active segments of the Necurs botnet ceased operation and have not since resumed. On March 10, 2020 Microsoft took civil action against GOLD RIVERVIEW and made technical steps that would complicate the threat actors' ability to reconstitute the botnet.",
       "meta": {
+        "name-attribution": [
+          "GOLD RIVERVIEW:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD RIVERVIEW": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-riverview"
@@ -10457,6 +11641,9 @@
     {
       "description": "GOLD SKYLINE is a financially motivated cybercriminal threat group operating from Nigeria engaged in high-value wire fraud facilitated by business email compromise (BEC) and spoofing (BES). Also known as Wire-Wire Group 1 (WWG1), GOLD SKYLINE has been active since at least 2016 and relies heavily on compromised email accounts, social engineering, and increasingly malware to divert inter-organization funds transfers.",
       "meta": {
+        "name-attribution": [
+          "GOLD SKYLINE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD SKYLINE": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-skyline"
@@ -10468,6 +11655,9 @@
     {
       "description": "GOLD SOUTHFIELD is a financially motivated cybercriminal threat group that authors and operates the REvil (aka Sodinokibi) ransomware on behalf of various affiliated threat groups. Operational since April 2019, the group obtained the GandCrab source code from GOLD GARDEN, the operators of GandCrab that voluntarily withdrew their ransomware from underground markets in May 2019. GOLD SOUTHFIELD is responsible for authoring REvil and operating the backend infrastructure used by affiliates (also called partners) to create malware builds and to collect ransom payments from victims. CTU researchers assess with high confidence that GOLD SOUTHFIELD is a former GandCrab affiliate and continues to work with other former GandCrab affiliates.",
       "meta": {
+        "name-attribution": [
+          "GOLD SOUTHFIELD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD SOUTHFIELD": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-southfield",
@@ -10482,6 +11672,9 @@
     {
       "description": "GOLD SYMPHONY is a financially motivated cybercrime group, likely based in Russia, that is responsible for the development and sale on underground forums of the Buer Loader malware. First discovered around August 2019, Buer Loader is offered as a malware-as-a-service (MasS) and has been advertised by a threat actor using the handle 'memeos'. Customers include GOLD BLACKBURN, the operators of the TrickBot malware. In addition to TrickBot, Buer Loader has been reported to download Cobalt Strike and other tools for use in post-intrusion ransomware attacks.",
       "meta": {
+        "name-attribution": [
+          "GOLD SYMPHONY:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD SYMPHONY": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-symphony"
@@ -10493,6 +11686,9 @@
     {
       "description": "GOLD WATERFALL is a group of financially motivated cybercriminals responsible for the creation, distribution, and operation of the Darkside ransomware. Active since August 2020, GOLD WATERFALL uses a variety of tactics, techniques, and procedures (TTPs) to infiltrate and move laterally within targeted organizations to deploy Darkside ransomware to its most valuable resources. Among these TTPs are using malicious documents delivered by email to establish a foothold and using stolen credentials to access victims' remote access services. In November 2020, the 'darksupp' persona was observed advertising an affiliate program on several semi-exclusive underground forums, marking GOLD WATERFALL's entry into the ransomware-as-a-service (RaaS) landscape.",
       "meta": {
+        "name-attribution": [
+          "GOLD WATERFALL:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD WATERFALL": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/gold-waterfall",
@@ -10505,6 +11701,9 @@
     {
       "description": "GOLD WINTER are a financially motivated group, likely based in Russia, who operate the Hades ransomware. Hades activity was first identified in December 2020 and its lack of presence on underground forums and marketplaces leads CTU researchers to conclude that it is not operated under a ransomware as a service affiliate model. GOLD WINTER do employ name-and-shame tactics, where data is stolen and used as additional leverage over victims, but rather than a single centralized leak site CTU researchers have observed the group using Tor sites customized for each victim that include a Tox chat ID for communication, which also appears to be unique for each victim.",
       "meta": {
+        "name-attribution": [
+          "GOLD WINTER:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD WINTER": "Secureworks",
         "refs": [
           "http://www.secureworks.com/research/threat-profiles/gold-winter"
@@ -10533,6 +11732,10 @@
         "cfr-target-category": [
           "Government",
           "Telecomms"
+        ],
+        "name-attribution": [
+          "BackdoorDiplomacy:3a43aca5-6366-4168-b182-a8afec4550b5",
+          "Quarian:3a43aca5-6366-4168-b182-a8afec4550b5"
         ],
         "refs": [
           "https://www.welivesecurity.com/2021/06/10/backdoordiplomacy-upgrading-quarian-turian/"
@@ -10575,6 +11778,9 @@
           "Universities",
           "Religious organization"
         ],
+        "name-attribution": [
+          "Gelsemium:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2021/06/09/gelsemium-when-threat-actors-go-gardening/",
           "https://www.venustech.com.cn/uploads/2018/08/231401512426.pdf",
@@ -10591,6 +11797,9 @@
     {
       "description": "Mentioned as operator of TriumphLoader and Matanbuchus",
       "meta": {
+        "name-attribution": [
+          "Matanbuchus:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/matanbuchus-malware-as-a-service/"
         ],
@@ -10604,6 +11813,9 @@
     {
       "description": "Threat actor Common Raven has been actively targeting financial sector institutions, compromising their SWIFT payment infrastructure to send out fraudulent payments.",
       "meta": {
+        "name-attribution": [
+          "OPERA1ER:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-common-raven-iocs",
           "https://www2.swift.com/isac/report/10118",
@@ -10622,6 +11834,9 @@
       "description": "Since 2017, Mandiant has been tracking FIN13, an industrious and versatile financially motivated threat actor conducting long-term intrusions in Mexico with an activity timeframe stretching back as early as 2016. Although their operations continue through the present day, in many ways FIN13's intrusions are like a time capsule of traditional financial cybercrime from days past. Instead of today's prevalent smash-and-grab ransomware groups, FIN13 takes their time to gather information to perform fraudulent money transfers. Rather than relying heavily on attack frameworks such as Cobalt Strike, the majority of FIN13 intrusions involve heavy use of custom passive backdoors and tools to lurk in environments for the long haul.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "FIN13:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:FIN13": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/fin13-cybercriminal-mexico",
@@ -10663,6 +11878,9 @@
           "Financial"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Antlion:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/china-apt-antlion-taiwan-financial-attacks"
         ]
@@ -10673,6 +11891,9 @@
     {
       "description": "Persistent cybercrime threat actor targeting aviation, aerospace, transportation, manufacturing, and defense industries for years. This threat actor consistently uses remote access trojans (RATs) that can be used to remotely control compromised machines. This threat actor uses consistent themes related to aviation, transportation, and travel. The threat actor has used similar themes and targeting since 2017.",
       "meta": {
+        "name-attribution": [
+          "TA2541:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2541": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/charting-ta2541s-flight"
@@ -10684,6 +11905,9 @@
     {
       "description": "This actor typically distributes instances of the SmokeLoader intermediate downloader, which, in turn, downloads additional malware of the actor’s choice -- often banking Trojans. Figure 3 shows a lure document from a November campaign in which TA516 distributed fake resumes with malicious macros that, if enabled, launch a PowerShell script that downloads SmokeLoader. In this instance, we observed SmokeLoader downloading a Monero coinminer. Since the middle of 2017, TA516 has used similar macro-laden documents as well as malicious JavaScript hosted on Google Drive to distribute both Panda Banker and a coinminer executable via SmokeLoader, often in the same campaigns.",
       "meta": {
+        "name-attribution": [
+          "TA516:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.thaicert.or.th/downloads/files/Threat_Group_Cards_v2.0.pdf"
         ]
@@ -10694,6 +11918,9 @@
     {
       "description": "TA547 is responsible for many other campaigns since at least November 2017. The other campaigns by the actor were often localized to countries such as Australia, Germany, the United Kingdom, and Italy. Delivered malware included ZLoader (a.k.a. Terdot), Gootkit, Ursnif, Corebot, Panda Banker, Atmos, Mazar Bot, and Red Alert Android malware.",
       "meta": {
+        "name-attribution": [
+          "TA547:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.thaicert.or.th/downloads/files/Threat_Group_Cards_v2.0.pdf"
         ]
@@ -10704,6 +11931,9 @@
     {
       "description": "Since May 2018, Proofpoint researchers have observed email campaigns using a new downloader called sLoad. sLoad is a PowerShell downloader that most frequently delivers Ramnit banker and includes noteworthy reconnaissance features. The malware gathers information about the infected system including a list of running processes, the presence of Outlook, and the presence of Citrix-related files. sLoad can also take screenshots and check the DNS cache for specific domains (e.g., targeted banks), as well as load external binaries.\nWhile initial versions of sLoad appeared in May 2018, we began tracking the campaigns from this actor (internally named TA554) since at least the beginning of 2017.",
       "meta": {
+        "name-attribution": [
+          "TA554:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.thaicert.or.th/downloads/files/Threat_Group_Cards_v2.0.pdf"
         ],
@@ -10717,6 +11947,9 @@
     {
       "description": "Beginning in May 2018, Proofpoint researchers observed a previously undocumented downloader dubbed AdvisorsBot appearing in malicious email campaigns. The campaigns appear to primarily target hotels, restaurants, and telecommunications, and are distributed by an actor we track as TA555. To date, we have observed AdvisorsBot used as a first-stage payload, loading a fingerprinting module that, as with Marap, is presumably used to identify targets of interest to further infect with additional modules or payloads. AdvisorsBot is under active development and we have also observed another version of the malware completely rewritten in PowerShell and .NET.",
       "meta": {
+        "name-attribution": [
+          "TA555:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.thaicert.or.th/downloads/files/Threat_Group_Cards_v2.0.pdf"
         ]
@@ -10727,6 +11960,9 @@
     {
       "description": "This attacker is an affiliate distributor of the The Trick, also known as Trickbot, and BazaLoader. (For more on how affiliates work, see the description of TA573).\nTA800 has targeted a wide range of industries in North America, infecting victims with banking Trojans and malware loaders (malware designed to download other malware onto a compromised device). Malicious emails have often included recipients’ names, titles and employers along with phishing pages designed to look like the targeted company. Lures have included hard-to-resist subjects such as related to payment, meetings, termination, bonuses and complaints in the subject line or body of the email.",
       "meta": {
+        "name-attribution": [
+          "TA800:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/q4-2020-threat-report-quarterly-analysis-cybersecurity-trends-tactics-and-themes"
         ]
@@ -10738,6 +11974,13 @@
       "description": "Cybereason Nocturnus describes Moses Staff as an Iranian hacker group, first spotted in October 2021. Their motivation appears to be to harm Israeli companies by leaking sensitive, stolen data.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "MosesStaff:adb3369a-5683-46b2-bceb-4dafa6526b21",
+          "Moses Staff:adb3369a-5683-46b2-bceb-4dafa6526b21",
+          "Marigold Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0500:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "VENGEFUL KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:DEV-0500": "Microsoft",
         "refs": [
           "https://twitter.com/campuscodi/status/1450455259202166799",
@@ -10784,6 +12027,10 @@
           "Germany"
         ],
         "country": "IN",
+        "name-attribution": [
+          "Bitter:1c141c9b-ec78-4f86-a8ea-b02944fa5492",
+          "TA397:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:APT-C-08": "QiAnXin",
         "refs": [
           "https://www.bitdefender.com/files/News/CaseStudies/study/352/Bitdefender-PR-Whitepaper-BitterAPT-creat4571-en-EN-GenericUse.pdf",
@@ -10806,6 +12053,15 @@
     {
       "description": "An actor group conducting large-scale social engineering and extortion campaign against multiple organizations with some seeing evidence of destructive elements.",
       "meta": {
+        "name-attribution": [
+          "LAPSUS:adb3369a-5683-46b2-bceb-4dafa6526b21",
+          "LAPSUS$:adb3369a-5683-46b2-bceb-4dafa6526b21",
+          "DEV-0537:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "SLIPPY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Strawberry Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UNC3661:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Lapsus:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "origin:DEV-0537": "Microsoft",
         "origin:UNC3661": "Mandiant",
         "refs": [
@@ -10844,6 +12100,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Scarab:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://web.archive.org/web/20150124025612/http://www.symantec.com:80/connect/blogs/scarab-attackers-took-aim-select-russian-targets-2012",
           "https://www.sentinelone.com/labs/chinese-threat-actor-scarab-targeting-ukraine"
@@ -10861,6 +12120,9 @@
           "Government"
         ],
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "BladeHawk:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2021/09/07/bladehawk-android-espionage-kurdish/",
           "https://telegra.ph/Discover-Malware-Android-03-26",
@@ -10916,6 +12178,16 @@
       "meta": {
         "GRU": "Military unit 29155",
         "country": "RU",
+        "name-attribution": [
+          "UNC2589:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "TA471:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Nascent Ursa:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Nodaria:e583434b-7fb8-42c8-90ce-89aa8ed35f0c",
+          "Storm-0587:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0587:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "EMBER BEAR:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Cadet Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0587": "Microsoft",
         "origin:Storm-0587": "Microsoft",
         "origin:UNC2589": "Mandiant",
@@ -10958,6 +12230,9 @@
       "description": "Mandiant observed this group operating since December 2019. Its techniques partially overlap with multiple Russian-based espionage actors (APT28 and APT29). They are described as having a high level of operational security, low malware footprint, adept evasive skills, and a large Internet of Things (IoT) device botnet at their disposal.",
       "meta": {
         "cfr-type-of-incident": "Espionage",
+        "name-attribution": [
+          "UNC3524:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC3524": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/unc3524-eye-spy-email"
@@ -10983,6 +12258,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "UNC3742:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC3742": "Mandiant",
         "refs": [
           "https://blog.google/threat-analysis-group/tracking-cyber-activity-eastern-europe",
@@ -11028,6 +12306,9 @@
       "description": "Cosmic Lynx is a Russia-based BEC cybercriminal organization that has significantly impacted the email threat landscape with sophisticated, high-dollar phishing attacks.",
       "meta": {
         "cfr-type-of-incident": "Business Email Compromise",
+        "name-attribution": [
+          "Cosmic Lynx:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.agari.com/cyber-intelligence-research/whitepapers/acid-agari-cosmic-lynx.pdf"
         ]
@@ -11041,6 +12322,9 @@
         "cfr-target-category": [
           "Civil Society"
         ],
+        "name-attribution": [
+          "ModifiedElephant:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/modifiedelephant-apt-and-a-decade-of-fabricating-evidence/"
         ]
@@ -11051,6 +12335,9 @@
     {
       "description": "EXOTIC LILY is a resourceful, financially motivated group whose activities appear to be closely linked with data exfiltration and deployment of human-operated ransomware such as Conti and Diavol. In early September 2021, the group has been obeserved exploiting a 0day in Microsoft MSHTML (CVE-2021-40444). Investigation lead researchers to believe that they are an Initial Access Broker (IAB) who appear to be working with the Russian cyber crime gang known as FIN12 (Mandiant, FireEye) / WIZARD SPIDER (CrowdStrike). This threat actor deploys tactics, techniques and procedures (TTPs) that are traditionally associated with more targeted attacks, like spoofing companies and employees as a means of gaining trust of a targeted organization through email campaigns that are believed to be sent by real human operators using little-to-no automation. Additionally and rather uniquely, they leverage legitimate file-sharing services like WeTransfer, TransferNow and OneDrive to deliver the payload, namely BUMBLEEBEE and BAZARLOADER, further evading detection mechanisms. This level of human-interaction is rather unusual for cyber crime groups focused on mass scale operations.",
       "meta": {
+        "name-attribution": [
+          "DEV-0413:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0413": "Microsoft",
         "refs": [
           "https://www.microsoft.com/security/blog/2021/09/15/analyzing-attacks-that-exploit-the-mshtml-cve-2021-40444-vulnerability",
@@ -11066,6 +12353,9 @@
     {
       "description": "TA578, a threat actor that Proofpoint researchers have been tracking since May of 2020. TA578 has previously been observed in email-based campaigns delivering Ursnif, IcedID, KPOT Stealer, Buer Loader, BazaLoader, and Cobalt Strike.",
       "meta": {
+        "name-attribution": [
+          "TA578:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/bumblebee-is-still-transforming"
         ]
@@ -11076,6 +12366,9 @@
     {
       "description": "TA579, a threat actor that Proofpoint researchers have been tracking since August 2021. This actor frequently delivered BazaLoader and IcedID in past campaigns.",
       "meta": {
+        "name-attribution": [
+          "TA579:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/bumblebee-is-still-transforming"
         ]
@@ -11119,6 +12412,9 @@
           "Military",
           "Government"
         ],
+        "name-attribution": [
+          "ToddyCat:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.bleepingcomputer.com/news/security/new-toddycat-apt-group-targets-exchange-servers-in-asia-europe/",
           "https://securelist.com/toddycat/106799/",
@@ -11159,6 +12455,12 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "LB",
+        "name-attribution": [
+          "POLONIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Plaid Rain:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UNC4453:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "INCENDIARY JACKAL:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:UNC4453": "Mandiant",
         "refs": [
           "https://www.microsoft.com/security/blog/2022/06/02/exposing-polonium-activity-and-infrastructure-targeting-israeli-organizations/",
@@ -11195,6 +12497,9 @@
           "Transportation systems"
         ],
         "cfr-type-of-incident": "Sabotage",
+        "name-attribution": [
+          "Indra:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://www.bbc.com/news/technology-62072480",
           "https://twitter.com/_cpresearch_/status/1541753913732366338",
@@ -11216,6 +12521,11 @@
         ],
         "cfr-type-of-incident": "Sabotage",
         "country": "RU",
+        "name-attribution": [
+          "DEV-0586:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Ruinous Ursa:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Cadet Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0586": "Microsoft",
         "refs": [
           "https://www.microsoft.com/security/blog/2022/01/15/destructive-malware-targeting-ukrainian-organizations/",
@@ -11244,6 +12554,10 @@
     {
       "description": "This group started operating during the first quarter of 2022. They published samples of alleged stolen data from companies on their site on Tor. It is unclear if they conducted the attacks themselves, or if they bought leaked databases from third parties.",
       "meta": {
+        "name-attribution": [
+          "Kinsing:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Money Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/20/k/analysis-of-kinsing-malwares-use-of-rootkit.html",
           "https://blog.aquasec.com/threat-alert-kinsing-malware-container-vulnerability",
@@ -11274,6 +12588,9 @@
           "Education"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Earth Berberoka:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Berberoka": "Trend Micro",
         "refs": [
           "https://documents.trendmicro.com/assets/white_papers/wp-operation-earth-berberoka.pdf",
@@ -11327,6 +12644,13 @@
           "Covid-19 research organizations"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Earth Lusca:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "TAG-22:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "AQUATIC PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Charcoal Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE UNIVERSITY:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE UNIVERSITY": "Secureworks",
         "origin:Earth Lusca": "Trend Micro",
         "refs": [
@@ -11442,6 +12766,9 @@
           "Education"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Earth Wendigo:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Wendigo": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/21/a/earth-wendigo-injects-javascript-backdoor-to-service-worker-for-.html"
@@ -11459,6 +12786,9 @@
           "Vietnam"
         ],
         "country": "CN",
+        "name-attribution": [
+          "BRONZE EDGEWOOD:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE EDGEWOOD": "Secureworks",
         "refs": [
           "https://www.pwc.co.uk/cyber-security/pdf/pwc-cyber-threats-2020-a-year-in-retrospect.pdf",
@@ -11485,6 +12815,10 @@
           "Defense industrial base"
         ],
         "country": "CN",
+        "name-attribution": [
+          "APT9:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "NIGHTSHADE PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://otx.alienvault.com/pulse/55bbc68e67db8c2d547ae393",
           "https://www.pwc.com/gx/en/issues/cybersecurity/cyber-threat-intelligence/cyber-year-in-retrospect/yir-cyber-threats-report-download.pdf",
@@ -11530,6 +12864,10 @@
           "Defense industrial base"
         ],
         "country": "CN",
+        "name-attribution": [
+          "UNC302:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "BRONZE SPRING:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE SPRING": "Secureworks",
         "origin:UNC302": "Mandiant",
         "refs": [
@@ -11550,6 +12888,11 @@
       "description": "BRONZE STARLIGHT has been active since mid 2021 and targets organizations globally across a range of industry verticals. The group leverages HUI Loader to load Cobalt Strike and PlugX payloads for command and control. CTU researchers have observed BRONZE STARLIGHT deploying ransomware to compromised networks as part of name-and-shame ransomware schemes, and posted victim names to leak sites. \nCTU researchers assess with moderate confidence that BRONZE STARLIGHT is located in China based on observed tradecraft, including the use of HUI Loader and PlugX which are associated with China-based threat group activity. It is plausible that BRONZE STARLIGHT deploys ransomware as a smokescreen rather than for financial gain, with the underlying motivation of stealing intellectual property theft or conducting espionage.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "DEV-0401:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Cinnamon Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE STARLIGHT:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE STARLIGHT": "Secureworks",
         "origin:DEV-0401": "Microsoft",
         "refs": [
@@ -11595,6 +12938,10 @@
           "Nigeria"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Evasive Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "BRONZE HIGHLAND:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE HIGHLAND": "Secureworks",
         "refs": [
           "https://blog.malwarebytes.com/threat-analysis/2020/07/chinese-apt-group-targets-india-and-hong-kong-using-new-variant-of-mgbot-malware",
@@ -11614,6 +12961,9 @@
       "description": "In December 2020, the IT management software provider SolarWinds announced that an unidentified threat actor had exploited a vulnerability in their Orion Platform software to deploy a web shell dubbed SUPERNOVA. CTU researchers track the operators of the SUPERNOVA web shell as BRONZE SPIRAL and assess with low confidence that the group is of Chinese origin. SUPERNOVA was likely deployed through exploitation of CVE-2020-10148, and CTU researchers observed post-exploitation reconnaissance commands roughly 30 minutes before the web shell was deployed. This may have been indicative of the threat actor conducting scan-and-exploit activity and then triaging for victims of particular interest, before deploying SUPERNOVA and attempting to dump credentials and move laterally.\n\nBRONZE SPIRAL has been associated with previous intrusions involving the targeting of ManageEngine servers, maintenance of long-term access to periodically harvest credentials and exfiltrate data, and espionage or theft of intellectual property. The threat group makes extensive use of native system tools and 'living off the land' techniques.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "BRONZE SPIRAL:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE SPIRAL": "Secureworks",
         "refs": [
           "https://unit42.paloaltonetworks.com/solarstorm-supernova",
@@ -11637,6 +12987,9 @@
           "Semiconductor Industry"
         ],
         "country": "CN",
+        "name-attribution": [
+          "BRONZE VAPOR:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE VAPOR": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/bronze-vapor"
@@ -11655,6 +13008,9 @@
           "Ukraine"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Vicious Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://securelist.com/microcin-is-here/97353",
           "https://securelist.com/a-simple-example-of-a-complex-cyberattack/82636",
@@ -11698,6 +13054,9 @@
     {
       "description": "Prying Libra, also known as Pickaxe, is a threat actor active since at least August 2017, and continues to remain active to this day. The adversary's goal is to install and maintain a popular cryptocurrency miner on the victim's machine. The miner in question is an open-source tool named XMRig that generates the Monero cryptocurrency. Malware is delivered via downloads through the popular Adfly advertisement platform. Users are often mislead into clicking on a malicious advertisement that results in the payload being delivered to the victim. Once installed, the malware leverages VBS scripts and redirection services, such as bitly, to ultimately download and execute XMRig. Over 15 million confirmed victims have been discovered to be infected in recent campaigns, with actual numbers likely to be between 30-45 million victims. The victims are found across the globe, with high concentrations in Thailand, Vietnam, Egypt, Indonesia, and Turkey.",
       "meta": {
+        "name-attribution": [
+          "Prying Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/atoms/pryinglibra/"
         ],
@@ -11711,6 +13070,9 @@
     {
       "description": "Thief Libra is a cloud-focused threat group that has a history of cryptojacking operations as well as cloud service platform credential scraping. They were first known to operate on January 27, 2019. They use a variety of custom build Go Scripts as well as repurposed cryptojacking scripts from other groups including TeamTNT. They are currently considered to be an opportunistic threat group that targets exposed cloud instances and applications.",
       "meta": {
+        "name-attribution": [
+          "Thief Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/atoms/thieflibra/"
         ],
@@ -11724,6 +13086,9 @@
     {
       "description": "Returned Libra, also known as 8220 Mining Group, is a cloud threat actor group that has been active since at least 2017. Tools commonly employed during their operations are PwnRig or DBUsed which are customized variants of the XMRig Monero mining software. The Returned Libra mining group is believed to have originated from a GitHub fork of the Rocke group's software. Returned Libra has elevated its mining operations with the use of cloud service platform credential scrapping.",
       "meta": {
+        "name-attribution": [
+          "Returned Libra:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/atoms/returnedlibra/"
         ],
@@ -11800,6 +13165,10 @@
           "Private Sector"
         ],
         "country": "CN",
+        "name-attribution": [
+          "GOBLIN PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Cycldek:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-august-goblin-panda/",
           "https://securelist.com/cycldek-bridging-the-air-gap/97157/",
@@ -11818,6 +13187,9 @@
     {
       "description": "Since 2018, security researchers tracked a financially-motivated cybercrime actor, TA558, targeting hospitality, travel, and related industries located in Latin America and sometimes North America, and western Europe. The actor sends malicious emails written in Portuguese, Spanish, and sometimes English. The emails use reservation-themed lures with business-relevant themes such as hotel room bookings. The emails may contain malicious attachments or URLs aiming to distribute one of at least 15 different malware payloads.",
       "meta": {
+        "name-attribution": [
+          "TA558:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "sources": [
           "https://www.proofpoint.com/us/blog/threat-insight/reservations-requested-ta558-targets-hospitality-and-travel"
         ]
@@ -11828,6 +13200,9 @@
     {
       "description": "One actor that has emerged in this trend of human-operated attacks is an active, highly adaptive group that frequently drops Wadhrama as payload.\n PARINACOTA impacts three to four organizations every week and appears quite resourceful: during the 18 months that we have been monitoring it, we have observed the group change tactics to match its needs and use compromised machines for various purposes, including cryptocurrency mining, sending spam emails, or proxying for other attacks. The group’s goals and payloads have shifted over time, influenced by the type of compromised infrastructure, but in recent months, they have mostly deployed the Wadhrama ransomware.\nThe group most often employs a smash-and-grab method, whereby they attempt to infiltrate a machine in a network and proceed with subsequent ransom in less than an hour. There are outlier campaigns in which they attempt reconnaissance and lateral movement, typically when they land on a machine and network that allows them to quickly and easily move throughout the environment.\nPARINACOTA’s attacks typically brute forces their way into servers that have Remote Desktop Protocol (RDP) exposed to the internet, with the goal of moving laterally inside a network or performing further brute-force activities against targets outside the network. This allows the group to expand compromised infrastructure under their control. Frequently, the group targets built-in local administrator accounts or a list of common account names. In other instances, the group targets Active Directory (AD) accounts that they compromised or have prior knowledge of, such as service accounts of known vendors.\nThe group adopted the RDP brute force technique that the older ransomware called Samas (also known as SamSam) infamously used. Other malware families like GandCrab, MegaCortext, LockerGoga, Hermes, and RobbinHood have also used this method in targeted ransomware attacks. PARINACOTA, however, has also been observed to adapt to any path of least resistance they can utilize. For instance, they sometimes discover unpatched systems and use disclosed vulnerabilities to gain initial access or elevate privileges.",
       "meta": {
+        "name-attribution": [
+          "Wine Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.microsoft.com/security/blog/2020/03/05/human-operated-ransomware-attacks-a-preventable-disaster/"
         ],
@@ -11897,6 +13272,10 @@
           "Telecommunications"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Aoqin Dragon:996c48de-7bb8-414d-b6fe-ec94abb5f461",
+          "UNC94:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/aoqin-dragon-newly-discovered-chinese-linked-apt-has-been-quietly-spying-on-organizations-for-10-years/",
           "https://khonggianmang.vn/uploads/CB_941_Canhbao_APT_36c5a857fa.pdf"
@@ -11917,6 +13296,9 @@
           "Cameroon",
           "Senegal",
           "Togo"
+        ],
+        "name-attribution": [
+          "DangerousSavanna:adb3369a-5683-46b2-bceb-4dafa6526b21"
         ],
         "refs": [
           "https://research.checkpoint.com/2022/dangeroussavanna-two-year-long-campaign-targets-financial-institutions-in-french-speaking-africa/"
@@ -11965,6 +13347,11 @@
         "cfr-type-of-incident": [
           "Denial of service"
         ],
+        "name-attribution": [
+          "NoName057(16):996c48de-7bb8-414d-b6fe-ec94abb5f461",
+          "NoName057:996c48de-7bb8-414d-b6fe-ec94abb5f461",
+          "NoName05716:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://decoded.avast.io/martinchlumecky/bobik/",
           "https://www.sentinelone.com/labs/noname05716-the-pro-russian-hacktivist-group-targeting-nato/",
@@ -11983,6 +13370,9 @@
     {
       "description": "BITWISE SPIDER has recently and quickly become a significant player in the big game hunting (BGH) landscape. Their dedicated leak site (DLS) has received the highest number of victims posted each month since July 2021 compared to other adversary DLSs due to the growing popularity and effectiveness of LockBit 2.0.",
       "meta": {
+        "name-attribution": [
+          "BITWISE SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/better-together-global-attitude-survey-takeaways-2021/",
           "https://socradar.io/lockbit-3-another-upgrade-to-worlds-most-active-ransomware/",
@@ -12033,6 +13423,9 @@
           "United Kingdom",
           "United States"
         ],
+        "name-attribution": [
+          "Void Balaur:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/the-sprawling-infrastructure-of-a-careless-mercenary/",
           "https://blog.google/threat-analysis-group/countering-hack-for-hire-groups/",
@@ -12066,6 +13459,10 @@
           "Germany"
         ],
         "country": "RU",
+        "name-attribution": [
+          "Storm-0978:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UAT-5647:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "origin:Storm-0978": "Microsoft",
         "refs": [
           "https://blogs.blackberry.com/en/2022/11/romcom-spoofing-solarwinds-keepass",
@@ -12088,6 +13485,11 @@
     {
       "description": "GOLD PRELUDE is a financially motivated cybercriminal threat group that operates the SocGholish (aka FAKEUPDATES) malware distribution network. GOLD PRELUDE operates a large global network of compromised websites, frequently running vulnerable content management systems (CMS), that redirect into a malicious traffic distribution system (TDS). The TDS, which researchers at Avast have named Parrot TDS, uses opaque criteria to select victims to serve a fake browser update page. These pages, which are customized to the specific visiting browser software, download the JavaScript-based SocGholish payload frequently embedded within a compressed archive.",
       "meta": {
+        "name-attribution": [
+          "TA569:cae79680-67a6-4411-903c-f824dbcc813f",
+          "UNC1543:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "GOLD PRELUDE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD PRELUDE": "Secureworks",
         "origin:UNC1543": "Mandiant",
         "refs": [
@@ -12113,6 +13515,10 @@
     {
       "description": "BazarCall campaigns forgo malicious links or attachments in email messages in favor of phone numbers that recipients are misled into calling. It’s a technique reminiscent of vishing and tech support scams where potential victims are being cold called by the attacker, except in BazarCall’s case, targeted users must dial the number. And when they do, the users are connected with actual humans on the other end of the line, who then provide step-by-step instructions for installing malware into their devices.",
       "meta": {
+        "name-attribution": [
+          "BazarCall:3176f708-da5b-4c41-926b-0a94ebeb0e3b",
+          "BazaCall:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.trellix.com/en-us/about/newsroom/stories/research/evolution-of-bazarcall-social-engineering-tactics.html",
           "https://www.microsoft.com/en-us/security/blog/2021/07/29/bazacall-phony-call-centers-lead-to-exfiltration-and-ransomware/"
@@ -12143,6 +13549,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Evasive Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "BRONZE HIGHLAND:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE HIGHLAND": "Secureworks",
         "refs": [
           "https://blog.malwarebytes.com/threat-analysis/2020/07/chinese-apt-group-targets-india-and-hong-kong-using-new-variant-of-mgbot-malware/",
@@ -12178,6 +13588,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "TA511:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://medium.com/walmartglobaltech/man1-moskal-hancitor-and-a-side-of-ransomware-d77b4d991618",
           "https://vixra.org/abs/1902.0257",
@@ -12212,6 +13625,10 @@
       "description": "One of the most active Qbot malware affiliates, Proofpoint has tracked the large cybercrime threat actor TA570 since 2018.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "TA570:cae79680-67a6-4411-903c-f824dbcc813f",
+          "DEV-0450:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0450": "Microsoft",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/first-step-initial-access-leads-ransomware",
@@ -12245,6 +13662,9 @@
     {
       "description": "TA575 is a Dridex affiliate tracked by Proofpoint since late 2020. This group distributes malware such as Dridex, Qakbot, and WastedLocker via malicious URLs, Office attachments, and password-protected files. On average, TA575 distributes almost 4,000 messages per campaign impacting hundreds of organizations.",
       "meta": {
+        "name-attribution": [
+          "TA575:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://blogs.blackberry.com/en/2021/08/blackberry-prevents-threat-actor-group-ta575-and-dridex-malware",
           "https://www.proofpoint.com/us/blog/threat-insight/ta575-uses-squid-game-lures-distribute-dridex-malware",
@@ -12303,6 +13723,9 @@
       "description": "TA577 is a prolific cybercrime threat actor tracked by Proofpoint since mid-2020. This actor conducts broad targeting across various industries and geographies, and Proofpoint has observed TA577 deliver payloads including Qbot, IcedID, SystemBC, SmokeLoader, Ursnif, and Cobalt Strike.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "TA577:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/first-step-initial-access-leads-ransomware",
           "https://thehackernews.com/2021/06/ransomware-attackers-partnering-with.html",
@@ -12371,6 +13794,9 @@
       "description": "TA2536, which has been active since at least 2015, is likely Nigerian based on its unique linguistic style, tactics and tools. It uses keyloggers such as HawkEye and distinctive stylometric features in typo-squatted domains that resemble legitimate names and the use of recurring names and substrings in email addresses.",
       "meta": {
         "country": "NG",
+        "name-attribution": [
+          "TA2536:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2536": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/dtpacker-net-packer-curious-password-1"
@@ -12432,6 +13858,9 @@
           "European Union"
         ],
         "country": "CN",
+        "name-attribution": [
+          "DEV-0147:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0147": "Microsoft",
         "refs": [
           "https://twitter.com/MsftSecIntel/status/1625181255754039318"
@@ -12461,6 +13890,9 @@
           "NGOs"
         ],
         "country": "KP",
+        "name-attribution": [
+          "TA406:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/triple-threat-north-korea-aligned-ta406-scams-spies-and-steals",
           "https://www.proofpoint.com/us/blog/threat-insight/ta406-pivots-front"
@@ -12508,6 +13940,10 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "IR",
+        "name-attribution": [
+          "APT42:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "UNC788:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC788": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/apt42-charms-cons-compromises",
@@ -12541,6 +13977,9 @@
       "description": "TA453 has employed the use of compromised accounts, malware, and confrontational lures to go after targets with a range of backgrounds from medical researchers to realtors to travel agencies.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "TA453:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/ta453-refuses-be-bound-expectations",
           "https://www.proofpoint.com/us/blog/threat-insight/badblood-ta453-targets-us-and-israeli-medical-research-personnel-credential"
@@ -12586,6 +14025,9 @@
         "cfr-target-category": [
           "Aviation",
           "Energy"
+        ],
+        "name-attribution": [
+          "Chamelgang:996c48de-7bb8-414d-b6fe-ec94abb5f461"
         ],
         "refs": [
           "https://www.ptsecurity.com/ww-en/analytics/pt-esc-threat-intelligence/new-apt-group-chamelgang/",
@@ -12663,6 +14105,11 @@
       "description": "Microsoft threat intelligence teams have been tracking multiple ransomware campaigns and have tied these attacks to DEV-0270, also known as Nemesis Kitten, a sub-group of Iranian actor PHOSPHORUS. Microsoft assesses with moderate confidence that DEV-0270 conducts malicious network operations, including widespread vulnerability scanning, on behalf of the government of Iran.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "DEV-0270:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Nemesis Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Storm-0270:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0270": "Microsoft",
         "origin:Storm-0270": "Microsoft",
         "refs": [
@@ -12689,6 +14136,11 @@
       "description": "PROPHET SPIDER is an eCrime actor, active since at least May 2017, that primarily gains access to victims by compromising vulnerable web servers, which commonly involves leveraging a variety of publicly disclosed vulnerabilities. The adversary has likely functioned as an access broker — handing off access to a third party to deploy ransomware — in multiple instances.",
       "meta": {
         "country": "",
+        "name-attribution": [
+          "Prophet Spider:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "UNC961:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "GOLD MELODY:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD MELODY": "Secureworks",
         "origin:UNC961": "Mandiant",
         "refs": [
@@ -12726,6 +14178,9 @@
       "meta": {
         "cfr-type-of-incident": "Financial Theft",
         "motive": "mainly financially motivated, additional espionage objective.",
+        "name-attribution": [
+          "TA866:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/screentime-sometimes-it-feels-like-somebodys-watching-me"
         ]
@@ -12855,6 +14310,9 @@
     {
       "description": "• APT43 is a prolific cyber operator that supports the interests of the North Korean regime. The group combines moderately-sophisticated technical capabilities with aggressive social engineering tactics, especially against South Korean and U.S.-based government organizations, academics, and think tanks focused on Korean peninsula geopolitical issues. \n• In addition to its espionage campaigns, we believe APT43 funds itself through cybercrime operations to support its primary mission of collecting strategic intelligence. \n• The group creates numerous spoofed and fraudulent personas for use in social engineering, as well as cover identities for purchasing operational tooling and infrastructure. \n• APT43 has collaborated with other North Korean espionage operators on multiple operations, underscoring the major role APT43 plays in the regime’s cyber apparatus.",
       "meta": {
+        "name-attribution": [
+          "APT43:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://www.mandiant.com/resources/blog/apt43-north-korea-cybercrime-espionage",
           "https://mandiant.widen.net/s/zvmfw5fnjs/apt43-report"
@@ -12866,6 +14324,9 @@
     {
       "description": "Hagga is believed to have been using Agent Tesla, 2021’s sixth most prevalent malware, to steal sensitive information from his victims since the latter part of 2021.",
       "meta": {
+        "name-attribution": [
+          "Aggah:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://www.team-cymru.com/post/an-analysis-of-infrastructure-linked-to-the-hagga-threat-actor",
           "https://otx.alienvault.com/pulse/62cfe4ef3415be5f83be81d1",
@@ -12893,6 +14354,15 @@
       "description": "[Microsoft] Volt Typhoon, a state-sponsored actor based in China that typically focuses on espionage and information gathering. Microsoft assesses with moderate confidence that this Volt Typhoon campaign is pursuing development of capabilities that could disrupt critical communications infrastructure between the United States and Asia region during future crises.\n\n[Secureworks] BRONZE SILHOUETTE likely operates on behalf the PRC. The targeting of U.S. government and defense organizations for intelligence gain aligns with PRC requirements, and the tradecraft observed in these engagements overlap with other state-sponsored Chinese threat groups.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Volt Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "VANGUARD PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "UNC3236:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "VOLTZITE:e4ed3168-7830-490f-9eed-d1b3ef2daccd",
+          "Dev-0391:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Storm-0391:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "BRONZE SILHOUETTE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:BRONZE SILHOUETTE": "Secureworks",
         "origin:Storm-0391": "Microsoft",
         "origin:UNC3236": "Mandiant",
@@ -12927,6 +14397,9 @@
     {
       "description": "The campaign, called SmugX, overlaps with previously reported activity by Chinese APT actors RedDelta and Mustang Panda. Although those two correlate to some extent with Camaro Dragon, there is insufficient evidence to link the SmugX campaign to the Camaro Dragon group.\n\nThe campaign uses new delivery methods to deploy (most notably – HTML Smuggling) a new variant of PlugX, an implant commonly associated with a wide variety of Chinese threat actors. Although the payload itself remains similar to the one found in older PlugX variants, its delivery methods results in low detection rates, which until recently helped the campaign fly under the radar.",
       "meta": {
+        "name-attribution": [
+          "SmugX:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2023/chinese-threat-actors-targeting-europe-in-smugx-campaign/"
         ]
@@ -12978,6 +14451,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Worok:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/2022/09/06/worok-big-picture/"
         ]
@@ -13001,6 +14477,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "BY",
+        "name-attribution": [
+          "MoustachedBouncer:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/moustachedbouncer-espionage-against-foreign-diplomats-in-belarus/"
         ]
@@ -13011,6 +14490,11 @@
     {
       "description": "The threat actor that Microsoft tracks as Storm-0324 is a financially motivated group known to gain initial access using email-based initial infection vectors and then hand off access to compromised networks to other threat actors. These handoffs frequently lead to ransomware deployment.",
       "meta": {
+        "name-attribution": [
+          "Storm-0324:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0324:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TA543:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:DEV-0324": "Microsoft",
         "origin:Storm-0324": "Microsoft",
         "refs": [
@@ -13052,6 +14536,13 @@
     {
       "description": "Scattered Spider, a highly active hacking group, has made headlines by targeting more than 130 organizations, with the number of victims steadily increasing.",
       "meta": {
+        "name-attribution": [
+          "Scattered Spider:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "UNC3944:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Octo Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Storm-0971:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0971:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0971": "Microsoft",
         "origin:Storm-0971": "Microsoft",
         "origin:UNC3944": "Mandiant",
@@ -13119,6 +14610,9 @@
           "Ukraine",
           "European Union"
         ],
+        "name-attribution": [
+          "Void Rabisu:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/23/j/void-rabisu-targets-female-leaders-with-new-romcom-variant.html",
           "https://www.trendmicro.com/en_za/research/23/e/void-rabisu-s-use-of-romcom-backdoor-shows-a-growing-shift-in-th.html"
@@ -13150,6 +14644,9 @@
       "description": "In early 2023, the Check Point Incident Response Team (CPIRT) team investigated a malware incident at a European healthcare institution involving a set of tools mentioned in the Avast report in late 2022. The incident was attributed to Camaro Dragon, a Chinese-based espionage threat actor whose activities overlap with activities tracked by different researchers as Mustang Panda and LuminousMoth, whose focus is primarily on Southeast Asian countries and their close peers.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Camaro Dragon:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2023/the-dragon-who-sold-his-camaro-analyzing-custom-router-implant/",
           "https://research.checkpoint.com/2023/beyond-the-horizon-traveling-the-world-on-camaro-dragons-usb-flash-drives/"
@@ -13172,6 +14669,9 @@
         ],
         "cfr-type-of-incident": "Espionage",
         "country": "CN",
+        "name-attribution": [
+          "Storm-0558:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0558": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/07/14/analysis-of-storm-0558-techniques-for-unauthorized-email-access/",
@@ -13191,6 +14691,9 @@
       "description": "Scarred Manticore has been pursuing high-value targets for years, utilizing a variety of IIS-based backdoors to attack Windows servers. These include a variety of custom web shells, custom DLL backdoors, and driver-based implants.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Scarred Manticore:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2023/from-albania-to-the-middle-east-the-scarred-manticore-is-listening/"
         ]
@@ -13201,6 +14704,9 @@
     {
       "description": "The threat group behind EnemyBot, Keksec, is well-resourced and has the ability to update and add new capabilities to its arsenal of malware on a daily basis (see below for more detail on Keksec)",
       "meta": {
+        "name-attribution": [
+          "Keksec:bfafdca5-3171-4953-86ab-c74f44822fd3"
+        ],
         "refs": [
           "https://www.fortinet.com/blog/threat-research/enemybot-a-look-into-keksecs-latest-ddos-botnet",
           "https://www.cybersecurity-insiders.com/rapidly-evolving-iot-malware-enemybot-now-targeting-content-management-system-servers-and-android-devices/?utm_source=rss&utm_medium=rss&utm_campaign=rapidly-evolving-iot-malware-enemybot-now-targeting-content-management-system-servers-and-android-devices",
@@ -13215,6 +14721,10 @@
       "description": "Xiaoqiying is a primarily Chinese-speaking threat group that is most well known for conducting website defacement and data exfiltration attacks on more than a dozen South Korean research and academic institutions in late-January 2023. Research from Recorded Futures Insikt Group has found that the groups affiliated threat actors have signaled a new round of cyberattacks against organizations in Japan and Taiwan. Although it shows no clear ties to the Chinese government, Xiaoqiying is staunchly pro-China and vows to target NATO countries as well as any country or region that is deemed hostile to China.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Xiaoqiying:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "Genesis Day:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/xiaoqiying-genesis-day-threat-actor-group-targets-south-korea-taiwan",
           "https://medium.com/s2wblog/%E5%8F%98%E8%84%B8-teng-snake-a-k-a-code-core-8c35268b4d1a",
@@ -13235,6 +14745,10 @@
           "Germany"
         ],
         "country": "RU",
+        "name-attribution": [
+          "TA473:cae79680-67a6-4411-903c-f824dbcc813f",
+          "TAG-70:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/winter-vivern-uncovering-a-wave-of-global-espionage/",
           "https://www.domaintools.com/resources/blog/winter-vivern-a-look-at-re-crafted-government-maldocs",
@@ -13259,6 +14773,9 @@
       "description": "UNC3886 is an advanced cyber espionage group with unique capabilities in how they operate on-network as well as the tools they utilize in their campaigns. UNC3886 has been observed targeting firewall and virtualization technologies which lack EDR support. Their ability to manipulate firewall firmware and exploit a zero-day indicates they have curated a deeper-level of understanding of such technologies. UNC3886 has modified publicly available malware, specifically targeting *nix operating systems.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC3886:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC3886": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/fortinet-malware-ecosystem",
@@ -13273,6 +14790,9 @@
     {
       "description": "Earth Longzhi is a subgroup of APT41 targeting organizations based in Taiwan, Thailand, the Philippines, and Fiji, and using “stack rumbling” via Image File Execution Options (IFEO), a new denial-of-service (DoS) technique to disable security software.",
       "meta": {
+        "name-attribution": [
+          "Earth Longzhi:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Longzhi": "Trend Micro",
         "refs": [
           "https://www.picussecurity.com/resource/blog/cyber-threat-intelligence-report-may-2023",
@@ -13312,6 +14832,9 @@
     {
       "description": "Trend Micro found that Earth Estries relies heavily on DLL sideloading to load various tools within its arsenal. Aside from the backdoors previously mentioned, this intrusion set also utilizes commonly used remote control tools like Cobalt Strike, PlugX, or Meterpreter stagers interchangeably in various attack stages. These tools come as encrypted payloads loaded by custom loader DLLs.",
       "meta": {
+        "name-attribution": [
+          "Earth Estries:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Estries": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/23/h/earth-estries-targets-government-tech-for-cyberespionage.html",
@@ -13336,6 +14859,9 @@
         "cfr-suspected-victims": [
           "Germany"
         ],
+        "name-attribution": [
+          "GoldenJackal:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/it-threat-evolution-q2-2023/110355/",
           "https://securelist.com/goldenjackal-apt-group/109677/",
@@ -13348,6 +14874,9 @@
     {
       "description": "Lancefly targets government, aviation, and telecom organizations in South and Southeast Asia. They use a custom backdoor named Merdoor, developed since 2018, and employ various tactics to gain access, including phishing emails, SSH credential brute-forcing, and exploiting server vulnerabilities. Additionally, Lancefly has been observed using a newer version of the ZXShell rootkit and tools like PlugX and ShadowPad RAT, which are typically associated with Chinese-speaking APT groups.",
       "meta": {
+        "name-attribution": [
+          "Lancefly:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/lancefly-merdoor-zxshell-custom-backdoor"
         ]
@@ -13369,6 +14898,9 @@
       "description": "The cyberattack campaign that Microsoft uncovered was launched by a China-linked hacking group called Storm-0062. According to the company, the group is launching cyberattacks by exploiting a vulnerability in the Data Center and Server editions of Confluence. Those are versions of the application that companies run on-premises.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Storm-0062:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0062": "Microsoft",
         "refs": [
           "https://techcommunity.microsoft.com/t5/microsoft-365-defender-blog/monthly-news-november-2023/ba-p/3970796",
@@ -13413,6 +14945,11 @@
           "Germany"
         ],
         "country": "KZ",
+        "name-attribution": [
+          "YoroTrooper:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7",
+          "ShadowSilk:21afba9e-cd2a-45c9-b421-b1f14fd181e9",
+          "Silent Lynx:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/attributing-yorotrooper/",
           "https://blog.talosintelligence.com/yorotrooper-espionage-campaign-cis-turkey-europe/",
@@ -13439,6 +14976,9 @@
     {
       "description": "Metador primarily targets telecommunications, internet service providers, and universities in several countries in the Middle East and Africa. Metador’s attack chains are designed to bypass native security solutions while deploying malware platforms directly into memory. SentinelLabs researchers discovered variants of two long-standing Windows malware platforms, and indications of an additional Linux implant.",
       "meta": {
+        "name-attribution": [
+          "Metador:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/the-mystery-of-metador-unpicking-mafaldas-anti-analysis-techniques/",
           "https://www.sentinelone.com/labs/the-mystery-of-metador-an-unattributed-threat-hiding-in-telcos-isps-and-universities/"
@@ -13485,6 +15025,9 @@
     {
       "description": "Symantec recently reported on activity attributed to a threat actor group dubbed Carderbee. In the campaign, the threat actors target entities in Hong Kong and other regions of Asia via a supply chain attack leveraging the legitimate Cobra DocGuard software. The activity began as early as September 2022.",
       "meta": {
+        "name-attribution": [
+          "Carderbee:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://blog.eclecticiq.com/chinese-state-sponsored-cyber-espionage-activity-targeting-semiconductor-industry-in-east-asia",
           "https://blog.polyswarm.io/carderbee-targets-hong-kong-in-supply-chain-attack",
@@ -13498,6 +15041,9 @@
       "description": "A suspected Iranian threat activity cluster has been linked to attacks aimed at Israeli shipping, government, energy, and healthcare organizations, in a campaign stretching back to late 2020. Researchers believe that the data harvested during the campaign could be used to support various activities. UNC3890, the threat actor behind the attacks, deployed two proprietary pieces of malware – a backdoor named “SUGARUSH” and a browser credential stealer called “SUGARDUMP”, which exfiltrates password information to email addresses registered with Gmail, ProtonMail, Yahoo and Yandex email services. The threat actor also employs a network of C&C servers that host fake login pages impersonating legitimate platforms such as Office 365, LinkedIn and Facebook. These servers are designed to communicate with the targets and also with a watering hole hosted on the login page of a legitimate Israeli shipping company.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "UNC3890:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC3890": "Mandiant",
         "refs": [
           "https://ics-cert.kaspersky.com/publications/reports/2023/03/24/apt-attacks-on-industrial-organizations-in-h2-2022/",
@@ -13510,6 +15056,10 @@
     {
       "description": "In October 2022, Kaspersky identified an active infection of government, agriculture and transportation organizations located in the Donetsk, Lugansk, and Crimea regions. Although the initial vector of compromise is unclear, the details of the next stage imply the use of spear phishing or similar methods. The victims navigated to a URL pointing to a ZIP archive hosted on a malicious web server.",
       "meta": {
+        "name-attribution": [
+          "RedStinger:f063b54b-293c-4713-87c1-92ff760ee4ba",
+          "Bad Magic:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.malwarebytes.com/blog/threat-intelligence/2023/05/redstinger",
           "https://securelist.com/bad-magic-apt/109087/"
@@ -13525,6 +15075,9 @@
       "description": "Witchetty was first documented by ESET in April 2022, who concluded that it was one of three sub-groups of TA410, a broad cyber-espionage operation with some links to the Cicada group (aka APT10). Witchetty’s activity was characterized by the use of two pieces of malware, a first-stage backdoor known as X4 and a second-stage payload known as LookBack. ESET reported that the group had targeted governments, diplomatic missions, charities, and industrial/manufacturing organizations.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Witchetty:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-witchetty-apt-group-active-iocs",
           "https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/witchetty-steganography-espionage",
@@ -13558,6 +15111,9 @@
       "description": "IndigoZebra is a Chinese state-sponsored actor mentioned for the first time by Kaspersky in its APT Trends report Q2 2017, targeting, at the time of its discovery, former Soviet Republics with multiple malware strains including Meterpreter, Poison Ivy, xDown, and a previously unknown backdoor called “xCaon.”",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "IndigoZebra:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2021/indigozebra-apt-continues-to-attack-central-asia-with-evolving-tools/",
           "https://www.rewterz.com/rewterz-news/rewterz-threat-intel-indigozebra-apt-group-targeting-central-asia-active-iocs",
@@ -13584,6 +15140,9 @@
     {
       "description": "OilAlpha has almost exclusively relied on infrastructure associated with the Public Telecommunication Corporation (PTC), a Yemeni government-owned enterprise reported to be under the direct control of the Houthi authorities. OilAlpha used encrypted chat messengers like WhatsApp to launch social engineering attacks against its targets. It has also used URL link shorteners. Per victimology assessment, it appears a majority of the targeted entities were Arabic-language speakers and operated Android devices.",
       "meta": {
+        "name-attribution": [
+          "OilAlpha:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.zimperium.com/blog/zimperium-mtd-against-oilalpha-a-comprehensive-defense-strategy/",
           "https://www.recordedfuture.com/oilalpha-likely-pro-houthi-group-targeting-arabian-peninsula"
@@ -13606,6 +15165,9 @@
     {
       "description": "Elastic's security team has published a report on REF5961, a cyber-espionage group they found on the network of a Foreign Affairs Ministry from a member of the Association of Southeast Asian Nations (ASEAN). Elastic says it found the group's tools next to the malware of another cyber-espionage group it tracks as REF2924. REF5961's arsenal includes malware such as EAGERBEE, RUDEBIRD, and DOWNTOWN.",
       "meta": {
+        "name-attribution": [
+          "REF5961:58d7efca-402a-4b36-9178-dc14e52f12e5"
+        ],
         "refs": [
           "https://www.elastic.co/security-labs/introducing-the-ref5961-intrusion-set",
           "https://www.elastic.co/security-labs/disclosing-the-bloodalchemy-backdoor"
@@ -13618,6 +15180,9 @@
       "description": "A group monitored as REF2924 by Elastic Security Labs is wielding novel data-stealing malware — an HTTP listener written in C# dubbed Naplistener by the researchers — in attacks against victims operating in southern and southeast Asia.According to a blog post by Elastic senior security research engineer Remco Sprooten, in that region of the world, network-based detection and prevention technologies are the de facto method for securing many environments.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "REF2924:58d7efca-402a-4b36-9178-dc14e52f12e5"
+        ],
         "refs": [
           "https://www.elastic.co/security-labs/ref2924-howto-maintain-persistence-as-an-advanced-threat",
           "https://www.elastic.co/security-labs/introducing-the-ref5961-intrusion-set"
@@ -13630,6 +15195,9 @@
       "description": "In early 2023, Microsoft In early 2023, observed a wave of activity from a Gaza-based group that we track as Storm-1133 targeting Israeli private sector energy, defense, and telecommunications organizations.",
       "meta": {
         "country": "PS",
+        "name-attribution": [
+          "Storm-1133:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1133": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/security-insider/microsoft-digital-defense-report-2023",
@@ -13642,6 +15210,9 @@
     {
       "description": "TA499, also known as Vovan and Lexus, is a Russia-aligned threat actor that has aggressively engaged in email campaigns since at least 2021.  The threat actor’s campaigns attempt to convince high-profile North American and European government officials as well as CEOs of prominent companies and celebrities into participating in recorded phone calls or video chats.",
       "meta": {
+        "name-attribution": [
+          "TA499:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/dont-answer-russia-aligned-ta499-beleaguers-targets-video-call-requests"
         ],
@@ -13670,6 +15241,9 @@
           "Germany"
         ],
         "country": "CN",
+        "name-attribution": [
+          "Sharp Dragon:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://blog.cyble.com/2023/06/01/sharppanda-apt-campaign-expands-its-arsenal-targeting-g20-nations/",
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-sharppanda-chinese-apt-group-targets-southeast-asian-government-active-iocs",
@@ -13780,6 +15354,9 @@
     {
       "description": "In September 2023, Cisco Talos identified a new malware family that it calls ‘HTTPSnoop’ being deployed against telecommunications providers in the Middle East. They also discovered a sister implant to 'HTTPSnoop,’ that they are naming ‘PipeSnoop,’ which can accept arbitrary shellcode from a named pipe and execute it on the infected endpoint. Based on these findings, the researchers assess with high confidence that both implants belong to a new intrusion set that it named ‘ShroudedSnooper.’",
       "meta": {
+        "name-attribution": [
+          "ShroudedSnooper:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/introducing-shrouded-snooper/",
           "https://www.sentinelone.com/labs/the-israel-hamas-war-cyber-domain-state-sponsored-activity-of-interest/"
@@ -13791,6 +15368,9 @@
     {
       "description": "ShinyHunters is a cybercriminal group of unknown origin that is motivated by financial gain. The group is known for its sophisticated attacks against a wide range of targets, including businesses, organizations, and government agencies. ShinyHunters typically uses phishing attacks and exploit kits to gain access to victim networks, where they deploy malware to steal sensitive data, such as names, addresses, phone numbers, Social Security numbers, and credit card information.",
       "meta": {
+        "name-attribution": [
+          "ShinyHunters:1c141c9b-ec78-4f86-a8ea-b02944fa5492"
+        ],
         "refs": [
           "https://cyberwarzone.com/shinyhunters-22-year-old-member-pleads-guilty-to-cyber-extortion-causing-6-million-in-damage/",
           "https://www.bitdefender.com/blog/hotforsecurity/pizza-hut-australia-leaks-one-million-customers-details-claims-shinyhunters-hacking-group/",
@@ -13842,6 +15422,10 @@
       "description": "TraderTraitor targets blockchain companies through spear-phishing messages. The group sends these messages to employees, particularly those in system administration or software development roles, on various communication platforms, intended to gain access to these start-up and high-tech companies. TraderTraitor may be the work of operators previously responsible for APT38 activity.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Jade Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UNC4899:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4899": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/north-korea-supply-chain",
@@ -13882,6 +15466,9 @@
     {
       "description": "UNC2565 is a threat group that has used the GOOTLOADER downloader to deliver Cobalt Strike BEACON. These intrusions have stemmed from victims accessing malicious websites that use SEO techniques to improve Google search rankings. After obtaining a foothold in the environment, UNC2565 has conducted reconnaissance and credential harvesting activity using common tools such as BLOODHOUND and KERBEROAST. UNC2565's motivations are currently unknown but overlaps with activity that has led to SODINOKIBI ransomware. This suggests that the threat group may be financially motivated.",
       "meta": {
+        "name-attribution": [
+          "UNC2565:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2565": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/tracking-evolution-gootloader-operations",
@@ -13929,6 +15516,9 @@
     {
       "description": "CrowdStrike identified a cryptojacking campaign targeting vulnerable Docker and Kubernetes infrastructure. Called “Kiss-a-dog,” the campaign targets Docker and Kubernetes infrastructure using an obscure domain from the payload, container escape attempt and anonymized “dog” mining pools.",
       "meta": {
+        "name-attribution": [
+          "Kiss-a-Dog:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/new-kiss-a-dog-cryptojacking-campaign-targets-docker-and-kubernetes/"
         ]
@@ -13939,6 +15529,9 @@
     {
       "description": "Microsoft reported on MCCrash, an IoT botnet operated by the DEV-1028 threat actor and used to launch DDoS attacks against private Minecraft servers.",
       "meta": {
+        "name-attribution": [
+          "DEV-1028:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-1028": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2022/12/15/mccrash-cross-platform-ddos-botnet-targets-private-minecraft-servers/"
@@ -13975,6 +15568,9 @@
     {
       "description": "Bluebottle, a cyber-crime group that specializes in targeted attacks against the financial sector, is continuing to mount attacks on banks in Francophone countries. The group makes extensive use of living off the land, dual-use tools, and commodity malware, with no custom malware deployed in this campaign.",
       "meta": {
+        "name-attribution": [
+          "BlueBottle:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "http://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/bluebottle-banks-targeted-africa"
         ]
@@ -14023,6 +15619,9 @@
       "description": "DiceyF is an advanced persistent threat group that has been targeting online casinos and other victims in Southeast Asia for an extended period. They have exhibited overlapping activity with LuckyStar PlugX and Earth Berberoka/GamblingPuppet, as reported by various cybersecurity vendors. While their motivations remain unclear, previous incidents suggest a combination of espionage and intellectual property theft rather than immediate financial gain. DiceyF continuously evolves their codebase and adds encryption capabilities to enhance their stealthy cyberespionage activities.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "DiceyF:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/diceyf-deploys-gameplayerframework-in-online-casino-development-studio/107723/"
         ]
@@ -14033,6 +15632,10 @@
     {
       "description": "Lace Tempest, also known as DEV-0950, is a threat actor that exploited vulnerabilities in software such as SysAid and PaperCut to gain unauthorized access to systems. Lace Tempest is known for deploying the Clop ransomware and exfiltrating data from compromised networks.",
       "meta": {
+        "name-attribution": [
+          "DEV-0950:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Lace Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0950": "Microsoft",
         "refs": [
           "http://www.microsoft.com/en-us/security/blog/2022/10/27/raspberry-robin-worm-part-of-larger-ecosystem-facilitating-pre-ransomware-activity/"
@@ -14060,6 +15663,10 @@
       "description": "WIRTE is a threat actor group that was first discovered in 2018. They are suspected to be part of the Gaza Cybergang, an Arabic politically motivated cyber criminal group. WIRTE has been observed changing their toolkit and operating methods to remain undetected for longer periods of time. They primarily target governmental and political entities, but have also been known to target law firms and financial institutions.",
       "meta": {
         "country": "PS",
+        "name-attribution": [
+          "WIRTE:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "Ashen Lepus:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://securelist.com/wirtes-campaign-in-the-middle-east-living-off-the-land-since-at-least-2019/105044/",
           "https://lab52.io/blog/wirte-group-attacking-the-middle-east/",
@@ -14075,6 +15682,9 @@
     {
       "description": "Caracal Kitten is an APT group that has been targeting activists associated with the Kurdistan Democratic Party. They employ a mobile remote access Trojan to gain unauthorized access to victims' devices. The group disguises their malware as legitimate mobile apps, tricking users into installing them and granting the hackers access to their personal data.",
       "meta": {
+        "name-attribution": [
+          "Caracal Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://deform.co/hacker-group-caracal-kitten-targets-kdp-activists-with-malware/",
           "https://www.ctfiot.com/138538.html"
@@ -14089,6 +15699,9 @@
     {
       "description": "Trend Micro discovered a threat actor they named Water Labbu that was targeting cryptocurrency scam websites. Typically, cryptocurrency scammers use social engineering techniques,  interacting with victims to gain their trust and then manipulating them into providing the permissions needed to transfer cryptocurrency assets. While Water Labbu managed to steal cryptocurrencies via a similar method by obtaining access permissions and token allowances from their victim’s wallets, unlike other similar campaigns, they did not use any kind of social engineering — at least not directly. Instead, Water Labbu lets other scammers use their social engineering tricks to scam unsuspecting victims.",
       "meta": {
+        "name-attribution": [
+          "Water Labbu:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/22/j/water-labbu-abuses-malicious-dapps-to-steal-cryptocurrency.html"
         ]
@@ -14100,6 +15713,9 @@
       "description": "TAG-56 is a threat actor group that shares similarities with the APT42 group. They use tactics such as fake registration pages and spearphishing to target victims, often using encrypted chat platforms like WhatsApp or Telegram. TAG-56 is believed to be part of a broader campaign led by an Iran-nexus threat activity group. They have been observed using shared web hosts and recycled code, indicating a preference for acquiring purpose-built infrastructure rather than establishing their own.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "TAG-56:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://socradar.io/dark-web-profile-apt42-iranian-cyber-espionage-group/",
           "https://www.recordedfuture.com/suspected-iran-nexus-tag-56-uses-uae-forum-lure-for-credential-theft-against-us-think-tank"
@@ -14112,6 +15728,9 @@
       "description": "Since early 2022, Proofpoint researchers have observed a prolific threat actor, tracked as TA482, regularly engaging in credential harvesting campaigns that target the social media accounts of mostly US-based journalists and media organizations. This victimology, TA482’s use of services originating from Turkey to host its domains and infrastructure, as well as Turkey’s history of leveraging social media to spread pro-President Recep Tayyip Erdogan and pro-Justice and Development Party (Turkey’s ruling party) propaganda support Proofpoint’s assessment that TA482 is aligned with the Turkish state.",
       "meta": {
         "country": "TR",
+        "name-attribution": [
+          "TA482:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/above-fold-and-your-inbox-tracing-state-aligned-activity-targeting-journalists"
         ]
@@ -14179,6 +15798,10 @@
       "description": "Bohrium is an Iranian threat actor that has been involved in spear-phishing operations targeting organizations in the US, Middle East, and India. They often create fake social media profiles, particularly posing as recruiters, to trick victims into running malware on their computers. Microsoft's Digital Crimes Unit has taken legal action and seized 41 domains used by Bohrium to disrupt their activities. The group has shown a particular interest in sectors such as technology, transportation, government, and education.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Smoke Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "IMPERIAL KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://twitter.com/CyberAmyHB/status/1532398956918890500"
         ],
@@ -14203,6 +15826,9 @@
     {
       "description": "KAX17 is a sophisticated threat actor that has been active since at least 2017. They have operated hundreds of malicious servers within the Tor network, primarily as entry and middle points. Their main objective appears to be collecting information on Tor users and mapping their routes within the network. Despite efforts to remove their servers, KAX17 has shown resilience and continues to operate.",
       "meta": {
+        "name-attribution": [
+          "KAX17:f063b54b-293c-4713-87c1-92ff760ee4ba"
+        ],
         "refs": [
           "https://www.malwarebytes.com/blog/news/2021/12/was-threat-actor-kax17-de-anonymizing-the-tor-network/amp",
           "https://therecord.media/a-mysterious-threat-actor-is-running-hundreds-of-malicious-tor-relays",
@@ -14217,6 +15843,10 @@
       "description": "MirrorFace is a Chinese-speaking advanced persistent threat group that has been targeting high-value organizations in Japan, including media, government, diplomatic, and political entities. They have been conducting spear-phishing campaigns, utilizing malware such as LODEINFO and MirrorStealer to steal credentials and exfiltrate sensitive data. While there is speculation about their connection to APT10, ESET currently track them as a separate entity.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "MirrorFace:3a43aca5-6366-4168-b182-a8afec4550b5",
+          "Earth Kasha:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Kasha": "Trend Micro",
         "refs": [
           "https://www.welivesecurity.com/2022/12/14/unmasking-mirrorface-operation-liberalface-targeting-japanese-political-entities/",
@@ -14251,6 +15881,9 @@
       "description": "Chernovite is a highly capable and sophisticated threat actor group that has developed a modular ICS malware framework called PIPEDREAM. They are known for targeting industrial control systems and operational technology environments, with the ability to disrupt, degrade, and potentially destroy physical processes. Chernovite has demonstrated a deep understanding of ICS protocols and intrusion techniques, making them a significant threat to critical infrastructure sectors.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Chernovite:e4ed3168-7830-490f-9eed-d1b3ef2daccd"
+        ],
         "refs": [
           "https://www.dragos.com/blog/pipedream-mousehole-opcua-module/",
           "https://www.dragos.com/blog/industry-news/chernovite-pipedream-malware-targeting-industrial-control-systems/",
@@ -14278,6 +15911,9 @@
       "description": "DriftingCloud is a persistent threat actor known for targeting various industries and locations. They are skilled at developing or acquiring zero-day exploits to gain unauthorized access to target networks. Compromising gateway devices is a common tactic used by DriftingCloud, making network monitoring solutions crucial for detecting their attacks.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "DriftingCloud:c2f76813-f24c-450e-abfd-0db4495ab68e"
+        ],
         "refs": [
           "https://socradar.io/driftingcloud-apt-group-exploits-zero-day-in-sophos-firewall/",
           "https://www.volexity.com/blog/2022/06/15/driftingcloud-zero-day-sophos-firewall-exploitation-and-an-insidious-breach/",
@@ -14291,6 +15927,9 @@
       "description": "UNC4191 is a China-linked threat actor that has been involved in cyber espionage campaigns targeting public and private sectors primarily in Southeast Asia. They have been known to use USB devices as an initial infection vector and have been observed deploying various malware families on infected systems. UNC4191's operations have also extended to the US, Europe, and the Asia Pacific Japan region, with a particular focus on the Philippines.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC4191:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4191": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/china-nexus-espionage-southeast-asia",
@@ -14304,6 +15943,9 @@
       "description": "DragonSpark is a threat actor that has been conducting attacks primarily targeting organizations in East Asia. They utilize the open-source tool SparkRAT, which is a multi-platform and frequently updated remote access Trojan. The threat actor is believed to be Chinese-speaking based on their use of Chinese language support and compromised infrastructure located in China and Taiwan. They employ various techniques to evade detection, including Golang source code interpretation and the use of the China Chopper webshell.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "DragonSpark:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/dragonspark-attacks-evade-detection-with-sparkrat-and-golang-source-code-interpretation/"
         ]
@@ -14324,6 +15966,9 @@
     {
       "description": "Earth Kitsune is an advanced persistent threat actor that has been active since at least 2019. They primarily target individuals interested in North Korea and use various tactics, such as compromising websites and employing social engineering, to distribute self-developed backdoors. Earth Kitsune demonstrates technical proficiency and continuously evolves their tools, tactics, and procedures. They have been associated with malware such as WhiskerSpy and SLUB.",
       "meta": {
+        "name-attribution": [
+          "Earth Kitsune:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Kitsune": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/23/b/earth-kitsune-delivers-new-whiskerspy-backdoor.html",
@@ -14350,6 +15995,9 @@
       "description": "UNC4841 is a well-resourced threat actor that has utilized a wide range of malware and purpose-built tooling to enable their global espionage operations. They have been observed selectively deploying specific malware families at high priority targets, with SKIPJACK being the most widely deployed. UNC4841 primarily targeted government and technology organizations, but they have also been observed targeting other verticals.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC4841:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4841": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/unc4841-post-barracuda-zero-day-remediation/",
@@ -14379,6 +16027,9 @@
       "description": "CL-STA-0043 is a Chinese state-nexus cyber-espionage actor tracked by Palo Alto Networks Unit 42, which promoted the activity cluster to the named threat actor Phantom Taurus in September 2025, having previously designated it TGR-STA-0043 and linked it to the Operation Diplomatic Specter campaign. The group targets government and telecommunications organizations, including ministries of foreign affairs, embassies and diplomatic missions, across Africa, the Middle East and Asia, with a focus on geopolitical and military intelligence collection. It typically gains access by exploiting internet-facing Internet Information Services (IIS) and Microsoft Exchange servers, then performs reconnaissance and privilege escalation using native Windows tooling. In more recent operations the actor deployed NET-STAR, a fileless .NET malware suite targeting IIS web servers that comprises the IIServerCore backdoor and the AssemblyExecuter V1 and V2 loaders.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Phantom Taurus:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://www.securonix.com/blog/securonix-threat-labs-monthly-intelligence-insights-june-2023/",
           "https://www.paloaltonetworks.com/blog/security-operations/through-the-cortex-xdr-lens-uncovering-a-new-activity-group-targeting-governments-in-the-middle-east-and-africa/",
@@ -14405,6 +16056,9 @@
     {
       "description": "DEV-0928 is a threat actor that has been tracked by Microsoft since September 2022. They are known for their involvement in high-volume phishing campaigns, using tools offered by DEV-1101. DEV-0928 sends phishing emails to targets and has been observed launching campaigns involving millions of emails. They also utilize evasion techniques, such as redirection to benign pages, to avoid detection.",
       "meta": {
+        "name-attribution": [
+          "DEV-0928:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0928": "Microsoft",
         "refs": [
           "http://www.microsoft.com/en-us/security/blog/2023/03/13/dev-1101-enables-high-volume-aitm-campaigns-with-open-source-phishing-kit/"
@@ -14439,6 +16093,9 @@
       "description": "TA444 is a North Korea state-sponsored threat actor that primarily focuses on financially motivated operations. They have been active since at least 2017 and have recently shifted their attention to targeting cryptocurrencies. TA444 employs various infection methods and has a diverse range of malware and backdoors at their disposal. They have been attributed to stealing hundreds of millions of dollars' worth of cryptocurrency and related assets.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "TA444:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/ta444-apt-startup-aimed-at-your-funds",
           "https://cyberscoop.com/north-korean-cryptocurrency-hackers-education-government/",
@@ -14467,6 +16124,9 @@
     {
       "description": "NewsPenguin is threat actor that has been targeting organizations in Pakistan. They use a complex payload delivery mechanism and exploit the upcoming Pakistan International Maritime Expo & Conference as a lure to trick their victims. The group has been linked to a phishing campaign that leverages spear-phishing emails and weaponized documents to deliver an advanced espionage tool.",
       "meta": {
+        "name-attribution": [
+          "NewsPenguin:94e95ed2-e07a-464a-9d56-a03679b9717a"
+        ],
         "refs": [
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-newspenguin-threat-actors-targeting-pakistani-entities-with-malicious-campaign-active-iocs",
           "https://blogs.blackberry.com/en/2023/02/newspenguin-a-previously-unknown-threat-actor-targets-pakistan-with-advanced-espionage-tool"
@@ -14494,6 +16154,9 @@
       "description": "PerSwaysion is a threat actor known for conducting phishing campaigns targeting high-level executives. They have been active since at least August 2019 and are believed to be based in Vietnam. PerSwaysion has recently updated their techniques, using more direct phishing methods and leveraging Microsoft 365 to steal credentials.",
       "meta": {
         "country": "VN",
+        "name-attribution": [
+          "PerSwaysion:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://blog.group-ib.com/perswaysion",
           "https://blog.scarletshark.com/perswaysion-threat-actor-updates-their-techniques-and-infrastructure-e9465157a653"
@@ -14506,6 +16169,9 @@
       "description": "Space Pirates is a cybercrime group that has been active since at least 2017. They primarily target Russian companies and have been observed using various malware, including Deed RAT and ShadowPad. The group uses a combination of publicly available tools and their own protocols to communicate with their command-and-control servers.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Webworm:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "http://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/webworm-espionage-rats",
           "https://www.ptsecurity.com/ww-en/analytics/pt-esc-threat-intelligence/space-pirates-a-look-into-the-group-s-unconventional-techniques-new-attack-vectors-and-tools/",
@@ -14535,6 +16201,9 @@
       "description": "Moshen Dragon is a Chinese-aligned cyberespionage threat actor operating in Central Asia. They have been observed deploying multiple malware triads and utilizing DLL search order hijacking to sideload ShadowPad and PlugX variants. The threat actor also employs various tools, including an LSA notification package and a passive backdoor known as GUNTERS. Their activities involve targeting the telecommunication sector and leveraging Impacket for lateral movement and data exfiltration.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Moshen Dragon:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/moshen-dragons-triad-and-error-approach-abusing-security-software-to-sideload-plugx-and-shadowpad/"
         ]
@@ -14546,6 +16215,10 @@
       "description": "One of their notable tools is a custom backdoor called SockDetour, which operates filelessly and socketlessly on compromised Windows servers. The group's activities have been linked to the exploitation of vulnerabilities in Zoho ManageEngine ADSelfService Plus and ServiceDesk Plus.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "DEV-0322:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Circle Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0322": "Microsoft",
         "refs": [
           "https://unit42.paloaltonetworks.com/sockdetour/",
@@ -14564,6 +16237,9 @@
       "description": "OldGremlin is a Russian-speaking ransomware group that has been active for several years. They primarily target organizations in Russia, including banks, logistics, industrial, insurance, retail, and IT companies. OldGremlin is known for using phishing emails as an initial infection vector and has developed custom malware for both Windows and Linux systems. They have conducted multiple malicious email campaigns and demand large ransoms from their victims, with some reaching millions of dollars.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "OldGremlin:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-new-ransomware-actor-oldgremlin-hits-multiple-organizations",
           "https://www.group-ib.com/blog/oldgremlin-comeback/",
@@ -14577,6 +16253,9 @@
       "description": "Storm Cloud is a Chinese espionage threat actor known for targeting organizations across Asia, particularly Tibetan organizations and individuals. They use a variety of malware families, including GIMMICK and GOSLU, which are feature-rich and multi-platform. Storm Cloud leverages public cloud hosting services like Google Drive for command-and-control channels, making it difficult to detect their activities.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Storm Cloud:c2f76813-f24c-450e-abfd-0db4495ab68e"
+        ],
         "refs": [
           "https://www.volexity.com/blog/2020/03/31/storm-cloud-unleashed-tibetan-community-focus-of-highly-targeted-fake-flash-campaign/",
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-gimmick-malware-active-iocs"
@@ -14588,6 +16267,9 @@
     {
       "description": "CostaRicto is a cyber-espionage threat actor that operates as a mercenary group, offering its services to various clients globally. They use bespoke malware tools and sophisticated techniques like VPN proxy and SSH tunnelling. While their targets are scattered across different regions, there is a concentration in South Asia.",
       "meta": {
+        "name-attribution": [
+          "CostaRicto:94e95ed2-e07a-464a-9d56-a03679b9717a"
+        ],
         "refs": [
           "https://blogs.blackberry.com/en/2020/11/the-costaricto-campaign-cyber-espionage-outsourced",
           "https://www.cybersecurityintelligence.com/blog/outsourced-cyber-spying-5335.html"
@@ -14600,6 +16282,9 @@
       "description": "TA402 is an APT group that has been tracked by Proofpoint since  2020. They primarily target government entities in the Middle East and North Africa, with a focus on intelligence collection. TA402 is known for using sophisticated phishing campaigns and constantly updating their malware implants and delivery methods to evade detection. They have been observed using cloud services like Dropbox and Google Drive for hosting malicious payloads and command-and-control infrastructure.",
       "meta": {
         "country": "PS",
+        "name-attribution": [
+          "TA402:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/ta402-uses-complex-ironwind-infection-chains-target-middle-east-based-government",
           "https://www.proofpoint.com/us/blog/threat-insight/ugg-boots-4-sale-tale-palestinian-aligned-espionage"
@@ -14648,6 +16333,9 @@
       "description": "DragonForce is a hacktivist group based in Malaysia that has been involved in cyberattacks targeting government institutions and commercial organizations in India. They have also targeted websites affiliated with Israel and have shown support for pro-Palestinian causes. The group has been observed using defacement attacks, distributed denial-of-service attacks, and data leaks as part of their campaigns. DragonForce Malaysia has demonstrated an ability to adapt and evolve their tactics over time.",
       "meta": {
         "country": "MY",
+        "name-attribution": [
+          "DragonForce:bfafdca5-3171-4953-86ab-c74f44822fd3"
+        ],
         "refs": [
           "https://www.darkowl.com/blog-content/hacktivist-groups-use-defacements-in-the-israel-hamas-conflict/",
           "https://blog.radware.com/security/2023/05/india-one-of-the-most-targeted-countries-for-hacktivist-groups/",
@@ -14663,6 +16351,10 @@
     {
       "description": "UNC1945 is an APT group that has been targeting telecommunications companies globally. They use Linux-based implants to maintain long-term access in compromised networks. UNC1945 has demonstrated advanced technical abilities, utilizing various tools and techniques to evade detection and move laterally through networks. They have also been observed targeting other industries, such as financial and professional consulting, and have been linked to other threat actors, including MustangPanada and RedDelta.",
       "meta": {
+        "name-attribution": [
+          "LightBasin:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "UNC1945:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC1945": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/unc2891-overview",
@@ -14690,6 +16382,9 @@
     {
       "description": "Wildcard is a threat actor that initially targeted Israel's educational sector with the SysJoker malware. They have since expanded their operations and developed additional malware variants, disguised as legitimate software, including one written in the Rust programming language called RustDown. Their precise identity remains unknown, but they have shown advanced capabilities and a focus on critical sectors within Israel.",
       "meta": {
+        "name-attribution": [
+          "WildCard:ac46bac7-e7b5-4efe-8f32-b79e9015ab86"
+        ],
         "refs": [
           "https://intezer.com/blog/research/wildcard-evolution-of-sysjoker-cyber-threat/"
         ]
@@ -14700,6 +16395,9 @@
     {
       "description": "WildPressure is a threat actor that targets industrial-related entities in the Middle East. They use a variety of programming languages, including C++, VBScript, and Python, to develop their malware. They have been observed using virtual private servers and compromised servers, particularly WordPress websites, in their infrastructure. While there are some minor similarities with other threat actors in the region, there is not enough evidence to make any attribution.",
       "meta": {
+        "name-attribution": [
+          "WildPressure:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.redpacketsecurity.com/it-threat-evolution-q3-2021/",
           "https://securelist.com/wildpressure-targets-macos/103072/",
@@ -14714,6 +16412,9 @@
       "description": "The TunnelSnake campaign demonstrates the activity of a sophisticated actor that invests significant resources in designing an evasive toolset and infiltrating networks of high-profile organizations. By leveraging Windows drivers, covert communications channels and proprietary malware, the group behind it maintains a considerable level of stealth. That said, some of its TTPs, like the usage of a commodity webshell and open-source legacy code for loading unsigned drivers, may get detected and in fact were flagged by Kaspersky's product, giving them visibility into the group’s operation.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "TunnelSnake:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://www.redpacketsecurity.com/operation-tunnelsnake/",
           "https://securelist.com/operation-tunnelsnake-and-moriya-rootkit/101831/"
@@ -14751,6 +16452,9 @@
       "description": "UNC2717 is a threat actor that engages in espionage activities aligned with Chinese government priorities. They demonstrate advanced tradecraft and take measures to avoid detection, making it challenging for network defenders to identify their tools and intrusion methods. UNC2717, along with other Chinese APT actors, has been observed stealing credentials, email communications, and intellectual property. They have targeted global government agencies using malware such as HARDPULSE, QUIETPULSE, and PULSEJUMP.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC2717:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2717": "Mandiant",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html",
@@ -14763,6 +16467,9 @@
     {
       "description": "UNC2659 has been active since at least January 2021. We have observed the threat actor move through the whole attack lifecycle in under 10 days. UNC2659 is notable given their use of an exploit in the SonicWall SMA100 SSL VPN product, which has since been patched by SonicWall. The threat actor appeared to download several tools used for various phases of the attack lifecycle directly from those tools’ legitimate public websites.",
       "meta": {
+        "name-attribution": [
+          "UNC2659:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2659": "Mandiant",
         "refs": [
           "http://internal-www.fireeye.com/blog/threat-research/2021/05/shining-a-light-on-darkside-ransomware-operations.html"
@@ -14774,6 +16481,9 @@
     {
       "description": "AeroBlade is a previously unknown threat actor that has been targeting an aerospace organization in the United States. Their objective appears to be conducting commercial and competitive cyber espionage. They employ spear-phishing as a delivery mechanism, using weaponized documents with embedded remote template injection techniques and malicious VBA macro code. The attacks have been ongoing since September 2022, with multiple phases identified in the attack chain. The origin and precise objective of AeroBlade remain unknown.",
       "meta": {
+        "name-attribution": [
+          "AeroBlade:94e95ed2-e07a-464a-9d56-a03679b9717a"
+        ],
         "refs": [
           "https://blogs.blackberry.com/en/2023/11/aeroblade-on-the-hunt-targeting-us-aerospace-industry"
         ]
@@ -14785,6 +16495,9 @@
       "description": "WIP19 is a Chinese-speaking threat group involved in espionage targeting the Middle East and Asia. They utilize a stolen certificate to sign their malware, including SQLMaggie, ScreenCap, and a credential dumper. The group has been observed targeting telecommunications and IT service providers, using toolsets authored by WinEggDrop. WIP19's activities suggest they are after specific information and are part of the broader Chinese espionage landscape.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "WIP19:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/wip19-espionage-new-chinese-apt-targets-it-service-providers-and-telcos-with-signed-malware/"
         ]
@@ -14795,6 +16508,9 @@
     {
       "description": "UNC2447 is a financially motivated threat actor with ties to multiple hacker groups. They have been observed deploying ransomware, including FiveHands and Hello Kitty, and engaging in double extortion tactics. They have been active since at least May 2020 and target organizations in Europe and North America.",
       "meta": {
+        "name-attribution": [
+          "UNC2447:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2447": "Mandiant",
         "refs": [
           "https://www.esentire.com/blog/hacker-infrastructure-used-in-cisco-breach-discovered-attacking-a-top-workforce-management-corporation-russias-evil-corp-gang-suspected-reports-esentire",
@@ -14810,6 +16526,9 @@
       "description": "UNC215 is a Chinese nation-state threat actor that has been active since at least 2014. They have targeted organizations in various sectors, including government, technology, telecommunications, defense, finance, entertainment, and healthcare. UNC215 has been observed using tools such as Mimikatz, FOCUSFJORD, and HYPERBRO for initial access and post-compromise activities. They have demonstrated a focus on evading detection and have employed tactics such as using trusted third parties, minimizing forensic evidence, and incorporating false flags. UNC215's targets are located globally, with a particular focus on the Middle East, Europe, Asia, and North America.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC215:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC215": "Mandiant",
         "refs": [
           "https://www.esentire.com/security-advisories/ransomware-hackers-attack-a-top-safety-testing-org-using-tactics-and-techniques-borrowed-from-chinese-espionage-groups",
@@ -14822,6 +16541,10 @@
     {
       "description": "DEV-0569, also known as Storm-0569, is a threat actor group that has been observed deploying the Royal ransomware. They utilize malicious ads and phishing techniques to distribute malware and gain initial access to networks. The group has been linked to the distribution of payloads such as Batloader and has forged relationships with other threat actors. DEV-0569 has targeted various sectors, including healthcare, communications, manufacturing, and education in the United States and Brazil.",
       "meta": {
+        "name-attribution": [
+          "DEV-0569:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Storm-0569:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0569": "Microsoft",
         "origin:Storm-0569": "Microsoft",
         "refs": [
@@ -14871,6 +16594,9 @@
       "description": "UNC2630 is a threat actor believed to be affiliated with the Chinese government. They engage in cyber espionage activities, targeting organizations aligned with Beijing's strategic objectives. UNC2630 demonstrates advanced tradecraft and employs various malware families, including SLOWPULSE and RADIALPULSE, to compromise Pulse Secure VPN appliances. They also utilize modified binaries and scripts to maintain persistence and move laterally within compromised networks.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC2630:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2630": "Mandiant",
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html",
@@ -14937,6 +16663,9 @@
     {
       "description": "Storm-1283 is a threat actor that targeted Microsoft Azure cloud platform. They gained access to user accounts and created OAuth applications using stolen credentials, allowing them to control resources and deploy virtual machines for cryptomining. The targeted organizations incurred significant financial losses ranging from $10,000 to $1.5 million. Storm-1283 utilized compromised accounts and subscriptions to carry out their illicit activities.",
       "meta": {
+        "name-attribution": [
+          "Storm-1283:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1283": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/12/12/threat-actors-misuse-oauth-applications-to-automate-financially-driven-attacks/"
@@ -14961,6 +16690,9 @@
       "description": "UNC4736 is a North Korean threat actor that has been involved in supply chain attacks targeting software chains of 3CX and X_TRADER. They have used malware strains such as TAXHAUL, Coldcat, and VEILEDSIGNAL to compromise Windows and macOS systems. UNC4736 has been linked to financially motivated cybercrime operations, particularly focused on cryptocurrency and fintech-related services. They have also demonstrated infrastructure overlap with other North Korean and APT43 activity.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "UNC4736:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4736": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/3cx-software-supply-chain-compromise"
@@ -14972,6 +16704,9 @@
     {
       "description": "GambleForce is a threat actor specializing in SQL injection attacks. They have targeted over 20 websites in various sectors across multiple countries, compromising six companies. GambleForce utilizes publicly available pentesting tools and has been active since mid-September 2023.",
       "meta": {
+        "name-attribution": [
+          "GambleForce:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/gambleforce-gang/"
         ]
@@ -15029,6 +16764,10 @@
     {
       "description": "Storm-1113 is a threat actor that acts both as an access broker focused on malware distribution through search advertisements and as an “as-a-service” entity providing malicious installers and landing page frameworks. In Storm-1113 malware distribution campaigns, users are directed to landing pages mimicking well-known software that host installers, often MSI files, that lead to the installation of malicious payloads. Storm-1113 is also the developer of EugenLoader, a commodity malware first observed around November 2022.",
       "meta": {
+        "name-attribution": [
+          "Storm-1113:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "APOTHECARY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:Storm-1113": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/12/28/financially-motivated-threat-actors-misusing-app-installer/"
@@ -15077,6 +16816,10 @@
       "description": "Gray Sandstorm is an Iran-linked threat actor that has been active since at least 2012. They have targeted defense technology companies, maritime transportation companies, and Persian Gulf ports of entry. Their primary method of attack is password spraying, and they have been observed using tools like o365spray. They have a specific focus on US and Israeli targets and are likely operating in support of Iranian interests.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Gray Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0343:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0343": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2021/11/16/evolving-trends-in-iranian-threat-actor-activity-mstic-presentation-at-cyberwarcon-2021/",
@@ -15132,6 +16875,9 @@
           "Germany"
         ],
         "country": "CN",
+        "name-attribution": [
+          "UNC5221:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5221": "Mandiant",
         "refs": [
           "https://www.volexity.com/blog/2024/01/10/active-exploitation-of-two-zero-day-vulnerabilities-in-ivanti-connect-secure-vpn/",
@@ -15178,6 +16924,9 @@
       "description": "TAG-28 is a Chinese state-sponsored threat actor that has been targeting Indian organizations, including media conglomerates and government agencies. They have been using the Winnti malware, which is commonly shared among Chinese state-sponsored groups. TAG-28's main objective is to gather intelligence on Indian targets, potentially for espionage purposes.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "TAG-28:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/blog/china-linked-tag-28-targets-indias-the-times-group"
         ]
@@ -15189,6 +16938,11 @@
       "description": "Flax Typhoon is a Chinese state-sponsored threat actor that primarily targets organizations in Taiwan. They conduct espionage campaigns and focus on gaining and maintaining long-term access to networks using minimal malware. Flax Typhoon relies on tools built into the operating system and legitimate software to remain undetected. They exploit vulnerabilities in public-facing servers, use living-off-the-land techniques, and deploy a VPN connection to maintain persistence and move laterally within compromised networks.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Flax Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Ethereal Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Storm-0919:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0919": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/08/24/flax-typhoon-using-legitimate-software-to-quietly-access-taiwanese-organizations/",
@@ -15220,6 +16974,9 @@
     {
       "description": "Caliente Bandits is a highly active threat group that targets multiple industries, including finance and entertainment. They distribute the Bandook remote access trojan using Spanish-language lures through low-volume email campaigns. The group primarily impacts individuals with Spanish surnames and conducts reconnaissance to obtain employee data. They masquerade as companies in South America and use Hotmail or Gmail email addresses.",
       "meta": {
+        "name-attribution": [
+          "TA2721:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2721": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/new-threat-actor-uses-spanish-language-lures-distribute-seldom-observed-bandook"
@@ -15254,6 +17011,11 @@
         ],
         "cfr-type-of-incident": "Information Operations",
         "country": "IR",
+        "name-attribution": [
+          "Cotton Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "NEPTUNIUM:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "HAYWIRE KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://blog.sekoia.io/iran-cyber-threat-overview/",
           "https://blogs.microsoft.com/on-the-issues/2023/02/03/dtac-charlie-hebdo-hack-iran-neptunium/",
@@ -15288,6 +17050,9 @@
       "description": "Denim Tsunami is a threat actor group that has been involved in targeted attacks against European and Central American customers. They have been observed using multiple Windows and Adobe 0-day exploits, including one for CVE-2022-22047, which is a privilege escalation vulnerability. Denim Tsunami developed a custom malware called Subzero, which has capabilities such as keylogging, capturing screenshots, data exfiltration, and running remote shells. They have also been associated with the Austrian spyware distributor DSIRF.",
       "meta": {
         "country": "AT",
+        "name-attribution": [
+          "KNOTWEED:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.thezdi.com/blog/2023/1/23/activation-context-cache-poisoning-exploiting-csrss-for-privilege-escalation",
           "https://socradar.io/threats-of-commercialized-malware-knotweed/",
@@ -15320,6 +17085,10 @@
       "description": "Cuboid Sandstorm is an Iranian threat actor that targeted an Israel-based IT company in July 2021. They gained access to the company's network and used it to compromise downstream customers in the defense, energy, and legal sectors in Israel. The group also utilized custom implants, including a remote access Trojan disguised as RuntimeBroker.exe or svchost.exe, to establish persistence on victim hosts.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Cuboid Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0228:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0228": "Microsoft",
         "refs": [
           "https://www.microsoft.com/security/blog/2021/11/18/iranian-targeting-of-it-sector-on-the-rise/"
@@ -15335,6 +17104,10 @@
       "description": "Pearl Sleet is a nation state activity group based in North Korea that has been active since at least 2012. They primarily target defectors from North Korea, media organizations in carrying out their cyber espionage activities.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Pearl Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0215:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0215": "Microsoft",
         "refs": [
           "https://techcommunity.microsoft.com/t5/microsoft-defender-xdr-blog/monthly-news-december-2023/ba-p/3998431"
@@ -15351,6 +17124,10 @@
       "description": "Carmine Tsunami is a threat actor linked to an Israel-based private sector offensive actor called QuaDream. QuaDream sells a platform called REIGN to governments for law enforcement purposes, which includes exploits, malware, and infrastructure for data exfiltration from mobile devices. Carmine Tsunami is associated with the iOS malware called KingsPawn and has targeted civil society victims, including journalists, political opposition figures, and NGO workers, in various regions. They utilize domain registrars and inexpensive cloud hosting providers, often using single domains per IP address and deploying free Let's Encrypt SSL certificates.",
       "meta": {
         "country": "IL",
+        "name-attribution": [
+          "DEV-0196:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "QuaDream:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0196": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/04/11/dev-0196-quadreams-kingspawn-malware-used-to-target-civil-society-in-europe-north-america-the-middle-east-and-southeast-asia/",
@@ -15367,6 +17144,10 @@
     {
       "description": "Mustard Tempest is a threat actor that primarily uses malvertising as their main technique to gain access to and profile networks. They deploy FakeUpdates, disguised as browser updates or software packages, to lure targets into downloading a ZIP file containing a JavaScript file. Once executed, the JavaScript framework acts as a loader for other malware campaigns, often Cobalt Strike payloads. Mustard Tempest has been associated with the cybercrime syndicate Mustard Tempest, also known as EvilCorp, and has been involved in ransomware attacks using payloads such as WastedLocker, PhoenixLocker, and Macaw.",
       "meta": {
+        "name-attribution": [
+          "Mustard Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0206:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0206": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2022/05/09/ransomware-as-a-service-understanding-the-cybercrime-gig-economy-and-how-to-protect-yourself/",
@@ -15393,6 +17174,9 @@
       "description": "UNC4990 is a financially motivated threat actor that has been active since at least 2020. They primarily target users in Italy and rely on USB devices for initial infection. The group has evolved their tactics over time, using encoded text files on popular websites like GitHub and Vimeo to host payloads. They have been observed using sophisticated backdoors like QUIETBOARD and EMPTYSPACE, and have targeted organizations in various industries, particularly in Italy.",
       "meta": {
         "country": "IT",
+        "name-attribution": [
+          "UNC4990:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4990": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/unc4990-evolution-usb-malware"
@@ -15404,6 +17188,9 @@
     {
       "description": "Caramel Tsunami is a threat actor that specializes in spyware attacks. They have recently resurfaced with an updated toolset and zero-day exploits, targeting specific victims through watering hole attacks. Candiru has been observed exploiting vulnerabilities in popular browsers like Google Chrome and using third-party signed drivers to gain access to the Windows kernel. They have also been linked to other spyware vendors and have been associated with extensive abuses of their surveillance tools.",
       "meta": {
+        "name-attribution": [
+          "Candiru:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://decoded.avast.io/threatresearch/avast-q2-2022-threat-report/",
           "https://decoded.avast.io/janvojtesek/the-return-of-candiru-zero-days-in-the-middle-east/",
@@ -15424,6 +17211,10 @@
       "description": "Storm-0867 is a threat actor that has been active since 2012 and has targeted various industries and regions. They employ sophisticated phishing campaigns, utilizing social engineering techniques and a phishing as a service platform called Caffeine. Their attacks involve intercepting and manipulating communication between users and legitimate services, allowing them to steal passwords, hijack sign-in sessions, bypass multifactor authentication, and modify authentication methods.",
       "meta": {
         "country": "EG",
+        "name-attribution": [
+          "Storm-0867:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0867:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0867": "Microsoft",
         "origin:Storm-0867": "Microsoft",
         "refs": [
@@ -15439,6 +17230,11 @@
     {
       "description": "Velvet Tempest is a threat actor associated with the BlackCat ransomware group. They have been observed deploying multiple ransomware payloads, including BlackCat, and have targeted various industries such as energy, fashion, tobacco, IT, and manufacturing. Velvet Tempest relies on access brokers to gain network access and utilizes tools like Cobalt Strike Beacons and PsExec for lateral movement and payload staging. They exfiltrate stolen data using a tool called StealBit and frequently disable unprotected antivirus products.",
       "meta": {
+        "name-attribution": [
+          "Velvet Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0504:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "ALPHA SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:DEV-0504": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2022/05/09/ransomware-as-a-service-understanding-the-cybercrime-gig-economy-and-how-to-protect-yourself/",
@@ -15465,6 +17261,10 @@
       "description": "DEV-0665 is a threat actor associated with the HermeticWiper attacks. Their objective is to disrupt, degrade, and destroy specific resources within a targeted country.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Sunglow Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0665:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0665": "Microsoft",
         "refs": [
           "https://twitter.com/ESETresearch/status/1503436420886712321",
@@ -15480,6 +17280,11 @@
     {
       "description": "Vice Society is a ransomware group that has been active since at least June 2021. They primarily target the education and healthcare sectors, but have also been observed targeting the manufacturing industry. The group has used multiple ransomware families and has been known to utilize PowerShell scripts for their attacks. There are similarities between Vice Society and the Rhysida ransomware group, suggesting a potential connection or rebranding.",
       "meta": {
+        "name-attribution": [
+          "Vanilla Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0832:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "VICE SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:DEV-0832": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2022/10/25/dev-0832-vice-society-opportunistic-ransomware-campaigns-impacting-us-education-sector/",
@@ -15509,6 +17314,10 @@
       "description": "Lilac Typhoon is a threat actor attributed to China. They have been identified as exploiting the Atlassian Confluence RCE vulnerability CVE-2022-26134, which allows for remote code execution. This vulnerability has been used in cryptojacking campaigns and is included in commercial exploit frameworks. Lilac Typhoon has also been involved in deploying various payloads such as Cobalt Strike, web shells, botnets, coin miners, and ransomware.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Lilac Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0234:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0234": "Microsoft",
         "refs": [
           "https://securityboulevard.com/2022/10/analysis-of-cisa-releases-advisory-on-top-cves-exploited-chinese-state-sponsored-groups/",
@@ -15526,6 +17335,9 @@
       "description": "Ruby Sleet is a threat actor linked to North Korea's Ministry of State Security. Cerium has been involved in spear-phishing campaigns, compromising devices, and conducting cyberattacks alongside other North Korean threat actors. They have also targeted companies involved in COVID-19 research and vaccine development.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Ruby Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://blogs.microsoft.com/on-the-issues/2020/11/13/health-care-cyberattacks-covid-19-paris-peace-forum/"
         ],
@@ -15549,6 +17361,9 @@
       "description": "Microsoft has tracked Raspberry Typhoon (RADIUM) as the primary threat group targeting nations that ring the South China Sea. Raspberry Typhoon consistently targets government ministries, military entities, and corporate entities connected to critical infrastructure, particularly telecoms. Since January 2023, Raspberry Typhoon has been particularly persistent. When targeting government ministries or infrastructure, Raspberry Typhoon typically conducts intelligence collection and malware execution. In many countries, targets vary from defense and intelligence-related ministries to economic and trade-related ministries",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Raspberry Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RW1aFyW"
         ],
@@ -15571,6 +17386,10 @@
     {
       "description": "Phlox Tempest is a threat actor responsible for a large-scale click fraud campaign targeting users through YouTube comments and malicious ads. They use ChromeLoader to infect victims' computers with malware, often delivered as ISO image files that victims are tricked into downloading. The attackers aim to profit from clicks generated by malicious browser extensions or node-WebKit installed on the victim's device. Microsoft and other cybersecurity organizations have issued warnings about this ongoing and prevalent campaign.",
       "meta": {
+        "name-attribution": [
+          "Phlox Tempest:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0796:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0796": "Microsoft",
         "refs": [
           "https://twitter.com/MsftSecIntel/status/1570911625841983489"
@@ -15585,6 +17404,10 @@
     {
       "description": "Storm-1295 is a threat actor group that operates the Greatness phishing-as-a-service platform. They utilize synchronous relay servers to present targets with a replica of a sign-in page, resembling traditional phishing attacks. Their adversary-in-the-middle capability allows Storm-1295 to offer their services to other attackers. Active since mid-2022, Storm-1295 is tracked by Microsoft and is known for their involvement in the Greatness PhaaS platform.",
       "meta": {
+        "name-attribution": [
+          "Storm-1295:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-1295:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-1295": "Microsoft",
         "origin:Storm-1295": "Microsoft",
         "refs": [
@@ -15602,6 +17425,10 @@
       "description": "Storm-1167 is a threat actor tracked by Microsoft, known for their use of an AiTM phishing kit. They were responsible for launching an attack that led to Business Email Compromise activity.",
       "meta": {
         "country": "ID",
+        "name-attribution": [
+          "Storm-1167:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-1167:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-1167": "Microsoft",
         "origin:Storm-1167": "Microsoft",
         "refs": [
@@ -15618,6 +17445,9 @@
       "description": "Konni is a threat actor associated with APT37, a North Korean cyber crime group. They have been active since 2012 and are known for their cyber-espionage activities. Konni has targeted various sectors, including education, government, business organizations, and the cryptocurrency industry. They have exploited vulnerabilities such as CVE-2023-38831 and have used malware like KonniRAT to gain control of victim hosts and steal important information.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Opal Sleet:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://nsfocusglobal.com/the-new-apt-group-darkcasino-and-the-global-surge-in-winrar-0-day-exploits/",
           "https://paper.seebug.org/3031/",
@@ -15646,6 +17476,10 @@
     {
       "description": "Storm-1044 has been identified as part of a cyber campaign in collaboration with Twisted Spider. They employ a strategic approach, targeting specific endpoints using an initial access trojan called DanaBot. Once they gain access, Storm-1044 initiates lateral movement through Remote Desktop Protocol sign-in attempts, passing control to Twisted Spider. Twisted Spider then compromises the endpoints by introducing the CACTUS ransomware. Microsoft has detected ongoing malvertising attacks involving Storm-1044, leading to the deployment of CACTUS ransomware.",
       "meta": {
+        "name-attribution": [
+          "Storm-1044:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-1044:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-1044": "Microsoft",
         "origin:Storm-1044": "Microsoft",
         "refs": [
@@ -15662,6 +17496,14 @@
       "description": "Agonizing Serpens is an Iranian-linked APT group that has been active since 2020. They are known for their destructive wiper and fake-ransomware attacks, primarily targeting Israeli organizations in the education and technology sectors. The group has strong connections to Iran's Ministry of Intelligence and Security and has been observed using various tools and techniques to bypass security measures. They aim to steal sensitive information, including PII and intellectual property, and inflict damage by wiping endpoints.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Pink Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0022:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Agrius:adb3369a-5683-46b2-bceb-4dafa6526b21",
+          "Agonizing Serpens:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "UNC2428:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "SPECTRAL KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:DEV-0022": "Microsoft",
         "origin:UNC2428": "Mandiant",
         "refs": [
@@ -15691,6 +17533,10 @@
       "description": "Storm-1084 is a threat actor that has been observed collaborating with the MuddyWater group. They have used the DarkBit persona to mask their involvement in targeted attacks. Storm-1084 has been linked to destructive actions, including the encryption of on-premise devices and deletion of cloud resources. They have been observed using tools such as Rport, Ligolo, and a customized PowerShell backdoor. The extent of their autonomy or collaboration with other Iranian threat actors is currently unclear.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Storm-1084:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-1084:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-1084": "Microsoft",
         "origin:Storm-1084": "Microsoft",
         "refs": [
@@ -15708,6 +17554,9 @@
       "description": "Storm-1099 is a sophisticated Russia-affiliated influence actor that has been conducting pro-Russia influence operations targeting international supporters of Ukraine since Spring 2022. They are known for their website forgery operation called \"Doppelganger\" and have been actively spreading false information. They have been involved in pushing the claim that Hamas acquired Ukrainian weapons for an attack on Israel. Storm-1099 has also been implicated in amplifying images of graffiti in Paris, suggesting possible Russian involvement and aligning with Russia's Active Measures playbook.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Storm-1099:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1099": "Microsoft",
         "refs": [
           "https://blogs.microsoft.com/on-the-issues/2023/12/07/russia-ukraine-digital-threat-celebrity-cameo-mtac/"
@@ -15719,6 +17568,9 @@
     {
       "description": "Storm-1286 is a threat actor that engages in large-scale spamming activities, primarily targeting user accounts without multifactor authentication enabled. They employ password spraying attacks to compromise these accounts and utilize legacy authentication protocols like IMAP and SMTP. In the past, they have attempted to compromise admin accounts and create new LOB applications with high administrative permissions to spread spam. Despite previous actions taken by Microsoft Threat Intelligence, Storm-1286 continues to explore new methods to establish a high-scale spamming platform within victim organizations using non-privileged users.",
       "meta": {
+        "name-attribution": [
+          "Storm-1286:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1286": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/12/12/threat-actors-misuse-oauth-applications-to-automate-financially-driven-attacks/"
@@ -15730,6 +17582,10 @@
     {
       "description": "DEV-1101 is a threat actor tracked by Microsoft who is responsible for developing and advertising phishing kits, specifically AiTM phishing kits. These kits are capable of bypassing multifactor authentication and are available for purchase or rent by other cybercriminals. DEV-1101 offers an open-source kit with various enhancements, such as mobile device management and CAPTCHA evasion. Their tool has been used in high-volume phishing campaigns by multiple actors, including DEV-0928, and is sold for $300 with VIP licenses available for $1,000.",
       "meta": {
+        "name-attribution": [
+          "Storm-1101:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-1101:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-1101": "Microsoft",
         "origin:Storm-1101": "Microsoft",
         "refs": [
@@ -15746,6 +17602,10 @@
       "description": "Storm-0381 is a threat actor identified by Microsoft as a Russian cybercrime group. They are known for their use of malvertising to deploy Magniber, a type of ransomware.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Storm-0381:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0381:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0381": "Microsoft",
         "origin:Storm-0381": "Microsoft",
         "refs": [
@@ -15762,6 +17622,10 @@
       "description": "H0lyGh0st is a North Korean threat actor that has been active since June 2021. They are responsible for developing and deploying the H0lyGh0st ransomware, which targets small-to-medium businesses in various sectors. The group employs \"double extortion\" tactics, encrypting data and threatening to publish it if the ransom is not paid. There are connections between H0lyGh0st and the PLUTONIUM APT group, indicating a possible affiliation.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Storm-0530:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0530:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0530": "Microsoft",
         "origin:Storm-0530": "Microsoft",
         "refs": [
@@ -15782,6 +17646,9 @@
     {
       "description": "Storm-0539 is a financially motivated threat actor that has been active since at least 2021. They primarily target retail organizations for gift card fraud and theft. Their tactics include phishing via emails or SMS to distribute malicious links that redirect users to phishing pages designed to steal credentials and session tokens. Once access is gained, Storm-0539 registers a device for secondary authentication prompts, bypassing multi-factor authentication and gaining persistence in the environment. They also collect emails, contact lists, and network configurations for further attacks against the same organizations.",
       "meta": {
+        "name-attribution": [
+          "Storm-0539:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0539": "Microsoft",
         "refs": [
           "https://www.rewterz.com/rewterz-news/rewterz-threat-update-microsoft-warns-of-emerging-threat-by-storm-0539-behind-gift-card-frauds/",
@@ -15795,6 +17662,9 @@
       "description": "Storm-1152, a cybercriminal group, was recently taken down by Microsoft for illegally reselling Outlook accounts. They operated by creating approximately 750 million fraudulent Microsoft accounts and earned millions of dollars in illicit revenue. Storm-1152 also offered CAPTCHA-solving services and was connected to ransomware and extortion groups. Microsoft obtained a court order to seize their infrastructure and domains, disrupting their operations.",
       "meta": {
         "country": "VN",
+        "name-attribution": [
+          "Storm-1152:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1152": "Microsoft",
         "refs": [
           "https://securityboulevard.com/2023/12/microsoft-storm-1152-crackdown-stopping-threat-actors/",
@@ -15808,6 +17678,11 @@
     {
       "description": "Storm-1567 is the threat actor behind the Ransomware-as-a-Service Akira. They attacked Swedish organizations in March 2023. This ransomware utilizes the ChaCha encryption algorithm, PowerShell, and Windows Management Instrumentation (WMI). Microsoft's Defender for Endpoint successfully blocked a large-scale hacking campaign carried out by Storm-1567, highlighting the effectiveness of their security solution.",
       "meta": {
+        "name-attribution": [
+          "Storm-1567:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "PUNK SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD SAHARA:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD SAHARA": "Secureworks",
         "origin:Storm-1567": "Microsoft",
         "refs": [
@@ -15838,6 +17713,10 @@
     {
       "description": "Nwgen is a group that focuses on data exfiltration and ransomware activities. They have been found to share techniques with other threat groups such as Karakurt, Lapsus$, and Yanluowang. Nwgen has been observed carrying out attacks and deploying ransomware, encrypting files and demanding a ransom of $150,000 in Monero cryptocurrency for the decryption software.",
       "meta": {
+        "name-attribution": [
+          "Storm-0829:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0829:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0829": "Microsoft",
         "origin:Storm-0829": "Microsoft",
         "refs": [
@@ -15857,6 +17736,9 @@
     {
       "description": "Storm-1674 is an access broker known for using tools based on the publicly available TeamsPhisher tool to distribute DarkGate malware. Storm-1674 campaigns have typically relied on phishing lures sent over Teams with malicious attachments, such as ZIP files containing a LNK file that ultimately drops DarkGate and Pikabot. In September 2023, Microsoft observed handoffs from Storm-1674 to ransomware operators that have led to Black Basta ransomware deployment.",
       "meta": {
+        "name-attribution": [
+          "Storm-1674:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1674": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2023/12/28/financially-motivated-threat-actors-misusing-app-installer/",
@@ -15869,6 +17751,9 @@
     {
       "description": "Cybercriminals have launched a phishing campaign targeting senior executives in U.S. firms, using the EvilProxy phishing toolkit for credential harvesting and account takeover attacks. This campaign, initiated in July 2023, primarily targets sectors such as banking, financial services, insurance, property management, real estate, and manufacturing. The attackers exploit an open redirection vulnerability on the job search platform \"indeed.com,\" redirecting victims to malicious phishing pages impersonating Microsoft. EvilProxy functions as a reverse proxy, intercepting credentials, two-factor authentication codes, and session cookies to hijack accounts. The threat actors, known as Storm-0835 by Microsoft, have hundreds of customers who pay monthly fees for their services, making attribution difficult. The attacks involve sending phishing emails with deceptive links to Indeed, redirecting victims to EvilProxy pages for credential harvesting.",
       "meta": {
+        "name-attribution": [
+          "Storm-0835:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0835": "Microsoft",
         "refs": [
           "https://www.linkedin.com/pulse/cyber-criminals-using-evilproxy-phishing-kit-target-senior-soral/"
@@ -15880,6 +17765,9 @@
     {
       "description": "Storm-1575 is a threat actor identified by Microsoft as being involved in phishing campaigns using the Dadsec platform. They utilize hundreds of Domain Generated Algorithm domains to host credential harvesting pages and target global organizations to steal Microsoft 365 credentials.",
       "meta": {
+        "name-attribution": [
+          "Storm-1575:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1575": "Microsoft",
         "refs": [
           "https://www.bridewell.com/insights/blogs/detail/analysing-widespread-microsoft365-credential-harvesting-campaign",
@@ -15892,6 +17780,9 @@
     {
       "description": "Since January 2020, Proofpoint researchers have tracked an actor abusing Microsoft Office 365 (O365) third-party application (3PA) access, with suspected activity dating back to August 2019. The actor, known as TA2552, uses well-crafted Spanish language lures that leverage a narrow range of themes and brands. The lures entice users to click a link in the message, taking them to the legitimate Microsoft third-party apps consent page. There they are prompted to grant a third-party application read-only user permissions to their O365 account via OAuth2 or other token-based authorization methods. TA2552 seeks access to specific account resources like the user’s contacts and mail. Requesting read-only permissions for such account resources could be used to conduct account reconnaissance, silently steal data, or to intercept password reset messages from other accounts such as those at financial institutions. While organizations with global presence have received messages from this group, they appear to choose recipients who are likely Spanish speakers. \n\n",
       "meta": {
+        "name-attribution": [
+          "TA2552:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2552": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/ta2552-uses-oauth-access-token-phishing-exploit-read-only-risks"
@@ -15903,6 +17794,9 @@
     {
       "description": "TA2722 is a highly active threat actor that targets various industries including Shipping/Logistics, Manufacturing, Business Services, Pharmaceutical, and Energy. They primarily focus on organizations in North America, Europe, and Southeast Asia. This threat actor impersonates Philippine government entities and uses themes related to the government to gain remote access to target computers. Their objectives include information gathering, installing follow-on malware, and engaging in business email compromise activities.",
       "meta": {
+        "name-attribution": [
+          "TA2722:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2722": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/new-threat-actor-spoofs-philippine-government-covid-19-health-data-widespread"
@@ -15917,6 +17811,9 @@
     {
       "description": "In late March 2020, Proofpoint researchers began tracking a new actor with a penchant for using NanoCore and later AsyncRAT, popular commodity remote access trojans (RATs). Dubbed TA2719 by Proofpoint, the actor uses localized lures with colorful images that impersonate local banks, law enforcement, and shipping services. Proofpoint has observed this actor send low volume campaigns to recipients in Austria, Chile, Greece, Hungary, Italy, North Macedonia, Netherlands, Spain, Sweden, Taiwan, United States, and Uruguay. ",
       "meta": {
+        "name-attribution": [
+          "TA2719:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2719": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/threat-actor-profile-ta2719-uses-colorful-lures-deliver-rats-local-languages"
@@ -15943,6 +17840,10 @@
       "description": "Storm-0473 (Tomiris) is a threat actor that has been active since at least 2019. They primarily target government and diplomatic entities in the Commonwealth of Independent States region, with occasional victims in other regions being foreign representations of CIS countries. Tomiris uses a wide variety of malware implants, including downloaders, backdoors, and file stealers, developed in different programming languages. They employ various attack vectors such as spear-phishing, DNS hijacking, and exploitation of vulnerabilities. There are potential ties between Tomiris and Turla, but they are considered separate threat actors with distinct targeting and tradecraft by Kaspersky.",
       "meta": {
         "country": "KZ",
+        "name-attribution": [
+          "Storm-0473:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "UNC2849:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:Storm-0473": "Microsoft",
         "origin:UNC2849": "Mandiant",
         "refs": [
@@ -16001,6 +17902,9 @@
     {
       "description": "RevengeHotels is a targeted cybercrime campaign that has been active since 2015, primarily targeting hotels, hostels, and tourism companies. The threat actor uses remote access Trojan malware to infiltrate hotel front desks and steal credit card data from guests and travelers. The campaign has impacted hotels in multiple countries, including Brazil, Argentina, Chile, and Mexico. The threat actor employs social engineering techniques and sells credentials from infected systems to other cybercriminals for remote access.",
       "meta": {
+        "name-attribution": [
+          "RevengeHotels:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/revengehotels/95229/"
         ]
@@ -16012,6 +17916,14 @@
       "description": "GhostEmperor is a Chinese-speaking threat actor that targets government entities and telecom companies in Southeast Asia. They employ a Windows kernel-mode rootkit called Demodex to gain remote control over their targeted servers. The actor demonstrates a high level of sophistication and uses various anti-forensic and anti-analysis techniques to evade detection. They have been active for a significant period of time and continue to pose a threat to their targets.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "GhostEmperor:0d4886f9-97e1-4cb2-8822-580fd09540e5",
+          "FamousSparrow:3a43aca5-6366-4168-b182-a8afec4550b5",
+          "UNC2286:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Salt Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "RedMike:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "OPERATOR PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:UNC2286": "Mandiant",
         "refs": [
           "https://securelist.com/ghostemperor-from-proxylogon-to-kernel-mode/104407/",
@@ -16046,6 +17958,9 @@
     {
       "description": "Operation Triangulation is an ongoing APT campaign targeting iOS devices with zero-click iMessage exploits. The threat actor behind the campaign has been active since at least 2019 and continues to operate. The attack chain involves the delivery of a malicious iMessage attachment that launches a series of exploits, ultimately leading to the deployment of the TriangleDB implant. Kaspersky researchers have discovered and reported multiple vulnerabilities used in the campaign, with patches released by Apple.",
       "meta": {
+        "name-attribution": [
+          "Operation Triangulation:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/operation-triangulation-the-last-hardware-mystery/111669/",
           "https://securelist.com/operation-triangulation-catching-wild-triangle/110916/",
@@ -16059,6 +17974,9 @@
     {
       "description": "Operation Ghoul is a profit-driven threat actor that targeted over 130 organizations in 30 countries, primarily in the industrial and engineering sectors. They employed high-quality social engineering techniques, such as spear-phishing emails disguised as payment advice from a UAE bank, to distribute malware. The group's main motivation is financial gain through the sale of stolen intellectual property and business intelligence, as well as attacks on banking accounts. Their attacks were effective, particularly against companies that were unprepared to detect them.",
       "meta": {
+        "name-attribution": [
+          "Operation Ghoul:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/kaspersky-security-bulletin-2016-executive-summary/76858/",
           "https://securelist.com/operation-ghoul-targeted-attacks-on-industrial-and-engineering-organizations/75718/"
@@ -16082,6 +18000,9 @@
       "description": "Ferocious Kitten is an APT group that has been active against Persian-speaking individuals since 2015 and appears to be based in Iran. Although it has been active over a large timespan, the group has mostly operated under the radar until a lure document was uploaded to VirusTotal and was brought to public knowledge by researchers on Twitter. Subsequently, one of its implants was analyzed by a Chinese intelligence firm. Kaspersky then expanded some of the findings on the group and provided insights on additional variants. The malware dropped from the aforementioned document is dubbed MarkiRAT and is used to record keystrokes and clipboard content, provide file download and upload capabilities as well as the ability to execute arbitrary commands on the victims machine. Kaspersky were able to trace the implant back to at least 2015, along with variants intended to hijack the execution of the Telegram and Chrome applications as a persistence method. Interestingly, some of the TTPs used by this threat actor are reminiscent of other groups operating in the domain of dissident surveillance. For example, it used the same C2 domains across its implants for years, which was witnessed in the activity of Domestic Kitten. In the same vein, the Telegram execution hijacking technique observed in this campaign by Ferocious Kitten was also observed being used by Rampant Kitten, as covered by Check Point.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Ferocious Kitten:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://securelist.com/ferocious-kitten-6-years-of-covert-surveillance-in-iran/102806/"
         ]
@@ -16093,6 +18014,9 @@
       "description": "The threat actors compromised the update server of a remote support solutions provider to deliver a remote access tool called 9002 RAT to their targets of interest through the update process. They carried this out by first stealing the company’s certificate then using it to sign the malware. They also configured the update server to only deliver malicious files if the client is located in the range of IP addresses of their target organisations.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Operation Red Signature:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://decoded.avast.io/threatintel/avast-finds-backdoor-on-us-government-commission-network/?utm_source=rss&utm_medium=rss&utm_campaign=avast-finds-backdoor-on-us-government-commission-network",
           "https://www.trendmicro.com/en_my/research/18/h/supply-chain-attack-operation-red-signature-targets-south-korean-organizations.html"
@@ -16104,6 +18028,9 @@
     {
       "description": "Earth Yako is a threat actor that has been actively targeting researchers in academic organizations and think tanks in Japan. They use spearphishing emails with malicious attachments to gain initial access to their targets' systems. Earth Yako's objectives and patterns suggest a possible connection to a Chinese APT group, but conclusive proof of their nationality is lacking. They have been observed using various malware delivery methods and techniques, such as the use of Winword.exe for DLL Hijacking.",
       "meta": {
+        "name-attribution": [
+          "Earth Yako:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Yako": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/23/b/invitation-to-secret-event-uncovering-earth-yako-campaigns.html"
@@ -16119,6 +18046,9 @@
     {
       "description": "What sets Urpage attacks apart is its targeting of InPage, a word processor for Urdu and Arabic languages. However, its Delphi backdoor component, which it has in common with Confucius and Patchwork, and its apparent use of Bahamut-like malware, is what makes it more intriguing as it connects Urpage to these other known threats. Trend Micro covered the Delphi component in the context of the Confucius and Patchwork connection. They mentioned Urpage as a third unnamed threat actor connected to the two.",
       "meta": {
+        "name-attribution": [
+          "Urpage:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/18/h/the-urpage-connection-to-bahamut-confucius-and-patchwork.html"
         ]
@@ -16144,6 +18074,9 @@
     {
       "description": "TA2725 is a threat actor that has been tracked since March 2022. They primarily target organizations in Brazil and Mexico using Brazilian banking malware and phishing techniques. Recently, they have expanded their operations to also target victims in Spain and Mexico simultaneously. TA2725 typically uses GoDaddy virtual hosting for their URL redirector and hosts malicious files on legitimate cloud hosting providers like Amazon AWS, Google Cloud, or Microsoft Azure. They have been known to spoof legitimate companies, such as ÉSECÈ Group, to deceive their victims.",
       "meta": {
+        "name-attribution": [
+          "TA2725:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2725": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/copacabana-barcelona-cross-continental-threat-brazilian-banking-malware"
@@ -16202,6 +18135,11 @@
           "Sabotage"
         ],
         "country": "IR",
+        "name-attribution": [
+          "BANISHED KITTEN:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "Storm-0842:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "Red Sandstorm:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0842": "Microsoft",
         "refs": [
           "https://www.crowdstrike.com/adversaries/banished-kitten/",
@@ -16229,6 +18167,9 @@
     {
       "description": "Since the beginning of 2023, ResumeLooters have been able to compromise at least 65 websites. The group employs a variety of simple techniques, including SQL injection and XSS. The threat actor attempted to insert XSS scripts into all available forms, aiming to execute it on the administrators’ device to obtain admin credentials. While the group was able to execute the XSS script on some visitors’ devices with administrative access, allowing ResumeLooters to steal the HTML code of the pages the victims were visiting, Group-IB did not find any confirmation of admin credential thefts.",
       "meta": {
+        "name-attribution": [
+          "ResumeLooters:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/resumelooters/"
         ]
@@ -16239,6 +18180,9 @@
     {
       "description": "ShadowSyndicate is a threat actor associated with various ransomware groups, using a consistent Secure Shell fingerprint across multiple servers. They have been linked to ransomware families such as Quantum, Nokoyawa, and ALPHV. ShadowSyndicate's infrastructure overlaps with that of Cl0p, suggesting potential connections between the two groups. Their activities indicate they may be a Ransomware-as-a-Service affiliate.",
       "meta": {
+        "name-attribution": [
+          "ShadowSyndicate:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/shadowsyndicate-raas/"
         ]
@@ -16275,6 +18219,9 @@
       "description": "GoldFactory is a threat actor group attributed to developing sophisticated mobile banking malware targeting victims primarily in the Asia-Pacific region, specifically Vietnam and Thailand. They utilize social engineering to deliver malware to victims' devices and have close connections to the Gigabud malware family. GoldFactory's Trojans, such as GoldPickaxe and GoldDigger, employ tactics like smishing, phishing, and fake login screens to compromise victims' phones and steal sensitive information. Their evolving malware suite demonstrates a high level of operational maturity and ingenuity, requiring a proactive and multi-faceted cybersecurity approach to detect and mitigate their threats.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "GoldFactory:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/goldfactory-ios-trojan/"
         ]
@@ -16285,6 +18232,9 @@
     {
       "description": "SPIKEDWINE is a threat actor targeting European officials with a new backdoor called WINELOADER. They use a bait PDF document posing as an invitation letter from the Ambassador of India to lure diplomats. The attack is characterized by advanced tactics, techniques, and procedures in the malware and command and control infrastructure. The motivation behind the attacks seems to be exploiting the geopolitical relations between India and European nations.",
       "meta": {
+        "name-attribution": [
+          "SPIKEDWINE:1427d7df-a9b8-4809-afe0-1180cfdd930d"
+        ],
         "refs": [
           "https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-spikedwine-wineloader"
         ]
@@ -16307,6 +18257,10 @@
       "description": "UNC1549 is an Iranian threat actor linked to Tortoiseshell and potentially the IRGC. They have been active since at least June 2022, targeting entities worldwide with a focus on the Middle East. UNC1549 uses spear-phishing and credential harvesting for initial access, deploying custom malware like MINIBIKE and MINIBUS backdoors. They have also been observed using evasion techniques and a tunneler named LIGHTRAIL in their operations.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "UNC1549:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Nimbus Manticore:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "origin:UNC1549": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/suspected-iranian-unc1549-targets-israel-middle-east",
@@ -16347,6 +18301,9 @@
       "description": "UNC5325 is a suspected Chinese cyber espionage operator that exploited CVE-2024-21893 to compromise Ivanti Connect Secure appliances. UNC5325 leveraged code from open-source projects, installed custom malware, and modified the appliance's settings in order to evade detection and attempt to maintain persistence. UNC5325 has been observed deploying LITTLELAMB.WOOLTEA, PITSTOP, PITDOG, PITJET, and PITHOOK. Mandiant identified TTPs and malware code overlaps in LITTLELAMB.WOOLTEA and PITHOOK with malware leveraged by UNC3886. Mandiant assesses with moderate confidence that UNC5325 is associated with UNC3886.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC5325:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5325": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/investigating-ivanti-exploitation-persistence"
@@ -16358,6 +18315,12 @@
     {
       "description": "Earth Kapre is an APT group specializing in cyberespionage. They target organizations in various countries through phishing campaigns using malicious attachments to infect machines. Earth Kapre employs techniques like abusing PowerShell, curl, and Program Compatibility Assistant to execute malicious commands and evade detection within targeted networks. The group has been active since at least 2018 and has been linked to multiple incidents involving data theft and espionage.",
       "meta": {
+        "name-attribution": [
+          "Earth Kapre:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "RedCurl:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "GOLD BLADE:455b9e40-e8dd-443b-87b3-c70bd09b4231",
+          "GOLD BLADE:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:Earth Kapre": "Trend Micro",
         "origin:GOLD BLADE": "Secureworks",
         "refs": [
@@ -16377,6 +18340,9 @@
       "description": "Earth Krahang is an APT group targeting government organizations worldwide. They use spear-phishing emails, weak internet-facing servers, and custom backdoors like Cobalt Strike, RESHELL, and XDealer to conduct cyber espionage. The group creates VPN servers on infected systems, employs brute force attacks on email accounts, and exploits compromised government infrastructure to attack other governments. Earth Krahang has been linked to another China-linked actor, Earth Lusca, and is believed to be part of a specialized task force for cyber espionage against government institutions.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Earth Krahang:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Krahang": "Trend Micro",
         "refs": [
           "https://www.rewterz.com/rewterz-news/rewterz-threat-alert-china-linked-earth-krahang-apt-breached-70-organizations-in-23-nations-active-iocs",
@@ -16434,6 +18400,9 @@
     {
       "description": "UNC5174, a Chinese state-sponsored threat actor, has been identified by Mandiant for exploiting critical vulnerabilities in F5 BIG-IP and ScreenConnect. They have been linked to targeting research and education institutions, businesses, charities, NGOs, and government organizations in Southeast Asia, the U.S., and the UK. UNC5174 is believed to have connections to China's Ministry of State Security and has been observed using custom tooling and the SUPERSHELL framework in their operations. The actor has shown indications of transitioning from hacktivist collectives to working as a contractor for Chinese intelligence agencies.",
       "meta": {
+        "name-attribution": [
+          "UNC5174:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5174": "Mandiant",
         "refs": [
           "https://rhisac.org/threat-intelligence/f5-big-ip-and-screenconnect-cves/",
@@ -16498,6 +18467,9 @@
       "description": "CoralRaider is a financially motivated threat actor of Vietnamese origin, targeting victims in Asian and Southeast Asian countries since at least 2023. They use the RotBot loader family and XClient stealer to steal victim information, with hardcoded Vietnamese words in their payloads. CoralRaider operates from Hanoi, Vietnam, and uses a Telegram bot as a C2 channel for their malicious campaigns. Their activities include system reconnaissance, data exfiltration, and targeting victims in multiple countries in the region.",
       "meta": {
         "country": "VN",
+        "name-attribution": [
+          "CoralRaider:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/coralraider-targets-socialmedia-accounts/"
         ]
@@ -16519,6 +18491,9 @@
     {
       "description": "Starry Addax is a threat actor targeting human rights activists associated with the Sahrawi Arab Democratic Republic using a novel mobile malware called FlexStarling. They conduct phishing attacks to trick targets into installing malicious Android applications and serve credential-harvesting pages to Windows-based targets. Their infrastructure targets both Windows and Android users, with the campaign starting with spear-phishing emails containing requests to install specific mobile apps or related themes. The campaign is in its early stages, with potential for additional malware variants and infrastructure development.",
       "meta": {
+        "name-attribution": [
+          "Starry Addax:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/starry-addax/"
         ]
@@ -16576,6 +18551,9 @@
     {
       "description": "Mandiant created UNC5266 to track post-disclosure exploitation leading to deployment of Bishop Fox's SLIVER implant framework, a WARPWIRE variant, and a new malware family that Mandiant has named TERRIBLETEA. At this time, based on observed infrastructure usage similarities, Mandiant suspects with moderate confidence that UNC5266 overlaps in part with UNC3569, a China-nexus espionage actor that has been observed exploiting vulnerabilities in Aspera Faspex, Microsoft Exchange, and Oracle Web Applications Desktop Integrator, among others, to gain initial access to target environments. ",
       "meta": {
+        "name-attribution": [
+          "UNC5266:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5266": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/ivanti-post-exploitation-lateral-movement"
@@ -16604,6 +18582,9 @@
       "description": "UNC5330 is a suspected China-nexus espionage actor. UNC5330 has been observed chaining CVE-2024-21893 and CVE-2024-21887 to compromise Ivanti Connect Secure VPN appliances as early as Feb. 2024. Post-compromise activity by UNC5330 includes deployment of PHANTOMNET and TONERJAM. UNC5330 has employed Windows Management Instrumentation (WMI) to perform reconnaissance, move laterally, manipulate registry entries, and establish persistence.\nMandiant observed UNC5330 operating a server since Dec. 6, 2021, which the group used as a GOST proxy to help facilitate malicious tool deployment to endpoints. The default certificate for GOST proxy was observed from Sept. 1, 2022 through Jan. 1, 2024. UNC5330 also attempted to download Fast Reverse Proxy (FRP) from this server on Feb. 3, 2024, from a compromised Ivanti Connect Secure device. Given the SSH key reuse in conjunction with the temporal proximity of these events, Mandiant assesses with moderate confidence UNC5330 has been operating through this server since at least 2021.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC5330:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5330": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/ivanti-post-exploitation-lateral-movement"
@@ -16639,6 +18620,9 @@
       "description": "UNC5337 is a suspected China-nexus espionage actor that compromised Ivanti Connect Secure VPN appliances as early as Jan. 2024. UNC5337 is suspected to exploit CVE-2023-46805 (authentication bypass) and CVE-2024-21887 (command injection) for infecting Ivanti Connect Secure appliances. UNC5337 leveraged multiple custom malware families including the SPAWNSNAIL passive backdoor, SPAWNMOLE tunneler, SPAWNANT installer, and SPAWNSLOTH log tampering utility. Mandiant suspects with medium confidence that UNC5337 is UNC5221.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC5337:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5337": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/ivanti-post-exploitation-lateral-movement"
@@ -16687,6 +18671,9 @@
     {
       "description": "UNC5291 is a cluster of targeted probing activity that we assess with moderate confidence is associated with UNC3236, also known publicly as Volt Typhoon. Activity for this cluster started in December 2023 focusing on Citrix Netscaler ADC and then shifted to focus on Ivanti Connect Secure devices after details were made public in mid-Jan. 2024. Probing has been observed against the academic, energy, defense, and health sectors, which aligns with past Volt Typhoon interest in critical infrastructure. In Feb. 2024, the Cybersecurity and Infrastructure Security Agency (CISA) released an advisory warning that Volt Typhoon was targeting critical infrastructure and was potentially interested in Ivanti Connect Secure devices for initial access.",
       "meta": {
+        "name-attribution": [
+          "UNC5291:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5291": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/ivanti-post-exploitation-lateral-movement"
@@ -16708,6 +18695,9 @@
       "description": "China-nexus espionage actor that has been observed exploiting vulnerabilities in Aspera Faspex, Microsoft Exchange, and Oracle Web Applications Desktop Integrator, among others, to gain initial access to target environments. ",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC3569:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC3569": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/ivanti-post-exploitation-lateral-movement"
@@ -16720,6 +18710,9 @@
       "description": "Earth Freybug, identified as a subset of APT41, is a cyberthreat group active since at least 2012, engaging in espionage and financially motivated activities across various sectors worldwide. The tactics, techniques, and procedures (TTPs) used in this campaign are similar to the ones from a campaign (Operation CuckooBees) described in an article published by Cybereason. They employ a diverse toolkit, including LOLBins and custom malware, to execute sophisticated cyberespionage attacks. The group's recent tactics involve DLL hijacking and API unhooking through a newly discovered malware named UNAPIMON, which prevents child processes from being monitored. This technique was observed in a vmtoolsd.exe process creating remote tasks to deploy malicious batch files for reconnaissance and backdoor access. UNAPIMON's simplicity and use of Microsoft Detours for defense evasion highlight the group's evolving methods and the need for vigilant security measures, such as restricting admin privileges and adhering to the principle of least privilege. Earth Freybug's persistence and creativity in refining their techniques underscore the ongoing threat they pose and the importance of proactive cybersecurity practices.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Earth Freybug:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Freybug": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/d/earth-freybug.html"
@@ -16764,6 +18757,9 @@
     {
       "description": "ArcaneDoor is a campaign that is the latest example of state-sponsored actors targeting perimeter network devices from multiple vendors. Coveted by these actors, perimeter network devices are the perfect intrusion point for espionage-focused campaigns. As a critical path for data into and out of the network, these devices need to be routinely and promptly patched; using up-to-date hardware and software versions and configurations; and be closely monitored from a security perspective. Gaining a foothold on these devices allows an actor to directly pivot into an organization, reroute or modify traffic and monitor network communications. In the past two years, we have seen a dramatic and sustained increase in the targeting of these devices in areas such as telecommunications providers and energy sector organizations — critical infrastructure entities that are likely strategic targets of interest for many foreign governments.",
       "meta": {
+        "name-attribution": [
+          "ArcaneDoor:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/arcanedoor-new-espionage-focused-campaign-found-targeting-perimeter-network-devices/"
         ]
@@ -16774,6 +18770,9 @@
     {
       "description": "UAT4356 is a state-sponsored threat actor that targeted government networks globally through a campaign named ArcaneDoor. They exploited two zero-day vulnerabilities in Cisco Adaptive Security Appliances to deploy custom malware implants called \"Line Runner\" and \"Line Dancer.\" The actor demonstrated a deep understanding of Cisco systems, utilized anti-forensic measures, and took deliberate steps to evade detection. UAT4356's sophisticated attack chain allowed them to conduct malicious actions such as configuration modification, reconnaissance, network traffic capture/exfiltration, and potentially lateral movement on compromised devices.",
       "meta": {
+        "name-attribution": [
+          "Storm-1849:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1849": "Microsoft",
         "refs": [
           "https://blog.talosintelligence.com/arcanedoor-new-espionage-focused-campaign-found-targeting-perimeter-network-devices/"
@@ -16801,6 +18800,9 @@
     {
       "description": "Water Orthrus is a threat actor known for distributing CopperStealer and CopperPhish malware. They target Microsoft 365 users with phishing campaigns to steal credit card information. The actor has evolved their malware to include rootkits for stealthy installations and has shifted their focus from personal information to cryptocurrency and credit card data. Water Orthrus has been linked to the Scranos campaign reported in 2019.",
       "meta": {
+        "name-attribution": [
+          "Water Orthrus:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/23/e/water-orthrus-new-campaigns-deliver-rootkit-and-phishing-modules.html"
         ]
@@ -16811,6 +18813,9 @@
     {
       "description": "Head Mare is a hacktivism focussed threat actor group known for targeting Russia and Belarus sectors using a remote access malware called PhantomRAT. They have been observed executing malicious code through specially crafted RAR archives, different from previous attacks exploiting vulnerabilities. The attribution of their campaign to Ukraine is uncertain due to limited visibility inside Russian networks. PhantomCore's use of RAR archives in their attack chain has been previously observed in other threat actor groups like Forest Blizzard.",
       "meta": {
+        "name-attribution": [
+          "Head Mare:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://therecord.media/russian-researchers-winrar-bug-ukraine-espionage",
           "https://www.facct.ru/blog/phantomdl-loader",
@@ -16836,6 +18841,9 @@
       "description": "Void Manticore is an Iranian APT group affiliated with MOIS, known for conducting destructive wiping attacks and influence operations. They collaborate with Scarred Manticore, sharing targets and conducting disruptive operations using custom wipers. Void Manticore's TTPs involve manual file deletion, lateral movement via RDP, and the deployment of custom wipers like the BiBi wiper. The group utilizes online personas like 'Karma' and 'Homeland Justice' to leak information and amplify the impact of their attacks.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Void Manticore:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2024/bad-karma-no-justice-void-manticore-destructive-activities-in-israel/"
         ]
@@ -16846,6 +18854,9 @@
     {
       "description": "ALPHA SPIDER is a threat actor known for developing and operating the Alphv ransomware as a service. They have been observed using novel offensive techniques, such as exploiting software vulnerabilities and leveraging legitimate administration tools for malicious activities. ALPHA SPIDER affiliates have demonstrated persistence in exfiltrating data and have shown the ability to bypass security measures like DNS-based filtering and multifactor authentication. Despite lacking specific operational security measures, defenders have opportunities to detect and respond to ALPHA SPIDER's operations effectively.",
       "meta": {
+        "name-attribution": [
+          "Alpha Spider:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/blog/anatomy-of-alpha-spider-ransomware/"
         ],
@@ -16868,6 +18879,9 @@
     {
       "description": "RansomHub is a rapidly growing ransomware group believed to be an updated version of the older Knight ransomware. They have been linked to attacks exploiting the Zerologon vulnerability to gain initial access. RansomHub has attracted former affiliates of the ALPHV ransomware group and operates as a Ransomware-as-a-Service with a unique affiliate prepayment model. The group has been active in extorting victims and leaking sensitive data to pressure for ransom payments.",
       "meta": {
+        "name-attribution": [
+          "RansomHub:e583434b-7fb8-42c8-90ce-89aa8ed35f0c"
+        ],
         "refs": [
           "https://symantec-enterprise-blogs.security.com/threat-intelligence/ransomhub-knight-ransomware",
           "https://forescoutstage.wpengine.com/blog/analysis-a-new-ransomware-group-emerges-from-the-change-healthcare-cyber-attack/",
@@ -16904,6 +18918,9 @@
       "description": "FlyingYeti is a Russia-aligned threat actor targeting Ukrainian military entities. They conduct reconnaissance activities and launch phishing campaigns using malware like COOKBOX. FlyingYeti exploits the WinRAR vulnerability CVE-2023-38831 to infect targets with malicious payloads. Cloudforce One has successfully disrupted their operations and provided recommendations for defense against their phishing campaigns.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Storm-1837:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1837": "Microsoft",
         "refs": [
           "https://blog.cloudflare.com/disrupting-flyingyeti-campaign-targeting-ukraine",
@@ -16933,6 +18950,9 @@
     {
       "description": "LilacSquid is an APT actor targeting a variety of industries worldwide since at least 2021. They use tactics such as exploiting vulnerabilities and compromised RDP credentials to gain access to victim organizations. Their post-compromise activities involve deploying MeshAgent and a customized version of QuasarRAT known as PurpleInk to maintain control over infected systems. LilacSquid has been observed using tools like Secure Socket Funneling for data exfiltration.",
       "meta": {
+        "name-attribution": [
+          "LilacSquid:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/lilacsquid/"
         ]
@@ -16975,6 +18995,9 @@
     {
       "description": "UNC5537 is a financially motivated threat actor targeting Snowflake customer databases. They use stolen credentials obtained from infostealer malware to access and exfiltrate large volumes of data. The compromised accounts lack multi-factor authentication, allowing UNC5537 to conduct data theft and extortion.",
       "meta": {
+        "name-attribution": [
+          "UNC5537:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5537": "Mandiant",
         "refs": [
           "https://research.checkpoint.com/2024/17th-june-threat-intelligence-report/",
@@ -16998,6 +19021,9 @@
     {
       "description": "TA571 is a spam distributor actor known for delivering a variety of malware, including DarkGate, NetSupport RAT, and information stealers. They use phishing emails with macro-enabled attachments to spread malicious PDFs containing rogue OneDrive links. TA571 has been observed using unique filtering techniques with intermediary \"gates\" to target specific users and bypass automated sandboxing. Proofpoint assesses with high confidence that TA571 infections can lead to ransomware.",
       "meta": {
+        "name-attribution": [
+          "TA571:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/security-brief-ta571-delivers-icedid-forked-loader",
           "https://www.proofpoint.com/us/blog/threat-insight/clipboard-compromise-powershell-self-pwn"
@@ -17038,6 +19064,9 @@
     {
       "description": "Void Arachne is a threat actor group targeting Chinese-speaking users with malicious MSI files containing legitimate software installers for AI software. They exploit public interest in VPN technology and AI software to distribute malware through SEO poisoning and Chinese-language-themed Telegram channels. The group's campaign includes bundling malicious Winos payloads with deepfake pornography-generating AI software and voice-and-face-swapping AI software. Void Arachne also promotes AI technologies for virtual kidnapping and uses AI voice-alternating technology to pressure victims into paying ransom.",
       "meta": {
+        "name-attribution": [
+          "Void Arachne:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/f/behind-the-great-wall-void-arachne-targets-chinese-speaking-user.html"
         ],
@@ -17051,6 +19080,9 @@
     {
       "description": "Markopolo is a threat actor known for running scams targeting cryptocurrency users through a fake app called Vortax. They use social media and a dedicated blog to legitimize their malicious activities. Markopolo has been linked to a credential-harvesting operation and is agile in pivoting to new scams when detected. The actor leverages shared hosting and C2 infrastructure for their malicious builds.",
       "meta": {
+        "name-attribution": [
+          "Markopolo:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.darkreading.com/remote-workforce/vortax-meeting-software-branding-spreads-infostealers",
           "https://www.recordedfuture.com/the-travels-of-markopolo-self-proclaimed-meeting-software-vortax-spreads-infostealers"
@@ -17075,6 +19107,9 @@
     {
       "description": "JuiceLedger is a threat actor known for infostealing through their JuiceStealer .NET assembly. They have evolved from spreading fraudulent applications to conducting supply chain attacks, targeting PyPI contributors with phishing campaigns and typosquatting. Their malicious packages contain a code snippet that downloads and executes JuiceStealer, which has evolved to support additional browsers and Discord. Victims of JuiceLedger attacks are advised to reset passwords and report any suspicious activity to security@pypi.org.",
       "meta": {
+        "name-attribution": [
+          "JuiceLedger:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/pypi-phishing-campaign-juiceledger-threat-actor-pivots-from-fake-apps-to-supply-chain-attacks/"
         ]
@@ -17086,6 +19121,9 @@
       "description": "RedJuliett is a likely Chinese state-sponsored threat actor targeting government, academic, technology, and diplomatic organizations in Taiwan. They exploit vulnerabilities in network edge devices for initial access and use SQL injection and directory traversal exploits against web and SQL applications. The group operates from Fuzhou, China, and aims to support Beijing's intelligence collection on Taiwan's economic and diplomatic relations. RedJuliett has also expanded its operations to compromise organizations in other countries such as Hong Kong, Malaysia, and the United States.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "RedJuliett:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/redjuliett-intensifies-taiwanese-cyber-espionage-via-network-perimeter"
         ]
@@ -17097,6 +19135,9 @@
       "description": "SneakyChef is a threat actor known for using the SugarGh0st RAT to target government agencies, research institutions, and organizations worldwide. They have been active since at least August 2023, with a focus on leveraging old and new command and control domains. The group has been observed using lures in the form of scanned documents related to Ministries of Foreign Affairs and embassies. Talos Intelligence assesses with medium confidence that the operators are likely Chinese-speaking based on language preferences and specific targets.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "SneakyChef:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/sneakychef-sugarghost-rat/"
         ]
@@ -17122,6 +19163,9 @@
     {
       "description": "BlueHornet is an advanced persistent threat group targeting government organizations in China, North Korea, Iran, and Russia. They have compromised and leaked data from other APT groups like Kryptonite Panda and Lazarus Group. BlueHornet has been involved in campaigns such as Operation Renminbi, Operation Ruble, and Operation EUSec, focusing on exfiltrating region-specific data and selling it on the dark web. They have also been known to collaborate with different threat actors and have recently disclosed a zero-day exploit in NGINX 1.18.",
       "meta": {
+        "name-attribution": [
+          "APT49:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://cyberint.com/blog/research/bluehornet-one-apt-to-terrorize-them-all/",
           "https://www.mandiant.com/resources/blog/killnet-new-capabilities-older-tactics",
@@ -17163,6 +19207,9 @@
       "description": "DRAGONBRIDGE is a Chinese state-sponsored threat actor known for engaging in information operations to promote the political interests of the People's Republic of China. They have been observed using AI-generated images and videos to spread propaganda on social media platforms. The group has targeted various countries and regions, including the US, Taiwan, and Japan, with narratives promoting pro-PRC viewpoints. DRAGONBRIDGE has been linked to campaigns discrediting the US political system, sowing division between allies, and criticizing specific companies and individuals.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Dragonbridge:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/prc-dragonbridge-influence-elections/",
           "https://quointelligence.eu/2024/06/european-election-at-risk-analysis/",
@@ -17178,6 +19225,9 @@
     {
       "description": "Boolka is a threat actor known for infecting websites with malicious JavaScript scripts for data exfiltration. They have been carrying out opportunistic SQL injection attacks since at least 2022. Boolka has developed a malware delivery platform based on the BeEF framework and has been distributing the BMANAGER trojan. Their activities demonstrate a progression from basic website infections to more sophisticated malware operations.",
       "meta": {
+        "name-attribution": [
+          "Boolka:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/boolka/"
         ]
@@ -17188,6 +19238,9 @@
     {
       "description": "CloudSorcerer is a sophisticated APT targeting Russian government entities, utilizing cloud infrastructure for stealth monitoring and data exfiltration. The malware leverages APIs and authentication tokens to access cloud resources for command and control, with GitHub serving as its initial C2 server. CloudSorcerer operates as separate modules depending on the process it's running in, executing from a single executable and utilizing complex inter-process communication through Windows pipes. The actor behind CloudSorcerer shows similarities to the CloudWizard APT in modus operandi, but the unique code and functionality suggest it is a new threat actor inspired by previous techniques.",
       "meta": {
+        "name-attribution": [
+          "CloudSorcerer:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/cloudsorcerer-new-apt-cloud-actor/113056/"
         ]
@@ -17199,6 +19252,9 @@
       "description": "The 8220 Gang, also known as Water Sigbin, is a threat actor group that focuses on deploying cryptocurrency-mining malware. They exploit vulnerabilities in Oracle WebLogic servers, such as CVE-2017-3506 and CVE-2023-21839, to deliver cryptocurrency miners using PowerShell scripts. The group has demonstrated a sophisticated multistage loading technique to deploy the PureCrypter loader and XMRIG crypto miner. They are known for using obfuscation techniques, such as hexadecimal encoding and code obfuscation, to evade detection and compromise systems.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Water Sigbin:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/f/water-sigbin-xmrig.html",
           "https://www.trendmicro.com/en_us/research/24/e/decoding-8220-latest-obfuscation-tricks.html",
@@ -17219,6 +19275,9 @@
     {
       "description": "Void Banshee is an APT group targeting North America, Europe, and Southeast Asia for information theft and financial gain. They exploit vulnerabilities like CVE-2024-38112 to deliver the Atlantida info-stealer through malicious PDFs disguised as book files. The group uses internet shortcuts with MHTML protocol handlers to access and execute files through disabled Internet Explorer, posing a significant threat to organizations. Void Banshee's TTPs include crafting URL strings to control window sizes in IE and using HTML files to hide malicious downloads from victims.",
       "meta": {
+        "name-attribution": [
+          "Void Banshee:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/g/CVE-2024-38112-void-banshee.html"
         ]
@@ -17250,6 +19309,9 @@
     {
       "description": "NullBulge is a cybercriminal threat group targeting AI and gaming focused entities. They weaponize code in publicly available repositories to distribute malware, including LockBit ransomware. The group claims to be motivated by a pro-art, anti-AI cause, but their activities indicate a financial focus. NullBulge uses obfuscated code in public repositories and malicious mods to target their victims.",
       "meta": {
+        "name-attribution": [
+          "Nullbulge:996c48de-7bb8-414d-b6fe-ec94abb5f461"
+        ],
         "refs": [
           "https://www.sentinelone.com/labs/nullbulge-threat-actor-masquerades-as-hacktivist-group-rebelling-against-ai/"
         ]
@@ -17306,6 +19368,9 @@
       "description": "APT45 is a North Korean cyber threat actor that has been active since at least 2009. They have conducted espionage campaigns targeting government agencies and defense industries, as well as financially-motivated operations, including ransomware development. APT45 has targeted critical infrastructure, financial organizations, nuclear research facilities, and healthcare and pharmaceutical companies. They use a mix of publicly available tools, modified malware, and custom malware families in their operations.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "APT45:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/apt45-north-korea-digital-military-machine"
         ]
@@ -17316,6 +19381,9 @@
     {
       "description": "TA4903 is a financially motivated threat actor known for conducting credential phishing and business email compromise campaigns. They target organizations in the U.S. across various sectors, spoofing government entities and private businesses. The actor has been observed using techniques such as QR codes in phishing campaigns and spoofing supplier domains to prompt victims to provide banking information. TA4903's activities typically involve stealing corporate credentials to facilitate follow-on BEC activities.",
       "meta": {
+        "name-attribution": [
+          "TA4903:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA4903": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/ta4903-actor-spoofs-us-government-small-businesses-phishing-bec-bids"
@@ -17327,6 +19395,9 @@
     {
       "description": "Storm-0506 (DEV-0506) is a financially motivated cybercriminal group operating as a core affiliate within the Black Basta ransomware-as-a-service (RaaS) ecosystem, having switched from deploying Conti ransomware around April 2022. This actor's operational model is distinguished by its strategic reliance on a dynamic network of initial access brokers, showcasing a division of labor common in RaaS operations. Throughout its history, Storm-0506 has leveraged access obtained through various brokers: initially Storm-0450/0464 via Qakbot infections (pre-September 2023), then expanding to include Storm-1674 delivering DarkGate, Pikabot, and IcedID (September 2023), and later employing Storm-1674's Microsoft Teams vishing campaigns (October 2024) and Storm-0569's SEO poisoning leading to BATLOADER and Cobalt Strike (December 2023). Following successful initial compromise, Storm-0506 employs a range of post-exploitation tools, including Cobalt Strike Beacon, SystemBC, and Brute Ratel C4 backdoors, and notably, often utilizes command-and-control (C2) infrastructure established by Storm-0365, indicating close collaboration or shared resources. This actor is characterized by hands-on-keyboard activity, culminating in the deployment of Black Basta ransomware. A resurgence in activity observed in October 2024, directly linked to Storm-1674's vishing, underscores the ongoing and adaptive threat that Storm-0506 represents within the ransomware landscape.",
       "meta": {
+        "name-attribution": [
+          "Storm-0506:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0506": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2024/07/29/ransomware-operators-exploit-esxi-hypervisor-vulnerability-for-mass-encryption/",
@@ -17353,6 +19424,11 @@
     {
       "description": "UNC4393 is a financially motivated threat actor primarily using BASTA ransomware. They have been active since early 2022 and have targeted over 40 organizations across various industries. UNC4393 has shown a willingness to cooperate with other threat clusters for initial access and has evolved from using existing tools to developing custom malware. They focus on efficient data exfiltration and multi-faceted extortion, often utilizing tools like COGSCAN and RCLONE for reconnaissance and data theft.",
       "meta": {
+        "name-attribution": [
+          "UNC4393:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Storm-1811:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "CURLY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:Storm-1811": "Microsoft",
         "origin:UNC4393": "Mandiant",
         "refs": [
@@ -17406,6 +19482,9 @@
       "description": "UNC4540 is a suspected Chinese threat actor targeting unpatched SonicWall Secure Mobile Access appliances to deploy custom malware that establishes long-term persistence for cyber espionage. The malware is designed to steal hashed credentials, provide shell access, and persist through firmware upgrades, utilizing a variant of the TinyShell backdoor. Mandiant has tracked UNC4540's activities back to 2021, noting their focus on maintaining access to compromised devices. The group's tactics are consistent with patterns observed in other Chinese threat actor campaigns targeting network devices for zero-day exploits.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC4540:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4540": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/suspected-chinese-persist-sonicwall"
@@ -17418,6 +19497,10 @@
       "description": "TIDRONE is an unidentified threat actor linked to Chinese-speaking groups, with a focus on military-related industry chains, particularly drone manufacturers in Taiwan. The actor employs advanced malware variants such as CXCLNT and CLNTEND, which are distributed through ERP software or remote desktops. The consistency in file compilation times and operational patterns aligns with other Chinese espionage activities, indicating a likely espionage motive.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "TIDRONE:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Earth Ammit:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Ammit": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/i/tidrone-targets-military-and-satellite-industries-in-taiwan.html",
@@ -17456,6 +19539,9 @@
       "description": "UNC2970 is a North Korean threat actor that primarily targets organizations through spear-phishing emails with job recruitment themes, often utilizing fake LinkedIn accounts to engage victims. The group employs the PLANKWALK backdoor and other malware families, leveraging compromised WordPress sites for command and control. They have been observed using BYOVD techniques to exploit vulnerable drivers for evading detection. Mandiant has noted a shift in UNC2970's targeting strategy, including a focus on security researchers and advancements in their operational capabilities against EDR tools.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "UNC2970:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2970": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/lightshow-north-korea-unc2970"
@@ -17479,6 +19565,9 @@
     {
       "description": "UNC4536 is a threat actor that distributes malware, including ICEDID, REDLINESTEALER, and CARBANAK, primarily through malvertising and trojanized MSIX installers masquerading as popular software. They utilize SEO poisoning tactics to direct victims to malicious sites that mimic legitimate software hosting platforms, facilitating the download of compromised installers. The actor employs a PowerShell script known as NUMOZYLOD to deliver tailored payloads, such as the CARBANAK backdoor, to their partners. Additionally, UNC4536 has been linked to campaigns that distribute NetSupport RAT, targeting IT administrators through fake sites promoted via Google Ads.",
       "meta": {
+        "name-attribution": [
+          "UNC4536:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4536": "Mandiant",
         "refs": [
           "https://www.googlecloudcommunity.com/gc/Community-Blog/Finding-Malware-Unveiling-NUMOZYLOD-with-Google-Security/ba-p/789551"
@@ -17541,6 +19630,9 @@
       "description": "Storm-1679 is a Russian disinformation group believed to be a spinoff of the Internet Research Agency, actively engaged in influence operations targeting the International Olympic Committee and the 2024 Olympic Games. The group has employed AI-generated content, including deepfake videos and fabricated narratives about violence, to discredit the IOC and instill fear among potential attendees. Their campaigns have been identified across multiple languages and platforms, utilizing techniques such as impersonation of media outlets and the creation of disinformation websites. Microsoft attributes significant disinformation activities related to the Olympics to Storm-1679, highlighting their focus on spreading falsehoods and promoting anti-Olympics messaging.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Storm-1679:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1679": "Microsoft",
         "refs": [
           "https://blogs.microsoft.com/on-the-issues/2024/06/02/russia-cyber-bots-disinformation-2024-paris-olympics/"
@@ -17589,6 +19681,9 @@
       "description": "Earth Baxia is a threat actor opearting out of China, targeting government organizations in Taiwan and potentially across the APAC region, using spear-phishing emails and exploiting the GeoServer vulnerability CVE-2024-36401 for remote code execution, deploying customized Cobalt Strike components with altered signatures, leveraging GrimResource and AppDomainManager injection techniques to deliver additional payloads, and utilizing a new backdoor named EAGLEDOOR for multi-protocol communication and payload delivery.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Earth Baxia:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Baxia": "Trend Micro",
         "refs": [
           "https://www.tgsoft.it/news/news_archivio.asp?id=1568",
@@ -17692,6 +19787,9 @@
     {
       "description": "Storm-0494 is a threat actor that facilitates Gootloader infections, which are then exploited by groups like Vice Society to deploy tools such as the Supper backdoor, AnyDesk, and MEGA. They utilize RDP for lateral movement and employ the WMI Provider Host to deploy the INC ransomware payload. Microsoft has identified their activities as part of a campaign targeting the U.S. health sector. Their operations are characterized by financially motivated tactics.",
       "meta": {
+        "name-attribution": [
+          "Storm-0494:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0494": "Microsoft",
         "refs": [
           "https://cisoseries.com/cybersecurity-news-inc-targets-healthcare-providence-schools-cyberattack-apple-ipads-bricked/",
@@ -17704,6 +19802,9 @@
     {
       "description": "DragonRank is a threat actor primarily targeting web application services in Asia and Europe, utilizing TTPs associated with Simplified Chinese-speaking hacking groups. They exploit vulnerabilities in platforms like phpMyAdmin and WordPress to deploy web shells, enabling the installation of PlugX and BadIIS malware for black hat SEO practices. Their operations involve lateral movement within compromised networks to maintain control and elevate privileges, while also engaging in unethical online marketing strategies. DragonRank's activities include manipulating search engine rankings and distributing scam websites through compromised Windows IIS servers.",
       "meta": {
+        "name-attribution": [
+          "DragonRank:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/dragon-rank-seo-poisoning/"
         ]
@@ -17715,6 +19816,9 @@
       "description": "Vice Spider is a Russian-speaking ransomware group that has been active since at least April 2021 and is linked to a significant increase in identity-based attacks, with a reported 583% rise in Kerberoasting incidents. CrowdStrike attributes 27% of these intrusions specifically to Vice Spider, which exploits vulnerabilities in the Kerberos authentication protocol to crack user passwords.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "VICE SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.techtarget.com/searchsecurity/news/366547445/CrowdStrike-observes-massive-spike-in-identity-based-attacks"
         ]
@@ -17747,6 +19851,9 @@
       "description": "Handala is a pro-Palestinian hacktivist group that targets Israeli organizations, employing tactics such as phishing, data theft, extortion, and destructive attacks using custom wiper malware. The group utilizes a multi-stage loading process, including a Delphi-coded second-stage loader and an AutoIT injector, to deliver wiper malware that specifically targets Windows and Linux environments. Their phishing campaigns often exploit major events and critical vulnerabilities, masquerading as legitimate organizations to gain initial access. Handala operates a data leak site to publicize stolen data, although claims of successful attacks are sometimes disputed by targeted organizations.",
       "meta": {
         "country": "PS",
+        "name-attribution": [
+          "Handala:3176f708-da5b-4c41-926b-0a94ebeb0e3b"
+        ],
         "refs": [
           "https://www.splunk.com/en_us/blog/security/handalas-wiper-threat-analysis-and-detections.html",
           "https://www.trellix.com/blogs/research/handalas-wiper-targets-israel/",
@@ -17759,6 +19866,9 @@
     {
       "description": "Storm-0501 is a financially motivated cybercriminal group that has been active since 2021, initially targeting US school districts with the Sabbath ransomware and later transitioning to a RaaS model deploying various ransomware strains, including Embargo. The group exploits weak credentials and over-privileged accounts to achieve lateral movement from on-premises environments to cloud infrastructures, establishing persistent backdoor access and deploying ransomware. They have utilized techniques such as credential theft, exploiting vulnerabilities in Zoho ManageEngine and Citrix NetScaler, and employing tools like Cobalt Strike and Rclone for lateral movement and data exfiltration. Storm-0501 has specifically targeted sectors such as government, manufacturing, transportation, and law enforcement in the United States.",
       "meta": {
+        "name-attribution": [
+          "Storm-0501:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0501": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2024/09/26/storm-0501-ransomware-attacks-expanding-to-hybrid-cloud-environments/"
@@ -17770,6 +19880,9 @@
     {
       "description": "CosmicBeetle is a threat actor known for deploying the ScRansom ransomware, which has replaced its previous variant, Scarab. The actor utilizes a custom toolset called Spacecolon, consisting of ScHackTool, ScInstaller, and ScService, to gain initial access through RDP brute forcing and exploiting vulnerabilities like CVE-2020-1472 and FortiOS SSL-VPN. CosmicBeetle has been observed impersonating the LockBit ransomware gang to leverage its reputation and has shown a tendency to leave artifacts on compromised systems. The group primarily targets SMBs globally, employing techniques such as credential dumping and data destruction.",
       "meta": {
+        "name-attribution": [
+          "CosmicBeetle:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/cosmicbeetle-steps-up-probation-period-ransomhub/"
         ]
@@ -17781,6 +19894,9 @@
       "description": "UNC1860 is a persistent and opportunistic Iranian state-sponsored threat actor that is likely affiliated with Iran’s Ministry of Intelligence and Security (MOIS). A key feature of UNC1860 is its collection of specialized tooling and passive backdoors that Mandiant believes supports several objectives, including its role as a probable initial access provider and its ability to gain persistent access to high-priority networks, such as those in the government and telecommunications space throughout the Middle East.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "UNC1860:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC1860": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/unc1860-iran-middle-eastern-networks"
@@ -17806,6 +19922,9 @@
     {
       "description": "Awaken Likho is an APT group that has targeted Russian government agencies and industrial enterprises, employing techniques such as information gathering via search engines and using MeshCentral for remote access. The group has been active since at least December 2021 and has ramped up its activities following the Russo-Ukrainian conflict. Recent reports indicate that they are focusing on espionage against critical infrastructure in the defense and energy sectors. Analysis of their malware reveals a new version that is still in development, suggesting ongoing operational capabilities.",
       "meta": {
+        "name-attribution": [
+          "Awaken Likho:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/awaken-likho-apt-new-implant-campaign/114101/",
           "https://bi.zone/eng/expertise/blog/core-werewolf-protiv-opk-i-kriticheskoy-infrastruktury/"
@@ -17821,6 +19940,9 @@
       "description": "CeranaKeeper is a China-aligned APT that has been active since at least early 2022, primarily targeting governmental institutions in Asian countries. The group employs custom backdoors like TONESHELL and OneDoor, leveraging cloud services such as Dropbox and OneDrive for data exfiltration. CeranaKeeper utilizes techniques like side-loading, brute-force attacks, and the deployment of BAT scripts to extend its reach within compromised networks. Their operations are characterized by a relentless pursuit of sensitive data, adapting their toolset and methods to evade detection.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "CeranaKeeper:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/separating-bee-panda-ceranakeeper-making-beeline-thailand/"
         ]
@@ -17871,6 +19993,9 @@
     {
       "description": "Asnarök is a threat actor that exploited CVE-2020-12271 and utilized command injection privilege escalation to gain root access to devices and install the Asnarök Trojan and demonstrated significant changes in TTPs, including the deployment of a web shell that did not reach out to external C2 for commands. X-Ops identified a patient-zero device linked to the attack and observed the use of an IC.sh script that stole local user account data. The actor's activities were linked to a broader pattern of malicious exploit research and targeted vulnerabilities disclosed by bug bounty researchers.",
       "meta": {
+        "name-attribution": [
+          "Personal Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://news.sophos.com/en-us/2024/10/31/pacific-rim-neutralizing-china-based-threat/",
           "https://news.sophos.com/en-us/2024/10/31/pacific-rim-timeline/"
@@ -17931,6 +20056,9 @@
     {
       "description": "UNC5820 is a threat actor exploiting the CVE-2024-47575 vulnerability in Fortinet's FortiManager, allowing them to bypass authentication and execute arbitrary commands. They have been observed exfiltrating configuration data, user information, and FortiOS256-hashed passwords from managed FortiGate devices. While the actor has staged and exfiltrated sensitive data, there is currently no evidence of lateral movement or further compromise of additional environments. Mandiant has not determined whether UNC5820 is state-sponsored or identified its geographic location.",
       "meta": {
+        "name-attribution": [
+          "UNC5820:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5820": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/fortimanager-zero-day-exploitation-cve-2024-47575/"
@@ -17942,6 +20070,9 @@
     {
       "description": "Water Makara employs the Astaroth banking malware, which features a new defense evasion technique. Their spear phishing campaigns exploit human error by targeting users to click on malicious files. To mitigate these threats, organizations should implement regular security training, enforce strong password policies, utilize multifactor authentication (MFA), keep security solutions updated, and apply the principle of least privilege.",
       "meta": {
+        "name-attribution": [
+          "Water Makara:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/j/water-makara-uses-obfuscated-javascript-in-spear-phishing-campai.html"
         ]
@@ -18214,6 +20345,11 @@
       "description": "WageMole is a North Korean state-sponsored APT that employs social engineering and technology to secure remote job opportunities in Western countries, leveraging stolen personal data from the Contagious Interview campaign. Threat actors create fake identities, including passports and driver's licenses, and prepare study guides for interviews, often utilizing generative AI for well-structured responses. They target small to mid-sized businesses and utilize job platforms like Upwork and Indeed, while employing automation scripts for account creation. WageMole's activities include sharing code within their group and requesting payments through platforms like PayPal to conceal their identity.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Famous Chollima:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "UNC5267:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Storm-1877:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1877": "Microsoft",
         "origin:UNC5267": "Mandiant",
         "refs": [
@@ -18240,6 +20376,9 @@
     {
       "description": "APT73 is a ransomware group that has publicly identified 12 victims and launched its data leak site on April 25th. The DLS bears a striking resemblance to that of LockBit, likely to leverage LockBit's reputation and attract potential affiliates. The rationale for this design mimicry is unclear, but it may be intended to signal operational parity with LockBit to inspire trust among low-level criminals. APT73 was formed by an alleged former LockBit affiliate following law enforcement's \"Operation Cronos\" in February 2024.",
       "meta": {
+        "name-attribution": [
+          "APT73:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://quointelligence.eu/2024/06/analyzing-shift-in-ransomware-dynamics/"
         ],
@@ -18265,6 +20404,9 @@
       "description": "TAG-112 is a Chinese state-sponsored APT that compromised Tibetan websites, including Tibet Post and Gyudmed Tantric University, to deliver Cobalt Strike malware. The group exploited vulnerabilities in the Joomla CMS to embed malicious JavaScript that spoofed a TLS certificate error, tricking users into downloading a compromised security certificate. TAG-112's infrastructure, concealed using Cloudflare, shows notable overlap with TAG-102, but it employs less sophisticated tactics, relying on Cobalt Strike rather than custom malware. The campaign reflects ongoing cyber-espionage efforts targeting Tibetan entities, likely for information collection and surveillance.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "TAG-112:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/research/china-nexus-tag-112-compromises-tibetan-websites"
         ]
@@ -18287,6 +20429,9 @@
       "description": "TA455 is an Iranian APT group targeting the aerospace industry through a campaign known as the “Iranian Dream Job Campaign,” utilizing deceptive job offers to lure victims. They employ spearphishing tactics with malicious ZIP files containing the executable “secur32[.]dll” and disguise their C2 communications within the traffic of reputable services like Cloudflare and GitHub. The group intentionally mimics the TTPs of the North Korean Lazarus group to mislead investigators and complicate attribution. Their multi-stage infection strategy enhances the likelihood of success while evading detection.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "TA455:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.clearskysec.com/irdreamjob24/"
         ]
@@ -18308,6 +20453,9 @@
       "description": "BrazenBamboo is a Chinese state-affiliated threat actor known for developing the LIGHTSPY, DEEPDATA, and DEEPPOST malware families. Their infrastructure includes capabilities for zero-day exploitation, specifically targeting vulnerabilities like FortiClient, and employs a command-and-control architecture that supports multi-platform operations. Volexity's analysis indicates that BrazenBamboo is a well-resourced entity with a focus on domestic targets, utilizing custom analyst software to manage data collected from their malware. The ongoing development of their malware families is evidenced by the timestamps associated with their latest payloads.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "BrazenBamboo:c2f76813-f24c-450e-abfd-0db4495ab68e"
+        ],
         "refs": [
           "https://www.volexity.com/blog/2024/11/15/brazenbamboo-weaponizes-forticlient-vulnerability-to-steal-vpn-credentials-via-deepdata/"
         ]
@@ -18318,6 +20466,9 @@
     {
       "description": "Water Barghest is a cybercriminal group that has compromised over 20,000 IoT devices by October 2024, monetizing them through a residential proxy marketplace. They automate the entire process from identifying vulnerable devices using n-day and zero-day exploits to deploying Ngioweb malware and selling the compromised assets. Their operations include leveraging Ubiquiti EdgeRouter devices for espionage and utilizing automated scripts to exploit vulnerabilities within minutes of discovery. Water Barghest has maintained a low profile for years, but their activities gained attention due to the deployment of a zero-day vulnerability against Cisco IOS XE devices in October 2023.",
       "meta": {
+        "name-attribution": [
+          "Water Barghest:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/24/k/water-barghest.html"
         ]
@@ -18339,6 +20490,10 @@
       "description": "TAG-100 is a cyber-espionage APT that targets government and private sector organizations globally, exploiting vulnerabilities in internet-facing devices such as Citrix NetScaler and F5 BIG-IP for initial access. The group employs open-source tools like Pantegana and SparkRAT for persistence and post-exploitation activities, including credential theft and email data exfiltration. TAG-100 has compromised entities in at least ten countries, including two Asia-Pacific intergovernmental organizations, and focuses on sectors like education, finance, and local government. Their operations highlight the challenges of attribution due to the use of off-the-shelf tools and techniques that overlap with other state-sponsored groups.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Storm-2077:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "TAG-100:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "origin:Storm-2077": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2024/11/22/microsoft-shares-latest-intelligence-on-north-korean-and-chinese-threat-actors-at-cyberwarcon/",
@@ -18388,6 +20543,9 @@
       "description": "Storm-0940 is a Chinese threat actor active since at least 2021, known for gaining initial access through password spray and brute-force attacks, as well as exploiting network edge applications. Microsoft has observed Storm-0940 utilizing valid credentials obtained from CovertNetwork-1658's password spray operations, indicating a close operational relationship between the two. Once inside a victim environment, Storm-0940 has been seen leveraging compromised credentials for further malicious activities. Additionally, Storm-0940 has employed botnets, such as Quad7, to facilitate password spraying attacks.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Storm-0940:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0940": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2024/10/31/chinese-threat-actor-storm-0940-uses-credentials-from-password-spray-attacks-from-a-covert-network/"
@@ -18436,6 +20594,9 @@
     {
       "description": "UNC2465 is a threat actor known for deploying the SMOKEDHAM .NET backdoor and DARKSIDE ransomware, utilizing TTPs such as phishing, Trojanized software installers, and supply chain attacks. They have employed the NGROK utility to expose internal services and facilitate lateral movement within victim environments. UNC2465 has also leveraged tools like UltraVNC, Cobalt Strike BEACON, and conducted credential harvesting via LSASS memory dumping. Their operations have included extortion tactics through a leaks website over TOR, applying pressure on victims by releasing stolen data.",
       "meta": {
+        "name-attribution": [
+          "UNC2465:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2465": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/shining-a-light-on-darkside-ransomware-operations",
@@ -18450,6 +20611,9 @@
       "description": "LIMINAL PANDA is a China-nexus APT that targets telecommunications entities, employing custom malware and publicly available tools for covert access, C2, and data exfiltration. The adversary demonstrates extensive knowledge of telecom networks, utilizing GSM protocols to retrieve mobile subscriber information and call metadata. LIMINAL PANDA exploits trust relationships and security gaps between providers to access core infrastructure, indicating a focus on SIGINT collection rather than financial gain. Their intrusion activity has primarily affected telecom providers in southern Asia and Africa, with potential for broader targeting based on network configurations.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "LIMINAL PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/en-us/blog/liminal-panda-telecom-sector-threats/"
         ]
@@ -18470,6 +20634,9 @@
     {
       "description": "UAC-0185 has been active since at least 2022, primarily targeting Ukrainian defense organizations through credential theft via messaging apps like Signal, Telegram, and WhatsApp, as well as military systems such as DELTA, TENETA, and Kropyva. The group employs phishing attacks, often impersonating the Ukrainian Union of Industrialists and Entrepreneurs (UUIE), to gain unauthorized access to the PCs of defense sector employees. They utilize custom tools, including MESHAGENT and UltraVNC, to facilitate their operations. Their activities are mapped to MITRE ATT&CK, focusing on tactics related to credential theft and remote access.",
       "meta": {
+        "name-attribution": [
+          "UNC4221:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4221": "Mandiant",
         "refs": [
           "https://cert.gov.ua/article/6281632"
@@ -18485,6 +20652,9 @@
       "description": "WASSONITE is a North Korea-linked APT that has targeted industrial sectors, including electric generation, nuclear energy, manufacturing, and research entities in India, South Korea, and Japan since at least 2018. The group employs DTrack RAT for remote access, Mimikatz for credential capture, and various system tools for lateral movement and file transfers. WASSONITE has been observed using nuclear energy-themed spear phishing lures to deploy the AppleSeed backdoor, which can take screenshots, log keystrokes, and execute commands from a C2 server. Their operations focus on initial access, reconnaissance, and data collection without demonstrating disruptive capabilities.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Wassonite:e4ed3168-7830-490f-9eed-d1b3ef2daccd"
+        ],
         "refs": [
           "https://www.dragos.com/blog/2022-ics-ot-threat-landscape-recap-what-to-watch-for-this-year/",
           "https://www.dragos.com/threat/wassonite/"
@@ -18516,6 +20686,9 @@
     {
       "description": "EC2 Grouper is a prolific threat actor known for leveraging AWS tools for PowerShell to conduct automated attacks in cloud environments. They typically utilize the CreateSecurityGroup API to establish remote access and exhibit a consistent security group naming convention. Credential acquisition is believed to stem from compromised cloud access keys, often sourced from public code repositories. Notably, their activities do not include calls to AuthorizeSecurityGroupIngress, suggesting a selective approach to escalation.",
       "meta": {
+        "name-attribution": [
+          "EC2 Grouper:bfafdca5-3171-4953-86ab-c74f44822fd3"
+        ],
         "refs": [
           "https://www.fortinet.com/blog/threat-research/catching-ec2-grouper-no-indicators-required"
         ]
@@ -18537,6 +20710,9 @@
       "description": "Operation DRBControl is a cyberespionage campaign targeting gambling companies in Southeast Asia, first identified in 2019. The operation involves the use of HyperBro malware and SysUpdate variants, with evidence of customer database and source code exfiltration. The threat actor has employed domain spoofing for command and control and has shown a consistent interest in the gambling industry. Trend Micro's analysis linked multiple tools and malware families to this campaign, indicating a sophisticated and evolving threat landscape.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Operation DRBControl:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/vinfo/us/security/news/cyber-attacks/operation-drbcontrol-uncovering-a-cyberespionage-campaign-targeting-gambling-companies-in-southeast-asia"
         ]
@@ -18568,6 +20744,9 @@
     {
       "description": "UNC3973 is a financially motivated threat actor tracked by Mandiant, distinguished from the broader BASTA ransomware ecosystem (primarily tracked as UNC4393) due to its unique operational characteristics and TTPs. This actor has demonstrated a specific focus on supply chain compromises, as evidenced by their June campaign targeting credit unions in western Canada via a compromised managed service provider (MSP). UNC3973 leverages unauthorized service accounts with elevated privileges, specifically domain administrator accounts shared between the compromised MSP and the target organizations, to gain initial access.This actor's post-exploitation activity includes attempts to disable security controls and deploy the SYSTEMBC tunneler for command and control (C2) communication, followed by attempts to deploy BASTA ransomware. While their attempts to deploy both SYSTEMBC and BASTA have been observed, these were thankfully thwarted by endpoint security solutions in observed instances. The targeted, supply chain-enabled nature of UNC3973's intrusions, coupled with its use of privileged shared accounts and attempts at deploying BASTA, all suggest that it is an exclusive group, perhaps even affiliates working closely with or possibly operating under the direct control, BASTA ransomware operators. This group's ability to exploit centralized access points, like MSPs, represents a significant threat to organizations reliant on third-party providers.",
       "meta": {
+        "name-attribution": [
+          "UNC3973:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC3973": "Mandiant",
         "refs": [
           "https://services.google.com/fh/files/misc/m_trends_2023_report.pdf",
@@ -18580,6 +20759,9 @@
     {
       "description": "Storm-0826 is a financially motivated cybercriminal group operating as an affiliate within the Black Basta ransomware-as-a-service (RaaS) ecosystem. This actor's primary known method of obtaining initial access is through handoffs from Storm-0464, a known distributor of the Qakbot malware",
       "meta": {
+        "name-attribution": [
+          "Storm-0826:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0826": "Microsoft",
         "refs": [
           "https://www.youtube.com/watch?v=U7p0J8aMZhM&t=193s",
@@ -18602,6 +20784,10 @@
     {
       "description": "GOLD REBELLION is a financially motivated cybercriminal threat group that operates the Black Basta name-and-shame ransomware. The group posted its first victim to its leak site in April 2022 and has continued to publish victim names at a rate of around 15 a month since then. GOLD REBELLION has not openly advertised or appeared to recruit for an affiliate program but the variety of tactics, techniques and procedures (TTP) observed in Black Basta intrusions suggests that multiple individuals are engaged in the ransomware scheme.Several security vendors and independent researchers have suggested the distributors of Black Basta may be former affiliates of GOLD ULRICK's Conti operation. Technical artifacts analyzed by CTU researchers suggest that Black Basta has been under development since at least early February 2022, several weeks before extensive public leaks detailed GOLD ULRICK's Conti operation. In November 2022, researchers at SentinelOne linked custom tooling used by GOLD REBELLION to the GOLD NIAGARA (FIN7) threat group. CTU researchers have not made independent observations corroborating a relationship between these threat groups or any others.GOLD REBELLION appear to have been a key customer of GOLD LAGOON's Qakbot: CTU researchers observed multiple incidents where Black Basta was distributed through it as an initial access vector (IAV), leading to Cobalt Strike and further lateral movement into the victim network. Following the takedown of Qakbot in August 2023, GOLD REBELLION explored new methods of delivery, including DarkGate and Pikabot. In one incident, CTU researchers observed a threat actor gain access to a victim network through a managed security services provider (MSSP). In October 2024, GOLD REBELLION likely exploited a vulnerability in a Sonic Wall VPN device for access. Also in 2024, CTU researchers observed multiple instances of the group using social engineering to convince victims to download remote management and monitoring tools like AnyDesk and Quick Assist. After spamming inboxes with multiple emails, the threat actors approached the affected users via Teams, purporting to be IT Support or Help Desk employees offering assistance with email inbox issues.Other tools members of the group have used include the SystemBC back connect malware, PsExec for remote execution, RDP for lateral movement, batch files to delete their own tools and disable anti-virus programs for defense evasion, and both Rclone and MegaSync for data exfiltration.",
       "meta": {
+        "name-attribution": [
+          "WANDERING SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0",
+          "GOLD REBELLION:a7119872-bc6b-494b-9f7a-8c50faaf53a9"
+        ],
         "origin:GOLD REBELLION": "Secureworks",
         "refs": [
           "https://www.secureworks.com/research/threat-profiles/gold-rebellion",
@@ -18627,6 +20813,9 @@
     {
       "description": "JavaGhost is a threat actor group that has targeted cloud environments, particularly AWS, for phishing campaigns without engaging in data theft for extortion. They exploit overly permissive IAM permissions and utilize long-term access keys to gain initial access, employing the GetFederationToken API to acquire temporary credentials for console access. JavaGhost has demonstrated advanced evasion techniques, avoiding common detection methods by not using the GetCallerIdentity API call. Their activities generate detectable logging footprints in CloudTrail, allowing organizations to identify and respond to their tactics.",
       "meta": {
+        "name-attribution": [
+          "JavaGhost:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/javaghost-cloud-phishing/"
         ]
@@ -18638,6 +20827,9 @@
       "description": "Angry Likho is an APT group that has been active since 2023, primarily targeting large organizations and government agencies in Russia and Belarus. Their attacks typically involve spear-phishing emails with malicious attachments, such as RAR archives, and utilize a known payload, the Lumma stealer, for data exfiltration. The group employs a compact infrastructure and has been linked to espionage activities, particularly in sectors like aviation and pharmaceuticals. Their operations have shown a focus on collecting sensitive information, including cryptowallet files and user credentials.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Angry Likho:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/angry-likho-apt-attacks-with-lumma-stealer/115663/",
           "https://www.morphisec.com/blog/sticky-werewolfs-aviation-attacks/"
@@ -18653,6 +20845,9 @@
       "description": "PlushDaemon is a China-aligned APT group that has conducted cyberespionage operations against targets in China, Taiwan, Hong Kong, South Korea, the United States, and New Zealand. They executed a supply chain attack on the South Korean VPN provider IPany, compromising its installer to deploy the SlowStepper backdoor, which features a toolkit of over 30 components. PlushDaemon primarily gains initial access by hijacking legitimate updates of Chinese applications and has also exploited vulnerabilities in legitimate web servers. Additionally, they have utilized the Visual Studio command line utility regcap.exe to side-load a malicious DLL named lregdll.dll.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "PlushDaemon:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/plushdaemon-compromises-supply-chain-korean-vpn-service/"
         ]
@@ -18663,6 +20858,9 @@
     {
       "description": "Storm-2139 is a cybercrime group that exploited stolen API keys from compromised Azure OpenAI Service accounts to generate harmful content, including non-consensual intimate imagery, using the DALL-E model. The group utilized reverse proxy infrastructure and custom software to bypass guardrails in Microsoft’s GenAI services. Microsoft has filed a lawsuit against four individuals associated with Storm-2139, alleging they modified customer systems and resold access to these capabilities. The group systematically harvested authentication tokens from U.S.-based enterprises and is linked to a broader network of illicit AI tool development and distribution.",
       "meta": {
+        "name-attribution": [
+          "Storm-2139:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-2139": "Microsoft",
         "refs": [
           "https://blogs.microsoft.com/on-the-issues/2025/02/27/disrupting-cybercrime-abusing-gen-ai/"
@@ -18764,6 +20962,9 @@
       "description": "Storm-2372 is a suspected nation-state actor aligned with Russian interests, engaging in device code phishing campaigns targeting governments, NGOs, and various industries across Europe, North America, Africa, and the Middle East. The actor employs tactics that involve impersonating prominent individuals through third-party messaging services like WhatsApp and Signal to gain rapport before sending phishing invitations. These invitations lure users into completing device code authentication requests, granting Storm-2372 initial access to victim accounts and enabling Graph API data collection activities, including email harvesting. Microsoft has observed the actor utilizing keyword searches within compromised accounts to exfiltrate sensitive information.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Storm-2372:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-2372": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/02/13/storm-2372-conducts-device-code-phishing-campaign/"
@@ -18821,6 +21022,9 @@
     {
       "description": "Verticals targeted during Operation FishMedley include governments, NGOs, and think tanks, across Asia, Europe, and the United States. ; Operators used implants – such as ShadowPad, SodaMaster, and Spyder – that are common or exclusive to China-aligned threat actors. ; We assess with high confidence that Operation FishMedley was conducted by the FishMonger APT group.",
       "meta": {
+        "name-attribution": [
+          "FishMedley:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/operation-fishmedley/"
         ]
@@ -18850,6 +21054,10 @@
     {
       "description": "Storm-0249 is an access broker active since 2021, known for distributing BazaLoader, IcedID, Bumblebee, and Emotet malware. The actor primarily employs phishing emails to deliver malware payloads, as evidenced by a campaign involving tax-themed emails that aimed to distribute BRc4 and Latrodectus malware. Storm-0249 has facilitated initial access for other threat actors, such as Storm-0501, by leveraging compromised credentials and exploiting known vulnerabilities in public-facing servers. Microsoft has detected malicious PDF attachments associated with Storm-0249's phishing campaigns.",
       "meta": {
+        "name-attribution": [
+          "Storm-0249:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DEV-0249:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:DEV-0249": "Microsoft",
         "origin:Storm-0249": "Microsoft",
         "refs": [
@@ -18866,6 +21074,9 @@
     {
       "description": "GOFFEE is a threat actor that has targeted entities in the Russian Federation since early 2022, employing spear phishing emails with malicious attachments, including modified Owowa and patched explorer.exe. They have utilized PowerTaskel, a non-public Mythic agent in PowerShell, and introduced a new implant called \"PowerModul\" for attacks against sectors such as media, telecommunications, and government. GOFFEE has increasingly shifted to a binary Mythic agent for lateral movement and has incorporated Word documents with malicious VBA scripts in their infection chains. The group has demonstrated a consistent evolution in their TTPs while maintaining identifiable characteristics that attribute their campaigns with high confidence.",
       "meta": {
+        "name-attribution": [
+          "GOFFEE:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/goffee-apt-new-attacks/116139/"
         ]
@@ -18876,6 +21087,9 @@
     {
       "description": "UAT-5918 is an APT group that targets entities in Taiwan, primarily in telecommunications, healthcare, and IT sectors, to establish long-term access for information theft. They exploit N-day vulnerabilities in unpatched web and application servers to gain initial access and utilize web shells, credential harvesting tools like Mimikatz and LaZagne, and red-teaming tools for post-compromise activities. UAT-5918 conducts network reconnaissance to pivot across endpoints, harvesting credentials and sensitive data, including database backups. Their operations show significant overlap with other APT groups in terms of TTPs and targeted industries.",
       "meta": {
+        "name-attribution": [
+          "UAT-5918:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-5918-targets-critical-infra-in-taiwan/"
         ]
@@ -18900,6 +21114,9 @@
     {
       "description": "Storm-2460 is a threat actor that has exploited elevation of privilege vulnerabilities to deploy PipeMagic malware and ransomware, enabling them to escalate access within compromised environments. They have been observed using the certutil utility to download malware from compromised legitimate third-party websites. Ransomware activity associated with Storm-2460 includes file encryption and the deployment of a ransom note named !_READ_ME_REXX2_!.txt. Microsoft recommends prioritizing security updates for elevation of privilege vulnerabilities to mitigate the impact of this actor's activities.",
       "meta": {
+        "name-attribution": [
+          "Storm-2460:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-2460": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/04/08/exploitation-of-clfs-zero-day-leads-to-ransomware-activity/"
@@ -18935,6 +21152,9 @@
       "description": "REF7707 is a cyber campaign targeting government entities, particularly a foreign ministry in South America, utilizing malware families such as FinalDraft, GuidLoader, and PathLoader for persistence and lateral movement. The threat actor employs the Microsoft Graph API for C2 communication, blending malicious traffic with legitimate activity to evade detection. Despite their technical sophistication, REF7707 operators exhibited poor operational security, leading to the exposure of their infrastructure and malware. Their tactics enable the extraction of sensitive data, including passwords and Active Directory information, facilitating ongoing espionage activities.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "REF7707:58d7efca-402a-4b36-9178-dc14e52f12e5"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/advanced-backdoor-squidoor/",
           "https://www.elastic.co/security-labs/fragile-web-ref7707",
@@ -18962,6 +21182,9 @@
     {
       "description": "Operation ForumTroll is a sophisticated cyber espionage campaign discovered by Kaspersky in mid-March 2025. The attack exploited a zero-day vulnerability in Google Chrome, identified as CVE-2025-2783, which allowed attackers to bypass the browser's security features. Victims were infected by clicking on personalized phishing links in emails, allegedly from the organizers of the \"Primakov Readings\" forum, targeting media outlets, educational institutions, and government organizations in Russia. The goal of the attack appears to be espionage, and the campaign is believed to be the work of a state-sponsored APT group. Google quickly released an update to fix the vulnerability after being notified by Kaspersky.",
       "meta": {
+        "name-attribution": [
+          "Operation ForumTroll:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/operation-forumtroll/115989/"
         ]
@@ -18973,6 +21196,9 @@
       "description": "Earth Alux is a China-linked APT group known for conducting cyberespionage attacks across various sectors, including government, technology, and telecommunications. They primarily exploit vulnerable services in exposed servers to gain initial access, implanting web shells like GODZILLA and deploying backdoors such as VARGEIT and COBEACON. The group employs tools like RSBINJECT and MASQLOADER for lateral movement and network discovery, while also utilizing RAILSETTER for persistence through mspaint injection. Their operations have predominantly targeted the APAC region and have extended to Latin America, with a focus on exfiltrating sensitive information to attacker-controlled cloud storage.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Earth Alux:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Alux": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/25/c/the-espionage-toolkit-of-earth-alux.html"
@@ -18985,6 +21211,9 @@
       "description": "Water Gamayun exploits the MSC EvilTwin zero-day vulnerability to compromise systems and exfiltrate data, utilizing custom payloads and advanced data exfiltration techniques. Their arsenal includes backdoors like SilentPrism and DarkWisp, as well as information stealers such as Stealc and Rhadamanthys. They employ delivery methods like provisioning malicious payloads through signed Microsoft Installer files and leveraging LOLBins to maintain persistence and control over infected systems. Comprehensive analysis of their command-and-control infrastructure reveals sophisticated evasion techniques and dynamic control capabilities.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Water Gamayun:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/25/c/deep-dive-into-water-gamayun.html"
         ]
@@ -19063,6 +21292,9 @@
     {
       "description": "Earth Kurma is an APT group targeting government and telecommunications sectors in Southeast Asia, with a primary focus on data exfiltration. They employ advanced custom malware, including rootkits like KRNRAT and MORIYA, and utilize cloud storage services for exfiltration. Their toolsets include TESDAT and SIMPOBOXSPY, and they demonstrate adaptive TTPs and complex evasion techniques. Attribution overlaps with other APT groups, but distinct attack patterns warrant their separate designation.",
       "meta": {
+        "name-attribution": [
+          "Earth Kurma:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "origin:Earth Kurma": "Trend Micro",
         "refs": [
           "https://www.trendmicro.com/en_us/research/25/d/earth-kurma-apt-campaign.html"
@@ -19128,6 +21360,9 @@
     {
       "description": "Storm-1977 is a sophisticated threat actor that conducts password-spraying attacks targeting cloud tenants, particularly in the education sector, utilizing the AzureChecker.exe CLI tool as their primary infection vector. They have successfully compromised over 200 containers, repurposing them for cryptocurrency mining operations by leveraging guest accounts to create new resource groups within compromised subscriptions. Microsoft Threat Intelligence researchers have identified unique operational patterns that distinguish Storm-1977 from other cryptomining threat actors. The group exploits compromised accounts as a primary attack surface in their operations.",
       "meta": {
+        "name-attribution": [
+          "Storm-1977:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1977": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/04/23/understanding-the-threat-landscape-for-kubernetes-and-containerized-assets/"
@@ -19139,6 +21374,9 @@
     {
       "description": "TAG-124 is a threat actor that employs a traffic distribution system to distribute malware, primarily using MintsLoader and targeting various sectors through phishing emails and compromised websites. The actor injects malicious JavaScript into WordPress sites, leading victims to fake Google Chrome update landing pages that facilitate malware downloads, often masquerading as legitimate updates. TAG-124 has been linked to multiple ransomware groups, including Rhysida and Interlock, and demonstrates high activity levels by regularly updating its infrastructure and refining its infection tactics, such as the ClickFix technique. Notable compromised sites include those associated with the Polish Centre for Testing and Certification and the Economic Community of West African States (ECOWAS).",
       "meta": {
+        "name-attribution": [
+          "TAG-124:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/research/uncovering-mintsloader-with-recorded-future-malware-intelligence-hunting",
           "https://www.recordedfuture.com/research/tag-124-multi-layered-tds-infrastructure-extensive-user-base"
@@ -19196,6 +21434,9 @@
     {
       "description": "Malsmoke primarily targets Japanese users through malvertising campaigns that deliver Zloader malware, often leveraging adult content lures and geographic IP information. The group has transitioned from exploit kits, such as Fallout, to social engineering tactics, including fake Java updates, while maintaining a focus on high-traffic adult websites. Their operations are characterized by the use of DGA for C2 server domains and the distribution of payloads via a custom loader, previously relying on Smoke Loader. Connections to past campaigns are evident through similarities in malware masquerading as Java plugins and shared registrar information among domains.",
       "meta": {
+        "name-attribution": [
+          "Malsmoke:f063b54b-293c-4713-87c1-92ff760ee4ba"
+        ],
         "refs": [
           "https://blog.malwarebytes.com/threat-analysis/2020/11/malsmoke-operators-abandon-exploit-kits-in-favor-of-social-engineering-scheme/",
           "https://www.malwarebytes.com/blog/social-engineering/2020/09/malvertising-campaigns-come-back-in-full-swing"
@@ -19207,6 +21448,9 @@
     {
       "description": "Luna Moth conducts high-tempo callback phishing campaigns targeting legal and financial organizations in the U.S., using social engineering to lure victims into calling fake helpdesk numbers. Attackers impersonate IT staff to install legitimate RMM tools, enabling direct access to victim systems for data exfiltration. The group demands ransoms between $1 million and $8 million, threatening to leak stolen data if payments are not made. Their operations reflect a shift from traditional ransomware tactics to data breach extortion, leveraging trusted systems to evade detection.",
       "meta": {
+        "name-attribution": [
+          "Luna Moth:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://blog.eclecticiq.com/from-callback-phishing-to-extortion-luna-moth-abuse-reamaze-helpdesk-and-rmm-tools-against-u.s.-legal-and-financial-sectors",
           "https://unit42.paloaltonetworks.com/luna-moth-callback-phishing/"
@@ -19255,6 +21499,9 @@
       "description": "Void Blizzard’s cyberespionage operations tend to be highly targeted at specific organizations of interest to the Russian government, including in government, defense, transportation, media, non-governmental organizations (NGOs), and healthcare sectors primarily in Europe and North America. The threat actor uses stolen credentials—which are likely procured from commodity infostealer ecosystems—and collects a high volume of email and files from compromised organizations.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Void Blizzard:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/05/27/new-russia-affiliated-actor-void-blizzard-targets-critical-sectors-for-espionage/",
           "https://www.aivd.nl/actueel/nieuws/2025/05/27/onbekende-russische-groep-achter-hacks-nederlandse-doelen",
@@ -19270,6 +21517,9 @@
     },
     {
       "meta": {
+        "name-attribution": [
+          "Storm-0113:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0113": "Microsoft",
         "synonyms": [
           "Storm-0113"
@@ -19314,6 +21564,9 @@
     {
       "description": "The actor systematically exported large volumes of data from numerous corporate Salesforce instances. GTIG assesses the primary intent of the threat actor is to harvest credentials. After the data was exfiltrated, the actor searched through the data to look for secrets that could be potentially used to compromise victim environments. GTIG observed UNC6395 targeting sensitive credentials such as Amazon Web Services (AWS) access keys (AKIA), passwords, and Snowflake-related access tokens. UNC6395 demonstrated operational security awareness by deleting query jobs, however logs were not impacted and organizations should still review relevant logs for evidence of data exposure.",
       "meta": {
+        "name-attribution": [
+          "UNC6395:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6395": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/data-theft-salesforce-instances-via-salesloft-drift"
@@ -19370,6 +21623,9 @@
     {
       "description": "TheWizards is a China-aligned APT group that employs the Spellbinder tool for adversary-in-the-middle attacks, utilizing IPv6 SLAAC spoofing to redirect legitimate software updates to malicious servers. They have developed the WizardNet backdoor for Windows and serve DarkNights to Android applications, indicating a connection to Dianke Network Security Technology. The group targets individuals and companies in the Philippines, Cambodia, the UAE, mainland China, and Hong Kong. ESET has observed their infrastructure and tools, including the acquisition of servers for hosting C&C and malicious updates.",
       "meta": {
+        "name-attribution": [
+          "TheWizards:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/thewizards-apt-group-slaac-spoofing-adversary-in-the-middle-attacks/",
           "https://www.welivesecurity.com/en/eset-research/nspx30-sophisticated-aitm-enabled-implant-evolving-since-2005/"
@@ -19397,6 +21653,9 @@
       "description": "Curly COMrades is a threat actor identified by Amazon Threat Intelligence and Bitdefender, believed to operate in support of Russian interests. They employ techniques such as Hyper-V abuse for EDR evasion and utilize proxy tools like Resocks, SSH, and Stunnel to gain access to internal networks. Their activities include repeated attempts to extract the NTDS database from domain controllers and establishing covert access through virtualization features on compromised Windows 10 machines.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Curly COMrades:1c141c9b-ec78-4f86-a8ea-b02944fa5492"
+        ],
         "refs": [
           "https://www.bitdefender.com/en-us/blog/businessinsights/curly-comrades-evasion-persistence-hidden-hyper-v-virtual-machines",
           "https://www.bitdefender.com/en-us/blog/businessinsights/curly-comrades-new-threat-actor-targeting-geopolitical-hotbeds"
@@ -19431,6 +21690,10 @@
       "description": "Earth Lamia is a China-nexus APT that targets organizations across multiple sectors, including finance, logistics, and government, primarily in Latin America, the Middle East, and Southeast Asia. The actor exploits web application vulnerabilities, such as CVE-2025-55182, and employs techniques like SQL injection, DLL sideloading, and the deployment of custom backdoors like PULSEPACK and BypassBoss. Earth Lamia conducts reconnaissance, file operations, and credential theft, often utilizing tools like Cobalt Strike and VShell.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Earth Lamia:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "UNC5454:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:Earth Lamia": "Trend Micro",
         "origin:UNC5454": "Mandiant",
         "refs": [
@@ -19459,6 +21722,9 @@
       "description": "UAT-9686 is a Chinese state-sponsored APT known for targeting networking infrastructure and edge appliances through a sophisticated espionage campaign. They exploit a critical flaw in the Cisco AsyncOS Spam Quarantine interface to gain root access and deploy custom malware, including AquaShell, along with Python scripts that execute natively. Their operations involve reverse tunneling and log purging, demonstrating a methodical approach to compromising communication infrastructure. Talos has observed overlaps in TTPs and tooling with other Chinese-nexus threat actors, indicating a consistent operational pattern.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-9686:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://www.secpod.com/blog/zero-day-crisis-cve-2025-20393-unpatched-on-cisco-email-gateways-exploited-by-china-linked-hackers/",
           "https://blog.talosintelligence.com/uat-9686/"
@@ -19482,6 +21748,9 @@
       "description": "Water Saci is a sophisticated cyber threat actor operating in Brazil, utilizing a multi-format attack chain that includes HTA files, ZIP archives, and PDFs to bypass security measures. The campaign employs an email-based C&C infrastructure using IMAP connections to terra.com.br accounts, enhancing its resilience and evasion tactics. It leverages social engineering through WhatsApp to propagate malware, specifically the SORVEPOTEL banking trojan, and incorporates advanced techniques for infection and persistence. The modular architecture of the malware allows for dynamic adaptation and extraction of sensitive credentials, indicating a significant evolution in adversarial capabilities.",
       "meta": {
         "country": "BR",
+        "name-attribution": [
+          "Water Saci:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/25/j/active-water-saci-campaign-whatsapp-update.html",
           "https://www.trendmicro.com/en_us/research/25/l/water-saci.html"
@@ -19494,6 +21763,9 @@
       "description": "UNC6032 is a threat actor that weaponizes interest in AI tools, specifically targeting users with fake \"AI video generator\" websites to distribute malware, including Python-based infostealers and backdoors. Victims are typically directed to these sites through malicious social media ads that impersonate legitimate tools. Compromises have led to the exfiltration of sensitive data, including login credentials and credit card information, via the Telegram API. Google Threat Intelligence Group assesses UNC6032 to have a Vietnam nexus.",
       "meta": {
         "country": "VN",
+        "name-attribution": [
+          "UNC6032:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6032": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/cybercriminals-weaponize-fake-ai-websites"
@@ -19506,6 +21778,9 @@
       "description": "UNC6293 is a Russian state-sponsored threat actor identified by Google's Threat Intelligence Group (GTIG), which associates them with APT29 with low confidence. They have conducted campaigns utilizing social engineering tactics, including leveraging App-Specific Passwords for account compromises. GTIG has also noted a second campaign by UNC6293 that incorporates Ukrainian themes.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "UNC6293:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6293": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/creative-phishing-academics-critics-of-russia"
@@ -19517,6 +21792,9 @@
     {
       "description": "UNC4487 is a threat actor that targeted Ukrainian government officials by compromising a Ukrainian auto insurance website essential for official travel. This attack facilitated the distribution of the MATANBUCHUS malware, which was used to monetize access to infected systems. Mandiant later identified additional malware samples, referred to as ChillyHell, linked to UNC4487 through the reuse of a code signing certificate associated with MATANBUCHUS. The group's activities highlight a focus on exploiting critical infrastructure for financial gain.",
       "meta": {
+        "name-attribution": [
+          "UNC4487:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC4487": "Mandiant",
         "refs": [
           "https://www.jamf.com/blog/chillyhell-a-modular-macos-backdoor/"
@@ -19528,6 +21806,9 @@
     {
       "description": "UNC6148 is a financially motivated threat actor that targets SonicWall Secure Mobile Access 100 series appliances, leveraging stolen credentials and possibly zero-day exploits to deploy a persistent backdoor known as OVERSTEP. They utilize a kernel-level rootkit for stealthy access and have been observed establishing SSL VPN sessions to launch reverse shells and manipulate system files. The actor's operations include credential theft, data exfiltration, and potential ransomware deployment, with evidence suggesting they modify legitimate scripts to maintain persistence. Their activities are characterized by the reuse of OTP seeds and admin credentials, allowing continued access even after security patches are applied.",
       "meta": {
+        "name-attribution": [
+          "UNC6148:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6148": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/sonicwall-secure-mobile-access-exploitation-overstep-backdoor/"
@@ -19540,6 +21821,9 @@
       "description": "UNC5342 is a North Korea-linked APT that employs the EtherHiding technique to deliver malware and facilitate cryptocurrency theft. The actor has been observed deploying EtherRAT and JADESNOW malware, utilizing transaction history as a Dead Drop Resolver to embed payloads directly into the calldata of blockchain transactions. Their operations involve leveraging centralized API services to interact with public blockchains like Ethereum and BNB Smart Chain. The malware is designed to exfiltrate sensitive data, particularly targeting cryptocurrency wallets and credentials.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "UNC5342:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5342": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/dprk-adopts-etherhiding"
@@ -19551,6 +21835,9 @@
     {
       "description": "UNC6485 is a cyber-espionage group exploiting CVE-2025-12480 in Gladinet’s Triofox file-sharing platform to gain initial network access and establish long-term persistence. They create unauthorized administrative accounts and deploy RATs, utilizing legitimate tools like Zoho Assist and AnyDesk to evade detection. Their TTPs indicate a sophisticated understanding of the platform, allowing them to blend malicious activities with legitimate administrative actions.",
       "meta": {
+        "name-attribution": [
+          "UNC6485:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6485": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/triofox-vulnerability-cve-2025-12480"
@@ -19563,6 +21850,10 @@
       "description": "UNC6384 (also tracked as Vertigo Panda) is a Chinese-affiliated APT that conducts targeted espionage campaigns primarily against diplomatic entities in Southeast Asia and Europe, specifically Belgium and Hungary. The group exploits the ZDI-CAN-25373 Windows shortcut vulnerability to gain initial code execution via malicious .LNK files, deploying the PlugX RAT through sophisticated delivery mechanisms, including DLL side-loading and adversary-in-the-middle attacks. Their operations involve social engineering tactics, such as spear-phishing emails themed around diplomatic events, to entice victims into executing malicious payloads. UNC6384's use of valid code signing and HTTPS hosting enhances their evasion of detection and increases the likelihood of user interaction.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC6384:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Vertigo Panda:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "origin:UNC6384": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/prc-nexus-espionage-targets-diplomats/"
@@ -19577,6 +21868,9 @@
     {
       "description": "UNC6040 is a financially motivated threat cluster that employs vishing to gain access to organizations' Salesforce environments, facilitating large-scale data exfiltration. The group manipulates end users into authorizing malicious connected apps, often masquerading as IT support personnel, to exploit OAuth permissions. Following initial access, UNC6040 leverages harvested credentials to move laterally within victim networks, targeting other cloud platforms like Okta and Microsoft 365. Their operations are characterized by the use of Mullvad VPN IP addresses and a focus on social engineering tactics to bypass security measures.",
       "meta": {
+        "name-attribution": [
+          "UNC6040:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6040": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/voice-phishing-data-extortion",
@@ -19591,6 +21885,9 @@
       "description": "Educated Manticore is an Iranian APT group aligned with the Islamic Revolutionary Guard Corps, primarily engaged in espionage targeting government, military, and academic sectors. The group employs spear-phishing tactics, utilizing custom backdoors like POWERLESS and phishing kits designed as SPAs to harvest credentials. Their operations have included impersonating credible figures to lure victims and using ISO images to initiate infection chains. Educated Manticore's activities are characterized by rapid domain setup and aggressive spear-phishing campaigns, particularly against Israeli individuals.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Educated Manticore:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2025/iranian-educated-manticore-targets-leading-tech-academics",
           "https://blog.checkpoint.com/security/check-point-research-uncovers-rare-techniques-used-by-iranian-affiliated-threat-actor-targeting-israeli-entities/",
@@ -19625,6 +21922,9 @@
       "description": "WARP PANDA is a China-nexus APT that targets VMware vCenter environments and Microsoft Azure infrastructures, primarily focusing on legal, technology, and manufacturing sectors in the U.S. The group exploits internet-facing edge devices for initial access, later pivoting to vCenter environments using compromised credentials or vulnerabilities. Their toolkit includes the BRICKSTORM backdoor, along with implants like Junction and GuestConduit, which facilitate command execution and network traffic tunneling. WARP PANDA demonstrates advanced OPSEC and aims for long-term persistence and data exfiltration aligned with the interests of the People's Republic of China.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "WARP PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.crowdstrike.com/en-us/blog/warp-panda-cloud-threats/"
         ]
@@ -19662,6 +21962,9 @@
     {
       "description": "Golden Eye Dog targets Chinese-speaking users engaged in online gambling, employing techniques such as SERP poisoning, social engineering, and DDoS attacks. The group utilizes trojanized NSIS installers to deliver RONINGLOADER, which executes complex process-injection workflows and deploys a modified Gh0st RAT for espionage. Their operations have included DLL sideloading and the use of watering hole websites to implant Trojans. The group is noted for its high anti-detection capabilities and has been associated with various malware development languages.",
       "meta": {
+        "name-attribution": [
+          "DragonBreath:455b9e40-e8dd-443b-87b3-c70bd09b4231"
+        ],
         "refs": [
           "https://www.sophos.com/fr-fr/blog/doubled-dll-sideloading-dragon-breath"
         ],
@@ -19687,6 +21990,9 @@
     {
       "description": "Storm-2657 is a financially motivated threat actor targeting US-based organizations, particularly in higher education, to compromise employee accounts and redirect salary payments to attacker-controlled accounts. They employ tactics such as creating inbox rules to delete warning notifications from HR platforms like Workday and using phishing emails that impersonate legitimate university communications to gain access. The actor modifies employee salary payment configurations to facilitate financial theft. Mitigation efforts include implementing phishing-resistant MFA methods to secure user identities against such attacks.",
       "meta": {
+        "name-attribution": [
+          "Storm-2657:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-2657": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/10/09/investigating-targeted-payroll-pirate-attacks-affecting-us-universities/"
@@ -19699,6 +22005,9 @@
       "description": "GhostRedirector is a China-aligned threat actor that has compromised at least 65 Windows servers across various sectors, primarily in Brazil, Thailand, and Vietnam. It employs a passive C++ backdoor named Rungan and a malicious IIS module called Gamshen to maintain persistent access and manipulate search engine results for SEO fraud. The actor utilizes public exploits like EfsPotato and BadPotato for privilege escalation and abuses code-signing certificates to evade detection. GhostRedirector's operations involve installing remote access tools, creating rogue administrator accounts, and leveraging SQL injection vulnerabilities to execute PowerShell for downloading malicious payloads.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "GhostRedirector:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/ghostredirector-poisons-windows-servers-backdoors-side-potatoes/"
         ]
@@ -19753,6 +22062,9 @@
       "description": "UAT-8837 is a sophisticated China-linked APT group exploiting critical zero-day vulnerabilities, such as CVE-2025-53690 in the Sitecore platform, to achieve remote code execution and deploy the WeepSteel backdoor for espionage and data exfiltration. The group targets high-value enterprise and government sectors, focusing on public-facing applications to gain initial access and conducting stealthy reconnaissance. UAT-8837 employs techniques like privilege escalation by creating administrative accounts and is linked to targeted intrusions aimed at credential harvesting and internal reconnaissance.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-8837:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-8837/"
         ]
@@ -19798,6 +22110,9 @@
       "description": "CryptoCore is a North Korean APT known for targeting cryptocurrency exchanges and financial institutions, employing spear-phishing techniques that lead to LONEJOGGER malware infections. The group has leveraged social engineering tactics, including deepfake technology and hijacked YouTube accounts, to execute sophisticated giveaway scams that deceive victims into sending cryptocurrencies. Their operations have involved the misuse of platforms like Gemini for reconnaissance and the development of fraudulent content. Additionally, CryptoCore has been linked to a variety of campaigns, including Dangerous Password and SnatchCrypto, focusing on financial gain through cryptocurrency theft.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "UNC1069:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC1069": "Mandiant",
         "refs": [
           "https://www.mandiant.com/resources/blog/north-korea-cyber-structure-alignment-2023",
@@ -19816,6 +22131,9 @@
       "description": "Storm-1175 is a cybercriminal group known for deploying Medusa ransomware and exploiting public-facing applications for initial access. They have been observed exploiting a critical deserialization vulnerability in GoAnywhere MFT, tracked as CVE-2025-10035, which could lead to command injection and potential RCE. Microsoft Defender researchers identified exploitation activity aligned with TTPs attributed to Storm-1175, including the use of post-compromise techniques that involve creating a group named “ESX Admins” in the domain.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Storm-1175:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1175": "Microsoft",
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2025/10/06/investigating-active-exploitation-of-cve-2025-10035-goanywhere-managed-file-transfer-vulnerability/"
@@ -19828,6 +22146,10 @@
       "description": "UAT-7237 is a Chinese-speaking APT group that has been active since at least 2022, primarily targeting web infrastructure entities in Taiwan. They utilize a customized Shellcode loader known as “SoundBill” to execute shellcode, including Cobalt Strike payloads, and rely on SoftEther VPN clients and RDP for persistence and access. UAT-7237 employs techniques such as credential extraction using Mimikatz, reconnaissance with WMI-based tools, and selective deployment of web shells. Their operations indicate a focus on long-term persistence and stealth, with a preference for open-sourced and customized tooling.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-7237:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7",
+          "CL-STA-1062:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-7237-targets-web-hosting-infra/",
           "https://unit42.paloaltonetworks.com/cl-sta-1062-tinyrct-backdoor/"
@@ -19888,6 +22210,10 @@
     {
       "description": "TA584 is a prominent initial access broker tracked by Proofpoint since November 2020, known for its high-volume campaigns targeting organizations globally. The actor employs various TTPs, including macro-enabled Excel documents, aggressive URL filtering, and geo-fenced landing pages, while frequently changing lures and delivery methods to evade detection. In 2025, TA584 expanded its geographic targeting to include Germany and Australia, while also introducing new malware such as Tsundere Bot alongside XWorm with the \"P0WER\" configuration. The actor's campaigns are characterized by rapid turnover and deliberate variability, making static indicators less effective for detection.",
       "meta": {
+        "name-attribution": [
+          "TA584:cae79680-67a6-4411-903c-f824dbcc813f",
+          "Storm-0900:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-0900": "Microsoft",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/cant-stop-wont-stop-ta584-innovates-initial-access",
@@ -19923,6 +22249,9 @@
     {
       "description": "DarkPink is an APT group that has been active since mid-2021, primarily targeting government, military, and non-profit organizations in Southeast Asia and Europe. The group employs spear phishing techniques, utilizing ISO images and malicious PDF files to deliver custom Trojan programs like TelePowerBot and KamiKakaBot for information theft. They have exploited vulnerabilities such as CVE-2023-38831 to enhance their attack processes and maintain persistence through DLL side-loading and scheduled tasks. DarkPink's operations are characterized by stealth and precision, making them a significant threat in the cyber landscape.",
       "meta": {
+        "name-attribution": [
+          "DarkPink:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/dark-pink-apt/",
           "https://www.group-ib.com/blog/dark-pink-episode-2/"
@@ -19962,6 +22291,9 @@
       "description": "UAT-8099 is a Chinese-speaking cybercrime group primarily engaged in SEO fraud and the theft of high-value credentials, configuration files, and certificate data from vulnerable IIS servers. They utilize web shells and PowerShell to deploy the GotoHTTP tool for remote access, while also employing techniques such as DLL sideloading and RDP for persistence. The group has been observed using BadIIS variants for SEO manipulation and executing reconnaissance commands to gather system information. Additionally, they create hidden accounts and utilize VPN tools to maintain long-term access to compromised systems.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-8099:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-8099-new-persistence-mechanisms-and-regional-focus/",
           "https://blog.talosintelligence.com/uat-8099-chinese-speaking-cybercrime-group-seo-fraud/"
@@ -19983,6 +22315,9 @@
     {
       "description": "Storm-1747 is an intrusion set that develops and operates the Tycoon 2FA phishing kit, which has been active since at least mid-2023 and is known for its sophisticated obfuscation and exfiltration techniques. The kit has been sold and distributed under the PhaaS model, making it one of the most widespread phishing kits by early 2025.",
       "meta": {
+        "name-attribution": [
+          "Storm-1747:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "origin:Storm-1747": "Microsoft",
         "refs": [
           "https://any.run/cybersecurity-blog/salty2fa-tycoon2fa-hybrid-phishing-2025/"
@@ -19994,6 +22329,9 @@
     {
       "description": "CryptoChameleon is a cybercriminal group known for targeting cryptocurrency exchanges and users to steal digital assets, employing tactics such as VIP spear phishing, SIM swapping, and email hacks. They have leveraged phishing kits, including a notable one associated with LastPass, and utilize infrastructure from bulletproof host NICENIC. The group primarily targets platforms like Coinbase and Ledger, and their attacks are characterized by rapid cash-out efforts following successful breaches. Their operational methods include manually guiding victims through phishing pages to evade detection by automated scanners.",
       "meta": {
+        "name-attribution": [
+          "UNC5356:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC5356": "Mandiant",
         "refs": [
           "https://www.silentpush.com/blog/poisonseed/",
@@ -20010,6 +22348,9 @@
       "description": "UAT-6382 is a Chinese-speaking threat actor that exploits CVE-2025-0944 to gain access to enterprise networks, particularly targeting local governing bodies in the U.S. They deploy web shells like AntSword and chinatso/Chopper on IIS web servers and utilize Rust-based loaders to implement Cobalt Strike and VSHell for persistent access. UAT-6382 employs custom tooling, such as TetraLoader, and conducts reconnaissance to identify and exfiltrate files of interest. Their VShell stager connects to a hardcoded C2 server and executes payloads in memory, indicating modifications made by the actor.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-6382:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-6382-exploits-cityworks-vulnerability/"
         ]
@@ -20021,6 +22362,9 @@
       "description": "TA829 is a Russia-aligned threat actor that employs the RomCom RAT for intelligence-gathering and financially motivated cyberattacks, exploiting zero-day vulnerabilities in Mozilla Firefox and Microsoft Windows. The group utilizes REM Proxy services hosted on compromised MikroTik routers to relay traffic and disguise its origin. In their operations, victims targeted by TA829 receive a strain known as SlipScreen, while their infrastructure and tactics show significant similarities to those of UNK_GreenSec. TA829's hybrid approach combines espionage with financial fraud, making it a notable player in the cyber threat landscape.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "TA829:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/10-things-i-hate-about-attribution-romcom-vs-transferloader"
         ]
@@ -20032,6 +22376,10 @@
       "description": "CopyCop is a Russian covert influence network that has established over 300 fictional media websites targeting the US, France, Canada, and other countries, primarily to disseminate pro-Russian and anti-Ukrainian narratives. The network employs TTPs such as deepfakes, fake interviews, and self-hosted LLMs for content generation, while also impersonating local media outlets and fact-checking organizations. Its operations are supported by the Moscow-based Center for Geopolitical Expertise and the GRU, aiming to undermine support for Ukraine and exacerbate political fragmentation in Western nations. CopyCop's influence content is amplified by a network of pro-Russian social media influencers and other Russian influence networks.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "Storm-1516:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "CopyCop:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "origin:Storm-1516": "Microsoft",
         "refs": [
           "https://www.recordedfuture.com/research/copycop-deepens-its-playbook-with-new-websites-and-targets",
@@ -20066,6 +22414,9 @@
       "description": "BladedFeline is an Iran-aligned APT group that has been active since at least 2017, targeting Iraqi and Kurdish government officials for cyberespionage. The group employs a variety of tools, including the Shahmaran backdoor, Whisper, and PrimeCache, which is a malicious IIS module. BladedFeline utilizes techniques such as spearphishing (T1566), exploiting public-facing applications (T1190), and timestomping to maintain access and exfiltrate data. The group is assessed with medium confidence to be a subgroup of OilRig, focusing on strategic access to high-ranking officials in the region.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "BladedFeline:3a43aca5-6366-4168-b182-a8afec4550b5"
+        ],
         "refs": [
           "https://www.welivesecurity.com/en/eset-research/bladedfeline-whispering-dark/"
         ]
@@ -20076,6 +22427,9 @@
     {
       "description": "INJ3CTOR3 is a threat actor first identified in 2020, known for targeting vulnerabilities in VoIP systems, specifically CVE-2019-19006 and CVE-2021-45461. Their operations involve exploiting FreePBX vulnerabilities to deploy PHP web shells for data exfiltration and persistence. The group utilizes tools for SIP server exploitation, including brute-force scripts and authentication bypass techniques. Observations indicate a resurgence of their attack patterns, reflecting historical behaviors while adapting to current vulnerabilities.",
       "meta": {
+        "name-attribution": [
+          "INJ3CTOR3:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2020/inj3ctor3-operation-leveraging-asterisk-servers-for-monetization/",
           "https://unit42.paloaltonetworks.com/digium-phones-web-shell/",
@@ -20110,6 +22464,9 @@
       "description": "Amaranth-Dragon is a previously untracked threat actor assessed to be closely linked to the China-affiliated APT 41 ecosystem, exhibiting similar tooling and operational patterns. The group demonstrated technical maturity by rapidly operationalizing CVE-2025-8088, a vulnerability in WinRAR, shortly after its public disclosure. Check Point Research has identified multiple campaigns targeting Cambodia, Thailand, Laos, Indonesia, Singapore, and the Philippines, with operations typically focused on one or two countries at a time. The overlaps in technical and operational indicators strongly suggest that Amaranth-Dragon is either affiliated with or part of the broader APT-41 ecosystem.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Amaranth-Dragon:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://blog.checkpoint.com/research/amaranth-dragon-targeted-cyber-espionage-campaigns-across-southeast-asia/"
         ]
@@ -20120,6 +22477,9 @@
     {
       "description": "UNC6671 is involved in credential harvesting operations, utilizing vishing tactics to impersonate IT staff and directing victims to enter credentials on a victim-branded site. They have gained access to Okta customer accounts and employed PowerShell to download sensitive data from SharePoint and OneDrive. Their extortion tactics include aggressive harassment of victim personnel, and they have used unbranded extortion emails with different Tox IDs for communication. The threat actors have shown a preference for registering domains with Tucows, indicating potential operational differences from related threat groups.",
       "meta": {
+        "name-attribution": [
+          "UNC6671:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6671": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/expansion-shinyhunters-saas-data-theft/"
@@ -20132,6 +22492,9 @@
       "description": "TAG-140 is a threat actor group that primarily targets Indian government entities, employing cyber espionage tactics such as phishing and malware campaigns. They have deployed a new variant of the DRAT RAT, known as DRAT V2, which utilizes a ClickFix lure and executes a remote script via mshta.exe to establish persistence and facilitate data exfiltration. Their operations include the use of the BroaderAspect loader and a custom TCP-based C2 protocol, enabling a range of post-exploitation activities. TAG-140's activities reflect a pattern of iterative advancement in their malware arsenal and delivery techniques, complicating detection and attribution efforts.",
       "meta": {
         "country": "PK",
+        "name-attribution": [
+          "TAG-140:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/research/drat-v2-updated-drat-emerges-tag-140s-arsenal"
         ]
@@ -20152,6 +22515,9 @@
     {
       "description": "SHADOW-VOID-042 is a provisional intrusion set tracked by Trend Micro, active in October-November 2025, conducting spear-phishing campaigns against energy, defense, pharmaceutical, cybersecurity, and other sectors using lures like HR complaints, research surveys, and fake Trend Micro security updates urging browser fixes. Attacks employ multi-stage loaders: shellcode generates machine-specific IDs for C2 \"get_module_hello\" requests fetching encrypted Stage 2 (SystemProcessHost.exe) with scheduled tasks for persistence, followed by Stage 3 fetching additional payloads via API hashing and retries on hardcoded C2s. Infrastructure overlaps with Void Rabisu (ROMCOM/Storm-0978), but lacks confirmed ROMCOM deployment or Ukraine focus, warranting separate tracking.\n",
       "meta": {
+        "name-attribution": [
+          "SHADOW-VOID-042:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/25/l/SHADOW-VOID-042.html"
         ]
@@ -20182,6 +22548,10 @@
     {
       "description": "TGR-STA-1030 is a state-aligned cyberespionage group operating out of Asia, known for compromising government and critical infrastructure organizations across 37 countries. The group frequently deploys web shells, such as Behinder, Neo-reGeorg, and Godzilla, on both external and internal web servers to maintain access and enable lateral movement. TGR-STA-1030 has conducted extensive reconnaissance against government infrastructure, particularly focusing on nations in the South China Sea and Gulf of Thailand regions, as well as European countries like Germany. The group primarily targets government ministries and departments for espionage purposes, especially those exploring specific economic partnerships.",
       "meta": {
+        "name-attribution": [
+          "UNC6619:da5cdcd1-7b15-4371-b7eb-ca32916d2052",
+          "Shadow Campaigns:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "origin:UNC6619": "Mandiant",
         "refs": [
           "https://unit42.paloaltonetworks.com/shadow-campaigns-uncovering-global-espionage/"
@@ -20286,6 +22656,9 @@
     {
       "description": "financially motivated threat actor operating from China",
       "meta": {
+        "name-attribution": [
+          "UNC6691:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6691": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/coruna-powerful-ios-exploit-kit?linkId=59478481"
@@ -20306,6 +22679,9 @@
     {
       "description": "suspected Russian espionage group.",
       "meta": {
+        "name-attribution": [
+          "UNC6353:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6353": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/coruna-powerful-ios-exploit-kit?linkId=59478481"
@@ -20326,6 +22702,9 @@
     {
       "description": "The Gentlemen is a ransomware group that employs a dual-extortion strategy, encrypting sensitive files while exfiltrating critical business data to pressure victims into paying ransoms. Their operations leverage advanced techniques such as abusing legitimate utilities like PowerRun.exe for privilege escalation, using custom-built tools for defense evasion, and employing flexible encryption methods based on file size. The group targets medium to large organizations across various sectors, particularly in the Asia-Pacific region, and has demonstrated a high level of technical maturity and operational discipline. Their activities include systematic compromise of enterprise environments, mass account enumeration, and the use of encrypted channels for data exfiltration.",
       "meta": {
+        "name-attribution": [
+          "The Gentlemen:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://socradar.io/blog/dark-web-profile-the-gentlemen-ransomware/",
           "https://www.trendmicro.com/en_us/research/25/i/unmasking-the-gentlemen-ransomware.html",
@@ -20340,6 +22719,9 @@
       "description": "UNC6201 is a sophisticated Chinese state-sponsored hacking group that exploited CVE-2026–22769, a critical vulnerability in Dell RecoverPoint for Virtual Machines appliances, to establish a persistent presence. They deployed a permanent backdoor using techniques like Single Packet Authorization and \"Port Knocking.\" Unlike typical hackers who conceal their activities within the Operating System, UNC6201 operated at the Virtualization Layer to avoid detection.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC6201:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6201": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/unc6201-exploiting-dell-recoverpoint-zero-day"
@@ -20352,6 +22734,9 @@
       "description": "UNC2814 is a suspected PRC-nexus cyber espionage group that has targeted telecommunications providers and government entities globally since at least 2017. The group employs the GRIDTIDE backdoor to blend malicious traffic with legitimate cloud API activity and utilizes living-off-the-land techniques, including SSH lateral movement and the creation of malicious systemd services. GTIG has confirmed 53 intrusions across 42 countries and identified suspected activity in at least 20 additional nations, with a focus on exfiltrating sensitive communications data. Google has taken significant disruption actions against UNC2814, including infrastructure takedowns and the release of IOCs to aid in detection.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC2814:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC2814": "Mandiant",
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/disrupting-gridtide-global-espionage-campaign/"
@@ -20376,6 +22761,10 @@
     {
       "description": "TAG-150, also known as GrayBravo, is a sophisticated threat actor responsible for developing multiple custom malware families, including CastleLoader and CastleRAT, and operates a large-scale, multi-layered infrastructure. The group employs the ClickFix technique to distribute malware through phishing attacks that impersonate legitimate services, leveraging deceptive domains and fake repositories. Insikt Group has identified four distinct activity clusters associated with TAG-150, each targeting different victim profiles and utilizing unique TTPs.",
       "meta": {
+        "name-attribution": [
+          "GrayBravo:ad7032df-0e9a-4ea9-b35c-c68ff854be80",
+          "TAG-150:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/research/graybravos-castleloader-activity-clusters-target-multiple-industries",
           "https://www.recordedfuture.com/research/from-castleloader-to-castlerat-tag-150-advances-operations"
@@ -20390,6 +22779,9 @@
     {
       "description": "Water Kurita is a financially motivated cybercriminal entity associated with the Lumma Stealer infostealer-as-a-service operation, primarily active on underground forums and marketplaces. It focuses on credential and information theft at scale, monetizing access via subscription-based malware distribution and resale of stolen data to other actors. The group demonstrates solid operational security and marketing tactics typical of mature MaaS ecosystems, although a 2025 doxxing campaign exposing alleged core members (personal and financial data) significantly disrupted its activity and drove customers toward competing infostealers.",
       "meta": {
+        "name-attribution": [
+          "Water Kurita:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/25/c/ai-assisted-fake-github-repositories.html",
           "https://www.trendmicro.com/en_us/research/25/g/lumma-stealer-returns.html",
@@ -20403,6 +22795,9 @@
     {
       "description": "UAT-8616 is a highly sophisticated cyber threat actor attributed by Cisco Talos, with evidence of activity dating back to at least 2023. They have been observed exploiting CVE-2026-20127 in the wild and previously exploited CVE-2022-20775 by escalating to root user access through a software version downgrade. Their operations indicate a focus on targeting network edge devices to establish persistent footholds in high-value organizations, including Critical Infrastructure sectors.",
       "meta": {
+        "name-attribution": [
+          "UAT-8616:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-8616-sd-wan/"
         ]
@@ -20414,6 +22809,9 @@
       "description": "UAT-9244 is a China-nexus APT actor, disclosed by Cisco Talos on March 5, 2026, assessed with high confidence as closely associated with Famous Sparrow and overlapping with Tropic Trooper. Active since 2024, it exclusively targets South American telecommunication providers, deploying three novel cross-platform malware families: TernDoor (Windows backdoor with DLL side-loading and evasion driver), PeerTime (Linux/embedded backdoor using BitTorrent for resilient C2), and BruteEntry (GoLang scanner turning edge devices into Operational Relay Boxes for SSH/Postgres/Tomcat brute-force). The campaign enables persistent access, remote command execution, lateral movement, and infrastructure relay via unified C2 with shared SSL certificates and domains like bloopencil.net.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-9244:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-9244/"
         ]
@@ -20424,6 +22822,9 @@
     {
       "description": "GTFire is a threat actor that leverages Google Firebase for hosting phishing pages and Google Translate to disguise malicious URLs, effectively bypassing security filters. The campaign employs a multi-step redirect chain to obscure the final phishing destination and utilizes All-in-1 PHP phishing scripts for rapid deployment and credential harvesting. Credentials are exfiltrated via URL parameters in a standard HTTP GET request, with minimal operational overhead.",
       "meta": {
+        "name-attribution": [
+          "GTFire:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/gtfire-phishing-scheme/"
         ]
@@ -20468,6 +22869,9 @@
     {
       "description": "UNC6426 exploited a supply chain compromise of the nx npm package to steal a developer's GitHub Personal Access Token and gain access to a victim's cloud environment. They abused the GitHub-to-AWS OpenID Connect trust to create a new administrator role, leveraging overly permissive permissions associated with the compromised GitHub-Actions-CloudFormation role. Using the legitimate open-source tool Nord Stream, UNC6426 conducted reconnaissance and extracted secrets from CI/CD environments, leading to the exfiltration of files from AWS S3 buckets and data destruction. The actor escalated to full AWS administrator permissions in under 72 hours.",
       "meta": {
+        "name-attribution": [
+          "UNC6426:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "origin:UNC6426": "Mandiant",
         "refs": [
           "https://cloud.google.com/security/report/resources/cloud-threat-horizons-report-h1-2026"
@@ -20506,6 +22910,9 @@
     {
       "description": "TA2723 is a financially-motivated, high-volume credential phishing threat actor known for spoofing Microsoft OneDrive, LinkedIn, and DocuSign. Proofpoint Threat Research has observed TA2723 conducting OAuth device code phishing campaigns, utilizing tools like Squarephish and Graphish to enhance their operations. The use of these tools allows TA2723 to mitigate the short-lived nature of device codes, facilitating larger campaigns. Successful attacks can lead to M365 account takeover, data exfiltration, and lateral movement.",
       "meta": {
+        "name-attribution": [
+          "TA2723:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "origin:TA2723": "Proofpoint",
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/access-granted-phishing-device-code-authorization-account-takeover"
@@ -20583,6 +22990,10 @@
     {
       "description": "TeamPCP is a threat actor that has executed a coordinated series of supply chain attacks, compromising widely-used open source tools such as Trivy, KICS, and LiteLLM to deploy credential-stealing malware. They employed techniques like credential harvesting, lateral movement within Kubernetes environments, and audio steganography to evade detection. The group has demonstrated the ability to leverage stolen credentials to propagate attacks across multiple ecosystems, including npm and PyPI, using a self-propagating worm known as CanisterWorm. Their operations have included the use of AES-256 encryption and RSA-4096 for exfiltration of sensitive data.",
       "meta": {
+        "name-attribution": [
+          "TeamPCP:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed",
+          "Altered Spider:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/26/c/teampcp-telnyx-attack-marks-a-shift-in-tactics.html",
           "https://www.trendmicro.com/en_us/research/26/c/inside-litellm-supply-chain-compromise.html",
@@ -20631,6 +23042,9 @@
     {
       "description": "UAT-10608 is a threat cluster observed by Cisco Talos conducting a large-scale, automated credential-harvesting campaign against public-facing web applications, especially Next.js deployments, using a custom framework called NEXUS Listener to extract and exfiltrate secrets such as credentials, SSH keys, cloud tokens, and API keys. The activity has been linked to broad opportunistic scanning and at least 766 compromised hosts across multiple regions and cloud providers.",
       "meta": {
+        "name-attribution": [
+          "UAT-10608:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-10608-inside-a-large-scale-automated-credential-harvesting-operation-targeting-web-applications/"
         ]
@@ -20680,6 +23094,9 @@
     {
       "description": "Coinbase Cartel is a ransomware threat actor that emerged in September 2025, focusing on data exfiltration rather than encryption, and has claimed over 60 victims, primarily in the healthcare, technology, and transportation sectors. The group employs TTPs such as social engineering, credential harvesting, and collaboration with Initial Access Brokers to gain initial access. They operate a data leak site where they publish victim names and issue ransom demands, requiring payment via Bitcoin.",
       "meta": {
+        "name-attribution": [
+          "Coinbase Cartel:1c141c9b-ec78-4f86-a8ea-b02944fa5492"
+        ],
         "refs": [
           "https://businessinsights.bitdefender.com/coinbase-cartel-ransomware-group-extortion-tactics"
         ]
@@ -20690,6 +23107,9 @@
     {
       "description": "GrayCharlie is a threat actor that compromises WordPress sites to inject malicious JavaScript, redirecting visitors to NetSupport RAT payloads via fake browser update pages or ClickFix mechanisms. Insikt Group has identified extensive infrastructure linked to GrayCharlie, primarily associated with MivoCloud and HZ Hosting Ltd., including command-and-control servers and staging infrastructure. The group employs two primary attack chains to deliver the NetSupport RAT, utilizing both fake updates and ClickFix techniques. GrayCharlie targets organizations worldwide, with a particular focus on the US, and has shown persistent behavior in its operations since its emergence in 2023.",
       "meta": {
+        "name-attribution": [
+          "GrayCharlie:ad7032df-0e9a-4ea9-b35c-c68ff854be80"
+        ],
         "refs": [
           "https://www.recordedfuture.com/research/graycharlie-hijacks-law-firm-sites-suspected-supply-chain-attack"
         ]
@@ -20743,6 +23163,9 @@
     {
       "description": "SHADOW-AETHER-015 is a highly adaptable cybercriminal group known for identity abuse and cloud compromise, primarily targeting identity and access management systems like Okta and Azure AD/Entra ID. They employ sophisticated social engineering techniques, including vishing and help-desk impersonation, to gain access to legitimate credentials. Their operations involve multi-pressure extortion tactics, such as data theft, ransomware, and employee intimidation, while leveraging MFA fatigue and token theft to bypass authentication controls. The group has been linked to the \"0ktapus\" phishing campaign and is most active in English-speaking countries, with a focus on sectors rich in sensitive data.",
       "meta": {
+        "name-attribution": [
+          "SHADOW-AETHER-015:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/26/a/shadow-aether-015-earth-preta-mitre.html"
         ]
@@ -20774,6 +23197,9 @@
     {
       "description": "UNC6692 is a threat actor that employs social engineering tactics, such as impersonating IT helpdesk personnel, to gain initial access to victim environments. They utilize a custom modular malware suite, including components like SNOWBELT, SNOWGLAZE, and SNOWBASIN, to facilitate deep network penetration and lateral movement. After extracting credentials from the LSASS process memory, they leverage Pass-The-Hash techniques to authenticate to domain controllers and exfiltrate sensitive data using LimeWire. The campaign highlights the systematic abuse of legitimate cloud services for payload delivery and command-and-control infrastructure.",
       "meta": {
+        "name-attribution": [
+          "UNC6692:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/unc6692-social-engineering-custom-malware/"
         ]
@@ -20785,6 +23211,9 @@
       "description": "NICKEL ALLEY is a North Korean threat group that targets technology professionals through fake job opportunities, employing social engineering tactics such as creating fraudulent LinkedIn pages and GitHub repositories for malware delivery. They utilize the ClickFix tactic to deploy the PyLangGhost RAT, which supports file exfiltration and system profiling, particularly focusing on Chrome cryptocurrency wallet data. The group has also leveraged Visual Studio Code tasks to execute commands for malware retrieval based on the victim's operating system. Their operations indicate a dual focus on cryptocurrency theft and potential supply chain compromise or corporate espionage.",
       "meta": {
         "country": "KP",
+        "name-attribution": [
+          "Nickel Alley:455b9e40-e8dd-443b-87b3-c70bd09b4231"
+        ],
         "refs": [
           "https://www.sophos.com/en-us/blog/nickel-alley-strategy-fake-it-til-you-make-it"
         ]
@@ -20796,6 +23225,9 @@
       "description": "UAT-8302 is a sophisticated China-nexus APT group targeting government entities in South America and southeastern Europe, deploying custom-made malware such as NetDraft, CloudSorcerer version 3, and VSHELL. They utilize tools like SNOWLIGHT and SNOWRUST for initial access and reconnaissance, employing techniques such as PowerShell scripts and SMB share discovery. UAT-8302 also establishes backdoor access through proxy servers and uses tools like Stowaway for tunneling traffic. Their operations indicate a close relationship with other known China-nexus threat actors, leveraging shared malware families and TTPs.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-8302:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-8302/"
         ]
@@ -20839,6 +23271,9 @@
       "description": "UNC6748 targets users in Saudi Arabia through a fake Snapchat website, employing a backdoor known as GHOSTKNIFE for data exfiltration. Their exploitation process initially featured basic obfuscation, which evolved to include anti-debugging measures. The actor primarily leveraged CVE-2025-31277 and CVE-2026-20700 for RCE exploits, but exhibited inconsistencies in exploit support for different iOS versions. Additionally, UNC6748's delivery mechanisms incorporated session storage checks to manage infection attempts.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "UNC6748:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/darksword-ios-exploit-chain/"
         ]
@@ -20849,6 +23284,9 @@
     {
       "description": "FlowerStorm is a phishing-as-a-service platform that mimics legitimate services to bypass multi-factor authentication structure. The majority of its targets are located in North America and Europe, with a significant focus on organizations in the United States. FlowerStorm's operational mistakes have led to vulnerabilities that can be exploited for disruption and analysis.",
       "meta": {
+        "name-attribution": [
+          "FlowerStorm:455b9e40-e8dd-443b-87b3-c70bd09b4231"
+        ],
         "refs": [
           "https://news.sophos.com/en-us/2024/12/19/phishing-platform-rockstar-2fa-trips-and-flowerstorm-picks-up-the-pieces/"
         ]
@@ -20870,6 +23308,9 @@
       "description": "SHADOW-EARTH-053 is a China-aligned threat group exploiting unpatched Microsoft Exchange Server vulnerabilities, specifically CVE-2021-26855, to conduct cyberespionage against government and defense-linked targets across Asia and Europe. The group primarily deploys ShadowPad malware, utilizing techniques such as credential dumping, tunneling tools, and lateral movement via WMIC. They have also been observed installing web shells for persistence and leveraging a custom ExchangeExport tool to extract high-value mailbox contents. Additionally, low-confidence associations with Noodle RAT and CVE-2025-55182 have been noted in their operations.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "Shadow-Earth-053:3ac8f6fc-9c04-4ebd-bda2-788cc02fe4ed"
+        ],
         "refs": [
           "https://www.trendmicro.com/en_us/research/26/d/inside-shadow-earth-053.html"
         ]
@@ -20902,6 +23343,9 @@
     {
       "description": "Storm-2561 is a cybercriminal threat actor known for a credential theft campaign that employs SEO poisoning to distribute fake VPN clients. The campaign redirects users to malicious ZIP files containing digitally signed trojans that harvest VPN credentials, leveraging user trust in search engine results. The malicious components are signed by “Taiyuan Lihua Near Information Technology Co., Ltd.” and were hosted on GitHub repositories that have since been taken down. This operation exhibits characteristics consistent with financially motivated cybercrime.",
       "meta": {
+        "name-attribution": [
+          "Storm-2561:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2026/03/12/storm-2561-uses-seo-poisoning-to-distribute-fake-vpn-clients-for-credential-theft/"
         ]
@@ -20914,6 +23358,9 @@
       "meta": {
         "country": "LB",
         "microsoft-origin-threat": "Lebanon",
+        "name-attribution": [
+          "Amethyst Rain:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json"
         ],
@@ -20939,6 +23386,10 @@
       "meta": {
         "country": "CN",
         "microsoft-origin-threat": "China",
+        "name-attribution": [
+          "Houndstooth Typhoon:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "DRAGNET PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json"
         ],
@@ -20964,6 +23415,9 @@
     {
       "description": "Microsoft threat actor profile from the public naming mapping feed.",
       "meta": {
+        "name-attribution": [
+          "RENEGADE JACKAL:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json"
         ],
@@ -20991,6 +23445,10 @@
       "description": "Microsoft threat actor profile. Origin/Threat: Group in development.",
       "meta": {
         "microsoft-origin-threat": "Group in development",
+        "name-attribution": [
+          "Storm-0252:d0c33595-b684-45ef-91c3-e2f5ce1a8191",
+          "CHATTY SPIDER:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json"
         ],
@@ -21014,6 +23472,9 @@
       "description": "Microsoft threat actor profile. Origin/Threat: India, Private sector offensive actor.",
       "meta": {
         "microsoft-origin-threat": "India, Private sector offensive actor",
+        "name-attribution": [
+          "DEV-0605:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://learn.microsoft.com/en-us/microsoft-365/security/intelligence/microsoft-threat-actor-naming?view=o365-worldwide",
           "https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json"
@@ -21051,6 +23512,9 @@
       "description": "GHOST STADIUM is a Chinese-speaking, financially motivated threat actor operating a sophisticated phishing campaign across over 300 domains, utilizing a custom React-based phishing kit that closely mimics FIFA's official website and exploits the PingIdentity SSO login flow. The campaign has the potential to generate financial losses estimated between $71 million and $474 million from premium ticket fraud alone, with total losses potentially reaching billions. GHOST STADIUM employs Facebook Ads as a primary traffic acquisition channel and has been linked to 2,513 compromised FIFA credentials available on dark-web markets. The actor is part of a broader fraud ecosystem that includes multiple parallel schemes, such as credential phishing and counterfeit merchandise sales.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "GHOST STADIUM:21afba9e-cd2a-45c9-b421-b1f14fd181e9"
+        ],
         "refs": [
           "https://www.group-ib.com/blog/ghost-stadium-football-fraud/"
         ]
@@ -21073,6 +23537,9 @@
       "description": "CL-UNK-1068 is a Chinese threat actor that has targeted critical infrastructure in Asia, primarily focusing on cyberespionage. They utilize cross-platform tools, including the Xnote Linux backdoor and the GodZilla web shell, to maintain a persistent presence and execute credential theft. Their TTPs involve DLL side-loading, the use of custom malware, and batch scripts to bypass security measures. The group has demonstrated a capability for data exfiltration from SQL servers and has employed tools like DumpIt and Volatility for memory analysis.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "CL-UNK-1068:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://unit42.paloaltonetworks.com/cl-unk-1068-targets-critical-sectors/"
         ]
@@ -21097,6 +23564,9 @@
       "description": "GREYVIBE is a low-to-moderately sophisticated threat actor associated with Russian state interests, primarily targeting Ukrainian entities. The group employs custom malware like LegionRelay and PhantomRelay, utilizing techniques such as decoy-and-payload execution logic and systematic use of GenAI and LLMs throughout their operations. Their campaigns exhibit operational overlaps with other groups, including shared C2 infrastructure and post-compromise tooling. WithSecure has identified design flaws in their malware that have provided insights into their victimology and operational behavior.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "GreyVibe:d597f230-4f70-43cb-817e-c745efd4fe35"
+        ],
         "refs": [
           "https://labs.withsecure.com/publications/greyvibe"
         ]
@@ -21130,6 +23600,9 @@
     {
       "description": "Storm-2949 is a sophisticated threat actor that exploited Microsoft’s Self-Service Password Reset process to compromise high-value accounts, primarily targeting IT personnel and senior leadership. They leveraged Azure tools and APIs to conduct reconnaissance, exfiltrate sensitive data from Microsoft 365 applications, and manipulate Azure resources, including Key Vaults and SQL databases. The actor employed social engineering tactics to bypass MFA and utilized custom Python scripts for directory discovery and data exfiltration. Their operations included lateral movement across cloud and endpoint environments while mimicking legitimate administrative behavior.",
       "meta": {
+        "name-attribution": [
+          "Storm-2949:d0c33595-b684-45ef-91c3-e2f5ce1a8191"
+        ],
         "refs": [
           "https://www.microsoft.com/en-us/security/blog/2026/05/18/storm-2949-turned-compromised-identity-into-cloud-wide-breach/"
         ]
@@ -21195,6 +23668,9 @@
       "description": "TA4922 is a Chinese-speaking cybercrime cluster that employs localized HR, payroll, tax, and invoice lures to deliver various malware families, including Atlas RAT, RomulusLoader, and SilentRunLoader. The actor conducts targeted email campaigns, often impersonating trusted authorities, to facilitate credential phishing and fraud. TA4922's operational tempo is high, with a focus on obtaining remote access for financial gain, and it has shown a rapid evolution in its malware arsenal. The group is also noted for using social engineering to shift communications from email to messaging platforms, enhancing their phishing efforts.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "TA4922:cae79680-67a6-4411-903c-f824dbcc813f"
+        ],
         "refs": [
           "https://www.proofpoint.com/us/blog/threat-insight/ta4922-suspected-chinese-crime-group-going-global"
         ]
@@ -21219,6 +23695,9 @@
       "description": "UNC6508 is a PRC-nexus threat actor targeting North American academic, medical, and military research institutions, employing tactics such as exploiting REDCap servers and deploying custom malware named INFINITERED. The actor utilized credential harvesting, internal reconnaissance, and a web shell named \"help.php\" for persistence. They also manipulated content compliance rules for covert data exfiltration, forwarding sensitive email communications to a threat actor-controlled Gmail address. GTIG attributes this espionage activity to UNC6508 with high confidence, based on infrastructure overlaps and specific targeting of defense and medical research sectors.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UNC6508:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/prc-targets-us-medical-research"
         ]
@@ -21241,6 +23720,9 @@
     {
       "description": "Mysterious Elephant is an APT group active since 2023 that primarily targets government and foreign affairs entities across South Asia, especially Pakistan, Bangladesh, Sri Lanka, Nepal, and Afghanistan. In its early-2025 campaign it shifted toward spear-phishing and custom/customized tools—including the BabShell reverse shell and MemLoader HidenDesk/Edge loaders—to deploy RATs like Remcos and VRat, while also using WhatsApp-specific exfiltration tools to steal shared documents, images, and archives. The group shares code and infrastructure with other APT clusters (Origami Elephant, Confucius, SideWinder), reflecting ongoing tool reuse and collaboration among South Asian threat actors.",
       "meta": {
+        "name-attribution": [
+          "Mysterious Elephant:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/mysterious-elephant-apt-ttps-and-tools/117596/",
           "https://www.anomali.com/blog/anomali-cyber-watch-f5-breach-mysterious-elephant-apt-malicious-mcp-servers"
@@ -21252,6 +23734,9 @@
     {
       "description": "Armored Likho is an APT group targeting government agencies and the electric power sector across Russia, Brazil, and Kazakhstan. Their operations blend financially motivated campaigns with cyber-espionage, utilizing obfuscated, modular RATs and infostealers designed to evade dynamic analysis. They employ spear-phishing emails with deceptive themes to gain initial access, distributing malicious attachments that mimic legitimate content. Their toolkit includes BusySnake Stealer and AquilaRAT, with a focus on evolving TTPs and leveraging AI tools for payload generation.",
       "meta": {
+        "name-attribution": [
+          "Armored Likho:0d4886f9-97e1-4cb2-8822-580fd09540e5"
+        ],
         "refs": [
           "https://securelist.com/tr/armored-likho-apt-with-busysnake-stealer/120292/"
         ],
@@ -21265,6 +23750,10 @@
     {
       "description": "Launched in August 2025, the Scattered LAPSUS$ Hunters collective has rapidly established itself as one of the most formidable threats on today’s cybercriminal landscape. This alliance brings together three of the most notorious English-speaking cybercriminal groups: Scattered Spider, LAPSUS$ and ShinyHunters. In just a few months, this organization has multiplied spectacular attacks against leading companies, stealing billions of pieces of data and perfecting the art of digital extortion.",
       "meta": {
+        "name-attribution": [
+          "Scattered Lapsus Hunters:e9491d3b-2174-47d6-8a15-ecec552d16ae",
+          "Scattered Lapsus$ Hunters:e9491d3b-2174-47d6-8a15-ecec552d16ae"
+        ],
         "refs": [
           "https://www.picussecurity.com/resource/blog/scattered-lapsus-hunters-2025s-most-dangerous-cybercrime-supergroup",
           "https://sosransomware.com/en/ransomware-groups/scattered-lapsus-hunters-the-cybercrime-alliance-that-will-shake-global-businesses-in-2025/",
@@ -21285,6 +23774,9 @@
     {
       "description": "UNC2529 is a well-resourced threat actor that conducted a global phishing campaign targeting various industries, utilizing tailored lures and sophisticated malware, including DOUBLEDRAG, DOUBLEDROP, and DOUBLEBACK. They compromised a legitimate domain to enhance their phishing efforts and employed at least 50 domains throughout the campaign. The actor demonstrated target research through personalized email addresses and subject lines, indicating a non-native English speaker. Their activities suggest a financial crime motive, with extensive use of obfuscation and fileless malware to evade detection.",
       "meta": {
+        "name-attribution": [
+          "UNC2529:da5cdcd1-7b15-4371-b7eb-ca32916d2052"
+        ],
         "refs": [
           "https://www.fireeye.com/blog/threat-research/2021/05/unc2529-triple-double-trifecta-phishing-campaign.html"
         ]
@@ -21306,6 +23798,9 @@
       "description": "UAT-7810 is an APT actor responsible for maintaining the LapDogs ORB network and developing custom malware, including the backdoors SHORTLEASH and LONGLEASH, as well as DOGLEASH and JARLEASH. They exploit known vulnerabilities in unpatched Ruckus wireless routers and have been observed using infrastructure to host malicious payloads across various hardware platforms. Forensic analysis has revealed their use of multiple IP addresses for hosting and deploying malware, including a test binary named LEASHTEST for functionality checks on MIPS devices. Talos assesses UAT-7810 as a China-nexus threat actor, providing infrastructure to secondary APTs while maintaining distinct objectives.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "UAT-7810:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-7810/"
         ]
@@ -21327,6 +23822,9 @@
       "description": "Cavern Manticore is an Iran-nexus APT primarily targeting Israeli organizations in the government and IT sectors, linked to the MOIS. The group employs a modular command-and-control framework built on a shared .NET foundation, utilizing multiple compilation formats to create an anti-analysis layer. Their operations demonstrate a high operational tempo and a disciplined approach to target selection, particularly during campaigns like \"Operation Epic Fury.\" By decoupling core infrastructure from mission-specific modules, Cavern Manticore enhances operational agility while complicating detection efforts for defenders.",
       "meta": {
         "country": "IR",
+        "name-attribution": [
+          "Cavern Manticore:adb3369a-5683-46b2-bceb-4dafa6526b21"
+        ],
         "refs": [
           "https://research.checkpoint.com/2026/cavern-manticore-exposing-iran-linked-modular-c2-framework/"
         ]
@@ -21338,6 +23836,9 @@
       "description": "UAT-11795 is a sophisticated, Russian-speaking, financially motivated adversary conducting malicious campaigns targeting users in the U.S. and Europe since June 2025. The actor employs CastleStealer and Remcos RAT as alternative payload implants. Their operations indicate a focus on financial gain through targeted attacks.",
       "meta": {
         "country": "RU",
+        "name-attribution": [
+          "UAT-11795:0adf6f0f-3795-4de1-9763-1bdd1c31a5d7"
+        ],
         "refs": [
           "https://blog.talosintelligence.com/uat-11795-deploys-novel-starland-rat-and-bespoke-wldr-c2-implant-in-financially-motivated-campaign/"
         ]
@@ -21349,6 +23850,9 @@
       "description": "Jackpot Panda is a China-nexus state-sponsored APT primarily focused on cyber espionage against East and Southeast Asian entities, particularly in the online gambling sector and domestic security. They rapidly exploited CVE-2025-55182 using automated scanning, reconnaissance commands, and multi-vulnerability campaigns. Their activities have been linked to infrastructure associated with the exploitation of trojanized platforms and malware deployment, including SNOWLIGHT and VShell.",
       "meta": {
         "country": "CN",
+        "name-attribution": [
+          "JACKPOT PANDA:f9eb432f-2293-48b7-bca4-cc78beb50df0"
+        ],
         "refs": [
           "https://cloud.google.com/blog/topics/threat-intelligence/threat-actors-exploit-react2shell-cve-2025-55182",
           "https://blog.polyswarm.io/multiple-threat-actors-leveraging-cve-2025-55182-react2shell",
@@ -21373,5 +23877,5 @@
       "value": "JadePuffer"
     }
   ],
-  "version": 345
+  "version": 347
 }


### PR DESCRIPTION
### Motivation
- Normalize and enrich threat actor entries with standardized name-attribution aliases and identifiers to improve vendor cross-references and attribution tracking.
- Add missing producer records for `Secureworks` and `MITRE` so those attribution sources can be referenced consistently.
- Bump producer catalog version after adding new producers.

### Description
- Added two new producer objects to `clusters/producer.json` for `Secureworks` and `MITRE` and incremented the file `version` from `24` to `25`.
- Performed a bulk update to `clusters/threat-actor.json` adding `name-attribution` arrays to many threat actor entries that map canonical names, vendor IDs, and UUIDs (linking APT identifiers, vendor labels like `STONE PANDA`, vendor UUIDs, and MITRE/TA/DEV tags) to normalize aliases and cross-source references.
- The change is strictly additive for attribution data (new `name-attribution` fields) and producer metadata; existing descriptive fields and UUIDs were preserved.
- Files touched: `clusters/producer.json` and `clusters/threat-actor.json`.

### Testing
- Ran JSON schema/format validation against the modified `clusters/*.json` files and fixed issues; validation passed.
- Ran repository linters (JSON/YAML formatting checks) against the changes; no linting errors were reported.
- No automated unit tests were modified by this change and the existing CI checks that exercise repository validation steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c4f58e0e48325a8ccadd41d0633d2)