### PR TITLE
producer: add Forescout Research - Vedere Labs

### DIFF
--- a/clusters/producer.json
+++ b/clusters/producer.json
@@ -3014,7 +3014,33 @@
       },
       "uuid": "a1ad5090-2487-46d2-8237-6151a2dd5063",
       "value": "MITRE"
+    },
+    {
+      "description": "Forescout Research - Vedere Labs is Forescout Technologies' threat intelligence research team, publishing analysis on vulnerabilities, malware, and threat actor activity affecting IT, OT, and IoT devices.",
+      "meta": {
+        "company-type": [
+          "Cyber Security Vendor"
+        ],
+        "country": "US",
+        "official-refs": [
+          "https://www.forescout.com/research-labs/"
+        ],
+        "product-type": [
+          "intelligence-feed-provider"
+        ],
+        "products": [
+          "Device Visibility and Control",
+          "OT/IoT Threat Intelligence"
+        ],
+        "synonyms": [
+          "Forescout Vedere Labs",
+          "Vedere Labs",
+          "Forescout"
+        ]
+      },
+      "uuid": "c9ce67dd-45d3-4f57-9f28-db4103ddca6d",
+      "value": "Forescout"
     }
   ],
-  "version": 25
+  "version": 26
 }


### PR DESCRIPTION
CISA's AIS TAXII feed attributes indicators to a `created_by_ref` identity named "Forescout Research -
Vedere Labs" - Forescout's threat intelligence research team. No cluster currently exists for this producer.

This adds a `producer` cluster entry


## Changes
- `clusters/producer.json`: add "Forescout Research - Vedere Labs" entry
  (uuid `c9ce67dd-45d3-4f57-9f28-db4103ddca6d`, generated via `uuid4()`
  per this repo's convention for new cluster entries)