### PR TITLE
Adds Jewelbug tools and expands references

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Category: *tmss* - source: *https://github.com/microsoft/Threat-matrix-for-stora
 
 [Tool](https://www.misp-galaxy.org/tool) - threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.
 
-Category: *tool* - source: *MISP Project* - total: *608* elements
+Category: *tool* - source: *MISP Project* - total: *611* elements
 
 [[HTML](https://www.misp-galaxy.org/tool)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/tool.json)]
 

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -21266,7 +21266,8 @@
         "refs": [
           "https://unit42.paloaltonetworks.com/advanced-backdoor-squidoor/",
           "https://www.elastic.co/security-labs/fragile-web-ref7707",
-          "https://www.security.com/threat-intelligence/jewelbug-apt-russia"
+          "https://www.security.com/threat-intelligence/jewelbug-apt-russia",
+          "https://www.security.com/threat-intelligence/jewelbug-crypto-fraud-espionage"
         ],
         "synonyms": [
           "CL-STA-0049",
@@ -21309,7 +21310,8 @@
         ],
         "origin:Earth Alux": "Trend Micro",
         "refs": [
-          "https://www.trendmicro.com/en_us/research/25/c/the-espionage-toolkit-of-earth-alux.html"
+          "https://www.trendmicro.com/en_us/research/25/c/the-espionage-toolkit-of-earth-alux.html",
+          "https://www.security.com/threat-intelligence/jewelbug-crypto-fraud-espionage"
         ]
       },
       "uuid": "6ccf810e-3021-4974-9b1e-29fb6cdcaedc",

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -11160,7 +11160,67 @@
       },
       "uuid": "7501abf2-4864-4fc2-a8a3-3a1250ab8e71",
       "value": "SilentRunLoader"
+    },
+    {
+      "description": "According to Symantec, Antino is the Windows backdoor used by the Jewelbug (aka REF7707, Earth Alux, CL-STA-0049) group. It is delivered by HTA downloaders themed on current geopolitical events, and as fake Adobe Flash or Adobe installers (file names such as flashcenter_pp_ax_install_en.exe and Adobeinstall.exe) hosted on group-controlled domains. Once running, it uses the Microsoft Graph API as its command-and-control channel, hiding its traffic inside legitimate Microsoft cloud services. It also sideloads a malicious 'PDF Viewer' browser extension into the victim's browser profile and drops a native-messaging helper registered as com.microsoft.runedge, which runs operator commands through the Windows command interpreter. Note that most antivirus engines label samples of this family as Fsysna, Midie or CRAITHNEX; Antino is the Symantec name.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.security.com/threat-intelligence/jewelbug-crypto-fraud-espionage"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "ff080026-9df7-4874-ad04-0c7d4dcb3e7f",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "dcdb06f3-2d50-4d5c-893b-383e0a2ea4ac",
+      "value": "Antino"
+    },
+    {
+      "description": "According to Symantec, ClientKing is a Rust implant used by the Jewelbug (aka REF7707, Earth Alux, CL-STA-0049) group to reach servers and network devices rather than browsers. Thirty-seven builds were observed, spanning x86-64 servers, ARM64 devices and ASUS consumer routers. It supports five command-and-control transports, including a custom DNS tunnel, and offers a full interactive shell, SOCKS pivoting and the ability to load kernel modules directly from memory. A companion toolkit adds a kernel-module rootkit and a malicious authentication module hooked into su and sudo to steal credentials.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.security.com/threat-intelligence/jewelbug-crypto-fraud-espionage"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "ff080026-9df7-4874-ad04-0c7d4dcb3e7f",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "ae48283b-562f-4800-98d2-df3eced24b29",
+      "value": "ClientKing"
+    },
+    {
+      "description": "According to Symantec, XG-Web is the operator control panel of the Jewelbug (aka REF7707, Earth Alux, CL-STA-0049) group, administering both its espionage and cryptocurrency fraud operations. It is a browser-centric remote-access and information-stealing platform built as a React panel over a Node.js backend, with a MySQL database that doubles as the rendezvous point for victim implants. Its developers describe it as a penetration-testing platform, while internal terms for its functions include browser hijacking, data theft and man-in-the-middle attack. Campaign payloads were served through public Google Documents created by the backend, and a scheduled job checked the group's own C&C domains against VirusTotal every twelve hours so operators could rotate away from flagged infrastructure.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.security.com/threat-intelligence/jewelbug-crypto-fraud-espionage"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "ff080026-9df7-4874-ad04-0c7d4dcb3e7f",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "078618f7-c422-4fea-b290-8dad859f5fa8",
+      "value": "XG-Web"
     }
   ],
-  "version": 177
+  "version": 178
 }


### PR DESCRIPTION
Expands coverage of the Jewelbug threat actor (aka REF7707, Earth Alux, CL-STA-0049) by introducing three newly documented tools and linking additional intelligence references across related actor entries:

- **Antino** – A Windows backdoor delivered via geopolitical-themed HTA downloaders and fake Adobe installers, using Microsoft Graph API as its C2 channel and abusing browser extensions for persistence
- **ClientKing** – A multi-architecture Rust implant targeting servers, network devices, and consumer routers, supporting five C2 transports including a custom DNS tunnel, with rootkit and credential-stealing capabilities
- **XG-Web** – The group's operator control panel, built as a React/Node.js/MySQL platform administering both espionage and cryptocurrency fraud operations, with built-in VirusTotal monitoring for infrastructure rotation

Also adds a reference to the `jewelbug-crypto-fraud-espionage` report across multiple threat actor entries to improve cross-linking with the latest Symantec intelligence.

Add Jewelbug tooling and cross-reference the Symantec report

Symantec's 13 Aug 2026 report on Jewelbug documents three previously uncatalogued tools, added here to tool with used-by relations to the existing REF7707 entry:

Antino — Windows backdoor using the Microsoft Graph API for C2
ClientKing — Rust implant for Linux servers, ARM64 devices and ASUS routers
XG-Web — the operator control panel administering both the espionage and the crypto-fraud side

The report also describes Jewelbug as "aka Earth Alux, REF7707, CL-STA-0049". It is added as a reference on both existing entries rather than merging them: the two clusters share no tooling (FinalDraft/GuidLoader/PathLoader vs GODZILLA/VARGEIT/COBEACON), come from separate producers (Elastic and Trend Micro), and the equivalence rests on this single source. Recording the claim leaves the merge decision to maintainers.

Note on Antino: Symantec is the only vendor using this name. On the sample published in the report (09ef7c73…), 39 of 40 engines label it Fsysna, Midie or CRAITHNEX, and VirusTotal suggests trojan.fsysna/midie. The entry is filed under the Symantec name with that caveat in its description; maintainers may prefer to treat it as an alias of an existing family.