### PR TITLE
chg: [mitre] bump to latest v19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Category: *attack-pattern* - source: *https://collaborate.mitre.org/attackics/in
 
 [Intrusion Set](https://www.misp-galaxy.org/mitre-intrusion-set) - Name of ATT&CK Group
 
-Category: *actor* - source: *https://github.com/mitre/cti* - total: *191* elements
+Category: *actor* - source: *https://github.com/mitre/cti* - total: *193* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-intrusion-set)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-intrusion-set.json)]
 
@@ -496,7 +496,7 @@ Category: *actor* - source: *https://github.com/mitre/cti* - total: *191* elemen
 
 [Malware](https://www.misp-galaxy.org/mitre-malware) - Name of ATT&CK software
 
-Category: *tool* - source: *https://github.com/mitre/cti* - total: *850* elements
+Category: *tool* - source: *https://github.com/mitre/cti* - total: *854* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-malware)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-malware.json)]
 

--- a/clusters/mitre-analytic.json
+++ b/clusters/mitre-analytic.json
@@ -27646,5 +27646,5 @@
       "value": "Analytic 1999 - AN1999"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/mitre-attack-pattern.json
+++ b/clusters/mitre-attack-pattern.json
@@ -13871,7 +13871,7 @@
       "value": "Technical Information Gathering - TA0015"
     },
     {
-      "description": "Adversaries may directly access a volume to bypass file access controls and file system monitoring. Windows allows programs to have direct access to logical volumes. Programs with direct access may read and write files directly from the drive by analyzing file system data structures. This technique may bypass Windows file access controls as well as file system monitoring tools. (Citation: Hakobyan 2009)\n\nUtilities, such as `NinjaCopy`, exist to perform these actions in PowerShell.(Citation: Github PowerSploit Ninjacopy) Adversaries may also use built-in or third-party utilities (such as `vssadmin`, `wbadmin`, and [esentutl](https://attack.mitre.org/software/S0404)) to create shadow copies or backups of data from system volumes.(Citation: LOLBAS Esentutl)",
+      "description": "Adversaries may directly access a volume to bypass file access controls and file system monitoring. Windows allows programs to have direct access to logical volumes. Programs with direct access may read and write files directly from the drive by analyzing file system data structures. This technique may bypass Windows file access controls as well as file system monitoring tools.(Citation: Hakobyan 2009)\n\nUtilities, such as `NinjaCopy`, exist to perform these actions in PowerShell.(Citation: Github PowerSploit Ninjacopy) Adversaries may also use built-in or third-party utilities (such as `vssadmin`, `wbadmin`, and [esentutl](https://attack.mitre.org/software/S0404)) to create shadow copies or backups of data from system volumes.(Citation: LOLBAS Esentutl)",
       "meta": {
         "external_id": "T1006",
         "kill_chain": [
@@ -36050,5 +36050,5 @@
       "value": "Keychain - T1579"
     }
   ],
-  "version": 36
+  "version": 37
 }

--- a/clusters/mitre-course-of-action.json
+++ b/clusters/mitre-course-of-action.json
@@ -10482,5 +10482,5 @@
       "value": "Audit - M1047"
     }
   ],
-  "version": 34
+  "version": 35
 }

--- a/clusters/mitre-data-component.json
+++ b/clusters/mitre-data-component.json
@@ -38,7 +38,7 @@
       "meta": {
         "external_id": "DC0063",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0063"
+          "https://attack.mitre.org/datacomponents/DC0063"
         ]
       },
       "related": [],
@@ -134,7 +134,7 @@
       "meta": {
         "external_id": "DC0001",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0001"
+          "https://attack.mitre.org/datacomponents/DC0001"
         ]
       },
       "related": [],
@@ -266,7 +266,7 @@
       "meta": {
         "external_id": "DC0013",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0013"
+          "https://attack.mitre.org/datacomponents/DC0013"
         ]
       },
       "related": [],
@@ -410,7 +410,7 @@
       "meta": {
         "external_id": "DC0083",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0083"
+          "https://attack.mitre.org/datacomponents/DC0083"
         ]
       },
       "related": [],
@@ -470,7 +470,7 @@
       "meta": {
         "external_id": "DC0078",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0078"
+          "https://attack.mitre.org/datacomponents/DC0078"
         ]
       },
       "related": [],
@@ -710,7 +710,7 @@
       "meta": {
         "external_id": "DC0016",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0016"
+          "https://attack.mitre.org/datacomponents/DC0016"
         ]
       },
       "related": [],
@@ -782,7 +782,7 @@
       "meta": {
         "external_id": "DC0032",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0032"
+          "https://attack.mitre.org/datacomponents/DC0032"
         ]
       },
       "related": [],
@@ -926,7 +926,7 @@
       "meta": {
         "external_id": "DC0035",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0035"
+          "https://attack.mitre.org/datacomponents/DC0035"
         ]
       },
       "related": [],
@@ -1286,7 +1286,7 @@
       "meta": {
         "external_id": "DC0099",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0099"
+          "https://attack.mitre.org/datacomponents/DC0099"
         ]
       },
       "related": [],
@@ -1298,7 +1298,7 @@
       "meta": {
         "external_id": "DC0112",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0112"
+          "https://attack.mitre.org/datacomponents/DC0112"
         ]
       },
       "related": [],
@@ -1322,7 +1322,7 @@
       "meta": {
         "external_id": "DC0113",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0113"
+          "https://attack.mitre.org/datacomponents/DC0113"
         ]
       },
       "related": [],
@@ -1346,7 +1346,7 @@
       "meta": {
         "external_id": "DC0115",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0115"
+          "https://attack.mitre.org/datacomponents/DC0115"
         ]
       },
       "related": [],
@@ -1370,7 +1370,7 @@
       "meta": {
         "external_id": "DC0117",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0117"
+          "https://attack.mitre.org/datacomponents/DC0117"
         ]
       },
       "related": [],
@@ -1382,7 +1382,7 @@
       "meta": {
         "external_id": "DC0118",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0118"
+          "https://attack.mitre.org/datacomponents/DC0118"
         ]
       },
       "related": [],
@@ -1394,7 +1394,7 @@
       "meta": {
         "external_id": "DC0119",
         "refs": [
-          "https://attack.mitre.org/data-components/DC0119"
+          "https://attack.mitre.org/datacomponents/DC0119"
         ]
       },
       "related": [],
@@ -1425,5 +1425,5 @@
       "value": "Application State - DC0123"
     }
   ],
-  "version": 7
+  "version": 8
 }

--- a/clusters/mitre-data-source.json
+++ b/clusters/mitre-data-source.json
@@ -751,5 +751,5 @@
       "value": "Certificate - DS0037"
     }
   ],
-  "version": 7
+  "version": 8
 }

--- a/clusters/mitre-detection-strategy.json
+++ b/clusters/mitre-detection-strategy.json
@@ -21046,5 +21046,5 @@
       "value": "Detect Social Engineering - DET0899"
     }
   ],
-  "version": 3
+  "version": 4
 }

--- a/clusters/mitre-intrusion-set.json
+++ b/clusters/mitre-intrusion-set.json
@@ -9215,7 +9215,7 @@
       "value": "Velvet Ant - G1047"
     },
     {
-      "description": "[VOID MANTICORE](https://attack.mitre.org/groups/G1055) is a threat group assessed to operate on behalf of Iran’s Ministry of Intelligence and Security (MOIS).(Citation: Check Point VOID MANTICORE Handala Hack March 2026) Active since at least mid-2022, VOID MANTICORE has targeted government entities, critical infrastructure, and private sector organizations across Albania, Israel, and the United States.(Citation: Check Point VOID MANTICORE Handala Hack March 2026)(Citation: Palo Alto VOID MANTICORE Iran Cyber Threats March 2026) [VOID MANTICORE](https://attack.mitre.org/groups/G1055) conducts destructive cyber operations, combining wiper attacks with hack-and-leak campaigns. The group has operated under multiple public-facing personas, including (LinkByld: C0038) in operations against Albania, Karma and Karma Below in campaigns targeting Israeli organizations, and Handala Hack, its current primary persona, which has claimed activity against Israeli and U.S. entities, including a March 2026 attack against Stryker Corporation.(Citation: Check Point VOID MANTICORE Handala Hack March 2026)(Citation: DOJ FBI Handala Hack March 2026)  [VOID MANTICORE](https://attack.mitre.org/groups/G1055) has been observed collaborating with Scarred Manticore, which has been linked to initial access operations preceding VOID MANTICORE’s activity.(Citation: Domain Tools Handala Hack Karma Homeland Justice MOIS April 2026) ",
+      "description": "[VOID MANTICORE](https://attack.mitre.org/groups/G1055) is a threat group assessed to operate on behalf of Iran’s Ministry of Intelligence and Security (MOIS).(Citation: Check Point VOID MANTICORE Handala Hack March 2026) Active since at least mid-2022, VOID MANTICORE has targeted government entities, critical infrastructure, and private sector organizations across Albania, Israel, and the United States.(Citation: Check Point VOID MANTICORE Handala Hack March 2026)(Citation: Palo Alto VOID MANTICORE Iran Cyber Threats March 2026) [VOID MANTICORE](https://attack.mitre.org/groups/G1055) conducts destructive cyber operations, combining wiper attacks with hack-and-leak campaigns. The group has operated under multiple public-facing personas, including [HomeLand Justice](https://attack.mitre.org/campaigns/C0038) in operations against Albania, Karma and Karma Below in campaigns targeting Israeli organizations, and Handala Hack, its current primary persona, which has claimed activity against Israeli and U.S. entities, including a March 2026 attack against Stryker Corporation.(Citation: Check Point VOID MANTICORE Handala Hack March 2026)(Citation: DOJ FBI Handala Hack March 2026)  [VOID MANTICORE](https://attack.mitre.org/groups/G1055) has been observed collaborating with Scarred Manticore, which has been linked to initial access operations preceding VOID MANTICORE’s activity.(Citation: Domain Tools Handala Hack Karma Homeland Justice MOIS April 2026) ",
       "meta": {
         "external_id": "G1055",
         "refs": [
@@ -22820,6 +22820,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "50be4e81-db74-41a2-a9aa-423314082bea",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "58a3e6aa-4453-4cc8-a51f-4befe80b31a8",
           "type": "uses"
         },
@@ -27964,7 +27968,405 @@
       ],
       "uuid": "14225573-63b5-4e50-ba9a-5fdcaf6a7b4c",
       "value": "AppleJeus - G1049"
+    },
+    {
+      "description": "[TeamPCP](https://attack.mitre.org/groups/G1056) is a financially-motivated, cloud-native threat group that has been active since at least September 2025. Initially focused on ransomware and cryptocurrency theft, [TeamPCP](https://attack.mitre.org/groups/G1056) shifted in early 2026 to systematic, worm-driven credential theft and software supply chain attacks targeting Continuous Integration and Continuous Delivery (CI/CD) workflows. [TeamPCP](https://attack.mitre.org/groups/G1056) has monetized access through extortion and through partnerships with ransomware actors including Vect and CipherForce.(Citation: Wiz TeamPCP Profile MAY 2026)(Citation: Wiz Trivy Compromise MAR 2026)(Citation: Aqua Security Trivy Compromise MAR 2026)(Citation: Aqua Security Blog Trivy Compromise APR 2026)(Citation: Palo Alto TeamPCP MAR 2026)(Citation: Trend Micro TeamPCP MAY 2026)",
+      "meta": {
+        "external_id": "G1056",
+        "refs": [
+          "https://attack.mitre.org/groups/G1056",
+          "https://cloud.google.com/blog/topics/threat-intelligence/ai-vulnerability-exploitation-initial-access",
+          "https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23",
+          "https://threats.wiz.io/all-actors/teampcp",
+          "https://unit42.paloaltonetworks.com/teampcp-supply-chain-attacks/",
+          "https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know",
+          "https://www.trendmicro.com/en_us/research/26/e/analyzing-teampcp-supply-chain-attacks.html",
+          "https://www.wiz.io/blog/trivy-compromised-teampcp-supply-chain-attack"
+        ],
+        "synonyms": [
+          "TeamPCP",
+          "PCPCat",
+          "ShellForce",
+          "DeadCatx3",
+          "SHADOW-WATER-058",
+          "UNC6780"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0458aab9-ad42-4eac-9e22-706a95bafee2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0f4a0c76-ab2d-4cb0-85d3-3f0efb8cba0d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "191cc6af-1bb2-4344-ab5f-28e496638720",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1c4e5d32-1fe9-4116-9d9d-59e3925bd6a2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "212306d8-efa4-44c9-8c2d-ed3d2e224aa0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "32901740-b42c-4fdd-bc02-345b5dc57082",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3c4a2599-71ee-4405-ba1e-0e28414b4bc5",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3ee16395-03f0-4690-a32e-69ce9ada0f9e",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3f886f2a-874f-4333-b794-aa6075009b1c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "40f5caa0-4cb7-4117-89fc-d421bb493df3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5b30f717-1d7b-4e91-a97d-be361d00aa5e",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "60b508a1-6a5e-46b1-821a-9f7b78752abf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "60c4b628-4807-4b0b-bbf5-fdac8643c337",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "66b34be7-6915-4b83-8d5a-b0f0592b5e41",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "6a6f9892-c46a-46db-b331-c09a99200fcf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7655ac3b-dfde-49c5-a967-242856174434",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7f211b2e-c008-4cac-9ea8-29bd7edd50a4",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "851e071f-208d-4c79-adc6-5974c85c78f3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "88d31120-5bc7-4ce3-a9c0-7cf147be8e54",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "9efb1ea7-c37b-4595-9640-b7680cd84279",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a10641f4-87b4-45a3-a906-92a149cb2c27",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a9d4b653-6915-42af-98b2-5758c4ceee56",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b17a1a56-e99c-403c-8948-561df0cffe81",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b1ccd744-3f78-4a0e-9bb2-2002057f7928",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b80d107d-fa0d-4b60-9684-b0433e8bdba0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c283d88f-8c23-4318-9da5-3d50cecad756",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c2e147a9-d1a8-4074-811a-d8789202d916",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cc3502b5-30cc-4473-ad48-42d51a6ef6d1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cd92d2b8-ce43-4666-9472-f1b4b9f4f8be",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cfb525cc-5494-401d-a82b-2539ca46a561",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "da051493-ae9c-4b1b-9760-c009c46c9b56",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "dfefe2ed-4389-4318-8762-f0272b350a1b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ec8fc7e2-b356-455c-8db5-2e37be158e7d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f005e783-57d4-4837-88ad-dbe7faee1c51",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f232fa7a-025c-4d43-abc7-318e81a73d65",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "fe5b2f0f-8fdc-459d-85b7-dd45c0217a0c",
+          "type": "uses"
+        }
+      ],
+      "uuid": "20f26558-e05d-46cf-8847-c2b5a83ee779",
+      "value": "TeamPCP - G1056"
+    },
+    {
+      "description": "[ShinyHunters](https://attack.mitre.org/groups/G1057) is a cyber criminal collective that has been active since at least 2019 operating under the ShinyCorp persona. [ShinyHunters](https://attack.mitre.org/groups/G1057) has targeted multiple industries and geographic regions gathering legitimate credentials and personally identifiable information (PII) for resale or extortion of victims. [ShinyHunters](https://attack.mitre.org/groups/G1057) has been associated with the broader collective called The Community, also known as The Com whose members have also included [Scattered Spider](https://attack.mitre.org/groups/G1015) and [LAPSUS$](https://attack.mitre.org/groups/G1004). Public reporting has mentioned a variety of names for operations [ShinyHunters](https://attack.mitre.org/groups/G1057) members have reportedly conducted with members of other groups, including “Scattered Lapsus Hunters,” “Scattered Lapsus Shiny Hunters,” and “SLSH.”(Citation: ElecticIQ Buyukkaya_ShinyHunters_Sept2025)(Citation: SOCRadar_ShinyHunters_Mar2024)(Citation: Unit42KelleyVaya_BlingLibra_Aug2024)(Citation: Intel471_SH_Aug2021)(Citation: FBI_SHLMS_May2026)(Citation: Google_SHOracle_Jun2026)(Citation: Mandiant_SHDataTheft_Jan2026)(Citation: Google Salesforce JUN 2025)",
+      "meta": {
+        "external_id": "G1057",
+        "refs": [
+          "https://attack.mitre.org/groups/G1057",
+          "https://blog.eclecticiq.com/shinyhunters-calling-financially-motivated-data-extortion-group-targeting-enterprise-cloud-applications",
+          "https://cloud.google.com/blog/topics/threat-intelligence/expansion-shinyhunters-saas-data-theft",
+          "https://cloud.google.com/blog/topics/threat-intelligence/shinyhunters-targets-education-sector-oracle-exploit",
+          "https://cloud.google.com/blog/topics/threat-intelligence/voice-phishing-data-extortion",
+          "https://socradar.io/dark-web-profile-shinyhunters/",
+          "https://unit42.paloaltonetworks.com/shinyhunters-ransomware-extortion/",
+          "https://www.ic3.gov/PSA/2026/PSA260515",
+          "https://www.intel471.com/blog/shinyhunters-data-breach-mitre-attack"
+        ],
+        "synonyms": [
+          "ShinyHunters",
+          "UNC6240",
+          "Bling Libra"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0cc222f5-c3ff-48e6-9f52-3314baf9d37e",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0f4a0c76-ab2d-4cb0-85d3-3f0efb8cba0d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "16e94db9-b5b1-4cd0-b851-f38fbd0a70f2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "191cc6af-1bb2-4344-ab5f-28e496638720",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1c4e5d32-1fe9-4116-9d9d-59e3925bd6a2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "248d3fe1-7fe1-4d71-91c7-8bb7ef35cad3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2d3f5b3c-54ca-4f4d-bb1f-849346d31230",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3298ce88-1628-43b1-87d9-0b5336b193d7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "354a7f88-63fb-41b5-a801-ce3b377b36f1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3f886f2a-874f-4333-b794-aa6075009b1c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "40597f16-0963-4249-bf4c-ac93b7fb9807",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4061e78c-1284-44b4-9116-73e4ac3912f7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "40f5caa0-4cb7-4117-89fc-d421bb493df3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "41868330-6ee2-4d0f-b743-9f2294c3c9b6",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "41e4d77a-6275-4976-9e35-785985598519",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5502c4e9-24ef-4d5f-8ee9-9e906c2f82c4",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "55bb4471-ff1f-43b4-88c1-c9384ec47abf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "57a3d31a-d04f-4663-b2da-7df8ec3f8c9d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "60c4b628-4807-4b0b-bbf5-fdac8643c337",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "65013dd2-bc61-43e3-afb5-a14c4fa7437a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "70910fbd-58dc-4c1c-8c48-814d11fcd022",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7bc57495-ea59-4380-be31-a64af124ef18",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "837f9164-50af-4ac0-8219-379d8a74cefc",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "851e071f-208d-4c79-adc6-5974c85c78f3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8565825b-21c8-4518-b75e-cbc4c717a156",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8c41090b-aa47-4331-986b-8c9a51a91103",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "92a78814-b191-47ca-909c-1ccfe3777414",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "9db0cf3a-a3c9-4012-8268-123b9db6fd82",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a2fdce72-04b2-409a-ac10-cc1695f4fce0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a782ebe2-daba-42c7-bc82-e8e9d923162d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a93494bb-4b80-4ea1-8695-3236a49916fd",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b17a1a56-e99c-403c-8948-561df0cffe81",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "bbc3cba7-84ae-410d-b18b-16750731dfa2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "bc76d0a4-db11-4551-9ac4-01a469cfb161",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "be2dcee9-a7a7-4e38-afd6-21b31ecc3d63",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "bf176076-b789-408e-8cba-7275e81c0ada",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c3d4bdd9-2cfe-4a80-9d0c-07a29ecdce8f",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cca0ccb6-a068-4574-a722-b1556f86833a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cff94884-3b1c-4987-a70b-6d5643c621c3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e358d692-23c0-4a31-9eb6-ecc13a8d7735",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ed7d0cb1-87a6-43b4-9f46-ef1bc56d6c68",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f005e783-57d4-4837-88ad-dbe7faee1c51",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f232fa7a-025c-4d43-abc7-318e81a73d65",
+          "type": "uses"
+        }
+      ],
+      "uuid": "5e30362d-935b-4b1c-8bf2-96c7b7b7e299",
+      "value": "ShinyHunters - G1057"
     }
   ],
-  "version": 40
+  "version": 41
 }

--- a/clusters/mitre-malware.json
+++ b/clusters/mitre-malware.json
@@ -641,6 +641,226 @@
       "value": "XLoader for Android - S0318"
     },
     {
+      "description": "The [TeamPCP Cloud Stealer](https://attack.mitre.org/software/S9041) is a comprehensive filesystem credential stealer that can harvest, encrypt, and exfiltrate credentials from over 50 sensitive file paths across CI/CD, cloud, developer tooling, and container environments. The [TeamPCP Cloud Stealer](https://attack.mitre.org/software/S9041) was the primary payload used by [TeamPCP](https://attack.mitre.org/groups/G1056) in March 2026 during early stages of a cascading supply chain campaign targeting CI/CD workflows.(Citation: Wiz Trivy Compromise MAR 2026)(Citation: Aqua Security Trivy Compromise MAR 2026)(Citation: Aqua Security Blog Trivy Compromise APR 2026)(Citation: Sysdig TeamPCP MAR 2026)(Citation: Wiz TeamPCP KICS MAR 2026)(Citation: Palo Alto TeamPCP MAR 2026)(Citation: Google AI Threat Tracker MAY 2026)(Citation: FBI TeamPCP JUL 2026)",
+      "meta": {
+        "external_id": "S9041",
+        "mitre_platforms": [
+          "Containers",
+          "Linux",
+          "macOS",
+          "SaaS",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/software/S9041",
+          "https://cloud.google.com/blog/topics/threat-intelligence/ai-vulnerability-exploitation-initial-access",
+          "https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23",
+          "https://unit42.paloaltonetworks.com/teampcp-supply-chain-attacks/",
+          "https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know",
+          "https://www.ic3.gov/CSA/2026/260702.pdf",
+          "https://www.sysdig.com/blog/teampcp-expands-supply-chain-compromise-spreads-from-trivy-to-checkmarx-github-actions",
+          "https://www.wiz.io/blog/teampcp-attack-kics-github-action",
+          "https://www.wiz.io/blog/trivy-compromised-teampcp-supply-chain-attack"
+        ],
+        "synonyms": [
+          "TeamPCP Cloud Stealer",
+          "SANDCLOCK"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "00f90846-cbd1-4fc5-9233-df5c2bf2a662",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "03d7999c-1f4c-42cc-8373-e7690d318104",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0470e792-32f8-46b0-a351-652bc35e9336",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0d91b3c0-5e50-47c3-949a-2a796f04d144",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0f4a0c76-ab2d-4cb0-85d3-3f0efb8cba0d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1365fe3b-0f50-455d-b4da-266ce31c23b0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1c34f7aa-9341-4a48-bfab-af22e51aca6c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1c4e5d32-1fe9-4116-9d9d-59e3925bd6a2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "248d3fe1-7fe1-4d71-91c7-8bb7ef35cad3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "24bfaeba-cb0d-4525-b3dc-507c77ecec41",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "30208d3e-0d6b-43c8-883e-44462a514619",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3120b9fa-23b8-4500-ae73-09494f607b7d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "354a7f88-63fb-41b5-a801-ce3b377b36f1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3ccef7ae-cb5e-48f6-8302-897105fbf55c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3fc9b85a-2862-4363-a64d-d692e3ffbee0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "57a3d31a-d04f-4663-b2da-7df8ec3f8c9d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "60b508a1-6a5e-46b1-821a-9f7b78752abf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "774a3188-6ba9-4dc4-879d-d54ee48a5ce9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7b50a1d3-4ca7-45d1-989d-a6503f04bfe1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7bc57495-ea59-4380-be31-a64af124ef18",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7e150503-88e7-4861-866b-ff1ac82c4475",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8187bd2a-866f-4457-9009-86b0ddedffa3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "837f9164-50af-4ac0-8219-379d8a74cefc",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "851e071f-208d-4c79-adc6-5974c85c78f3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "853c4192-4311-43e1-bfbb-b11b14911852",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "86a96bf6-cf8b-411c-aaeb-8959944d64f7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8f4a33ec-8b1f-4b80-a2f6-642b2e479580",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "92d7da27-2d91-488e-a00c-059dc162766d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a1df809c-7d0e-459f-8fe5-25474bab770b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a9d4b653-6915-42af-98b2-5758c4ceee56",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "bf176076-b789-408e-8cba-7275e81c0ada",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c5087385-9b7c-4488-9923-d9e370bf08df",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cc3502b5-30cc-4473-ad48-42d51a6ef6d1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cfb525cc-5494-401d-a82b-2539ca46a561",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cff94884-3b1c-4987-a70b-6d5643c621c3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d63a3fb8-9452-4e9d-a60a-54be68d5998c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "da051493-ae9c-4b1b-9760-c009c46c9b56",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "df8b2a25-8bdf-4856-953c-a04372b1c161",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "dfefe2ed-4389-4318-8762-f0272b350a1b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e24fcba8-2557-4442-a139-1ee2f2e784db",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e3b6daca-e963-4a69-aee6-ed4fd653ad58",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ec8fc7e2-b356-455c-8db5-2e37be158e7d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f24faf46-3b26-4dbb-98f2-63460498e433",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f8ef3a62-3f44-40a4-abca-761ab235c436",
+          "type": "uses"
+        }
+      ],
+      "uuid": "fe5b2f0f-8fdc-459d-85b7-dd45c0217a0c",
+      "value": "TeamPCP Cloud Stealer - S9041"
+    },
+    {
       "description": "[Pegasus for iOS](https://attack.mitre.org/software/S0289) is the iOS version of malware that has reportedly been linked to the NSO Group. It has been advertised and sold to target high-value victims.(Citation: Lookout-Pegasus)(Citation: PegasusCitizenLab) The Android version is tracked separately under [Pegasus for Android](https://attack.mitre.org/software/S0316).",
       "meta": {
         "external_id": "S0289",
@@ -786,6 +1006,256 @@
       ],
       "uuid": "051eaca1-958f-4091-9e5f-a9acd8f820b5",
       "value": "Exaramel for Windows - S0343"
+    },
+    {
+      "description": "[Mini Shai-Hulud](https://attack.mitre.org/software/S9043) is a credential stealer and self-replicating supply chain worm, derived from [Shai-Hulud](https://attack.mitre.org/software/S9008), that has been used by [TeamPCP](https://attack.mitre.org/groups/G1056) to target Continuous Integration and Continuous Delivery/Deployment (CI/CD) workflows since at least 2026. [Mini Shai-Hulud](https://attack.mitre.org/software/S9043) can compromise credentials across multiple cloud, container, and AI configuration file paths and can use stolen npm and GitHub OIDC tokens to spread to other packages maintained by the compromised user.  [Mini Shai-Hulud](https://attack.mitre.org/software/S9043) also has a targeted wiper component and has used multiple C2 and data exfiltration mechanisms.(Citation: Wiz Mini Shai-Hulud MAY 2026)(Citation: Trend Micro TeamPCP MAY 2026)(Citation: Hunt.io TeamPCP Toolkit MAY 2026)(Citation: Phoenix TeamPCP 20 MAY 2026)(Citation: Flashpoint Mini Shai-Hulud MAY 2026)(Citation: FBI TeamPCP JUL 2026)",
+      "meta": {
+        "external_id": "S9043",
+        "mitre_platforms": [
+          "Containers",
+          "IaaS",
+          "Linux",
+          "macOS",
+          "SaaS",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/software/S9043",
+          "https://flashpoint.io/blog/mini-shai-hulud-worm-new-era-ci-cd-exploitation/",
+          "https://hunt.io/blog/teampcp-python-toolkit-firescale-github-c2-takedown",
+          "https://phoenix.security/teampcp-github-breach-durabletask-pypi-supply-chain-wave-four-2026/",
+          "https://www.ic3.gov/CSA/2026/260702.pdf",
+          "https://www.trendmicro.com/en_us/research/26/e/analyzing-teampcp-supply-chain-attacks.html",
+          "https://www.wiz.io/blog/mini-shai-hulud-strikes-again-tanstack-more-npm-packages-compromised"
+        ],
+        "synonyms": [
+          "Mini Shai-Hulud"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "00f90846-cbd1-4fc5-9233-df5c2bf2a662",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "03d7999c-1f4c-42cc-8373-e7690d318104",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "04fd5427-79c7-44ea-ae13-11b24778ff1c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0d91b3c0-5e50-47c3-949a-2a796f04d144",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0f4a0c76-ab2d-4cb0-85d3-3f0efb8cba0d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "191cc6af-1bb2-4344-ab5f-28e496638720",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "19bf235b-8620-4997-b5b4-94e0659ed7c3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1c4e5d32-1fe9-4116-9d9d-59e3925bd6a2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "29be378d-262d-4e99-b00d-852d573628e6",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "30208d3e-0d6b-43c8-883e-44462a514619",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3120b9fa-23b8-4500-ae73-09494f607b7d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "315f51f0-6b03-4c1e-bfb2-84740afb8e21",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "354a7f88-63fb-41b5-a801-ce3b377b36f1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3ccef7ae-cb5e-48f6-8302-897105fbf55c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "451a9977-d255-43c9-b431-66de80130c8c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4a2975db-414e-4c0c-bd92-775987514b4b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "53ac20cd-aca3-406e-9aa0-9fc7fdc60a5a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "60b508a1-6a5e-46b1-821a-9f7b78752abf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7655ac3b-dfde-49c5-a967-242856174434",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7b50a1d3-4ca7-45d1-989d-a6503f04bfe1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7bc57495-ea59-4380-be31-a64af124ef18",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7de1f7ac-5d0c-4c9c-8873-627202205331",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "82caa33e-d11a-433a-94ea-9b5a5fbef81d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "837f9164-50af-4ac0-8219-379d8a74cefc",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "853c4192-4311-43e1-bfbb-b11b14911852",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "86a96bf6-cf8b-411c-aaeb-8959944d64f7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8861073d-d1b8-4941-82ce-dce621d398f0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8f104855-e5b7-4077-b1f5-bc3103b41abe",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "92d7da27-2d91-488e-a00c-059dc162766d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "960c3c86-1480-4d72-b4e0-8c242e84a5c5",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a542bac9-7bc1-4da7-9a09-96f69e23cc21",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a782ebe2-daba-42c7-bc82-e8e9d923162d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "acd0ba37-7ba9-4cc5-ac61-796586cd856d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b6301b64-ef57-4cce-bb0b-77026f14a8db",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c1b68a96-3c48-49ea-a6c0-9b27359f9c19",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c283d88f-8c23-4318-9da5-3d50cecad756",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c5087385-9b7c-4488-9923-d9e370bf08df",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c877e33f-1df6-40d6-b1e7-ce70f16f4979",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cc3502b5-30cc-4473-ad48-42d51a6ef6d1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cfb525cc-5494-401d-a82b-2539ca46a561",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cff94884-3b1c-4987-a70b-6d5643c621c3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d10cbd34-42e3-45c0-84d2-535a09849584",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d63a3fb8-9452-4e9d-a60a-54be68d5998c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "df8b2a25-8bdf-4856-953c-a04372b1c161",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "dfefe2ed-4389-4318-8762-f0272b350a1b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f005e783-57d4-4837-88ad-dbe7faee1c51",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f232fa7a-025c-4d43-abc7-318e81a73d65",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f24faf46-3b26-4dbb-98f2-63460498e433",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f3c544dc-673c-4ef3-accb-53229f1ae077",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f7827069-0bf2-4764-af4f-23fae0d181b7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f8ef3a62-3f44-40a4-abca-761ab235c436",
+          "type": "uses"
+        }
+      ],
+      "uuid": "7f211b2e-c008-4cac-9ea8-29bd7edd50a4",
+      "value": "Mini Shai-Hulud - S9043"
     },
     {
       "description": "[P.A.S. Webshell](https://attack.mitre.org/software/S0598) is a publicly available multifunctional PHP webshell in use since at least 2016 that provides remote access and execution on target web servers.(Citation: ANSSI Sandworm January 2021)",
@@ -4630,7 +5100,7 @@
       "value": "Cardinal RAT - S0348"
     },
     {
-      "description": "[Tsundere Botnet](https://attack.mitre.org/software/S9034) is a botnet first reported in mid-2025 that is delivered via MSI installer or PowerShell script. It leverages Node.js and JavaScript for payload delivery and execution, and uses smart contracts on the blockchain to host command and control (C2) addresses. [Tsundere Botnet](https://attack.mitre.org/software/S9034) is attributed to a likely Russian-speaking threat actor.\n\nA variant named DinDoor has been linked to [MuddyWater](https://attack.mitre.org/groups/G0069) operations and uses the Deno runtime for execution rather than Node.js. (Citation: Checkpoint_MOISCyberCrime_Mar2026)(Citation: SOCRadar_MuddyWaterDindoor_Mar2026)(Citation: CAL_MuddyWater_Mar2026)(Citation: SecureListUbiedo_Tsundere_Nov2025) ",
+      "description": "[Tsundere Botnet](https://attack.mitre.org/software/S9034) is a botnet first reported in mid-2025 that is delivered via MSI installer or a PowerShell script. It leverages Node.js and JavaScript for payload delivery and execution, and uses smart contracts on the blockchain to host command and control (C2) addresses. [Tsundere Botnet](https://attack.mitre.org/software/S9034) is attributed to a likely Russian-speaking threat actor.\n\nA variant named DinDoor has been linked to [MuddyWater](https://attack.mitre.org/groups/G0069) operations and uses the Deno runtime for execution rather than Node.js.(Citation: Checkpoint_MOISCyberCrime_Mar2026)(Citation: SOCRadar_MuddyWaterDindoor_Mar2026)(Citation: CAL_MuddyWater_Mar2026)(Citation: SecureListUbiedo_Tsundere_Nov2025) ",
       "meta": {
         "external_id": "S9034",
         "mitre_platforms": [
@@ -15259,10 +15729,6 @@
           "type": "uses"
         },
         {
-          "dest-uuid": "dfd7cc1d-e1d8-4394-a198-97c4cab8aa67",
-          "type": "uses"
-        },
-        {
           "dest-uuid": "e358d692-23c0-4a31-9eb6-ecc13a8d7735",
           "type": "uses"
         },
@@ -20580,7 +21046,7 @@
       "value": "TRITON - S0609"
     },
     {
-      "description": "[VajraSpy](https://attack.mitre.org/software/S9006) is Android malware distributed via trojanized messaging and news applications. It has been used to target individuals in Pakistan and India since at least 2021 and has been delivered through the Google Play Store, malicious domains, and other uncontrolled distribution channels. [VajraSpy](https://attack.mitre.org/software/S9006) is attributed with high confidence to [Patchwork](https://attack.mitre.org/groups/G0040) which has used the malware to conduct targeted espionage, primarily against devices in Pakistan. (Citation: ESET_VajraSpy_Feb2024)(Citation: ArcticWolf_DroppingElephant_July2025)(Citation: K7Dhanalakshmi_VajraSpy_April2022) ",
+      "description": "[VajraSpy](https://attack.mitre.org/software/S9006) is Android malware distributed via trojanized messaging and news applications. It has been used to target individuals in Pakistan and India since at least 2021 and has been delivered through the Google Play Store, malicious domains, and other uncontrolled distribution channels. [VajraSpy](https://attack.mitre.org/software/S9006) is attributed with high confidence to [Patchwork](https://attack.mitre.org/groups/G0040) which has used the malware to conduct targeted espionage, primarily against devices in Pakistan.(Citation: ESET_VajraSpy_Feb2024)(Citation: ArcticWolf_DroppingElephant_July2025)(Citation: K7Dhanalakshmi_VajraSpy_April2022) ",
       "meta": {
         "external_id": "S9006",
         "mitre_platforms": [
@@ -40709,10 +41175,6 @@
           "type": "uses"
         },
         {
-          "dest-uuid": "3f886f2a-874f-4333-b794-aa6075009b1c",
-          "type": "uses"
-        },
-        {
           "dest-uuid": "43e7dc91-05b2-474c-b9ac-2ed4fe101f4d",
           "type": "uses"
         },
@@ -40754,10 +41216,6 @@
         },
         {
           "dest-uuid": "c21d5a77-d422-4a69-acd7-2c53c1faa34b",
-          "type": "uses"
-        },
-        {
-          "dest-uuid": "c92e3d68-2349-49e4-a341-7edca2deff96",
           "type": "uses"
         },
         {
@@ -42521,6 +42979,158 @@
       "value": "CookieMiner - S0492"
     },
     {
+      "description": "[CanisterWorm](https://attack.mitre.org/software/S9042) is a self-propagating malware that has been used by [TeamPCP](https://attack.mitre.org/groups/G1056) in credential harvesting and software supply chain campaigns since at least 2026. [CanisterWorm](https://attack.mitre.org/software/S9042) has used npm credentials to infect software packages and propagate across developer ecosystems. [CanisterWorm](https://attack.mitre.org/software/S9042) has a targeted wiper component and can use decentralized C2 infrastructure implemented via an Internet Computer Protocol (ICP) blockchain canister.(Citation: Aikido TeamPCP Telnyx MAR 2026)(Citation: Palo Alto TeamPCP MAR 2026)(Citation: Aikido CanisterWorm MAR 2026)(Citation: Aikido TeamPCP Trivy MAR 2026)",
+      "meta": {
+        "external_id": "S9042",
+        "mitre_platforms": [
+          "Containers",
+          "Linux"
+        ],
+        "refs": [
+          "https://attack.mitre.org/software/S9042",
+          "https://unit42.paloaltonetworks.com/teampcp-supply-chain-attacks/",
+          "https://www.aikido.dev/blog/teampcp-deploys-worm-npm-trivy-compromise",
+          "https://www.aikido.dev/blog/teampcp-stage-payload-canisterworm-iran",
+          "https://www.aikido.dev/blog/telnyx-pypi-compromised-teampcp-canisterworm"
+        ],
+        "synonyms": [
+          "CanisterWorm"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "03d7999c-1f4c-42cc-8373-e7690d318104",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0470e792-32f8-46b0-a351-652bc35e9336",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0533ab23-3f7d-463f-9bd8-634d27e4dee1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0f4a0c76-ab2d-4cb0-85d3-3f0efb8cba0d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "106c0cf6-bf73-4601-9aa8-0945c2715ec5",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1365fe3b-0f50-455d-b4da-266ce31c23b0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "191cc6af-1bb2-4344-ab5f-28e496638720",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1c4e5d32-1fe9-4116-9d9d-59e3925bd6a2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3ccef7ae-cb5e-48f6-8302-897105fbf55c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4b46767d-4a61-4f30-995e-c19a75c2e536",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4bed873f-0b7d-41d4-b93a-b6905d1f90b0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "60b508a1-6a5e-46b1-821a-9f7b78752abf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7655ac3b-dfde-49c5-a967-242856174434",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7b50a1d3-4ca7-45d1-989d-a6503f04bfe1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7bc57495-ea59-4380-be31-a64af124ef18",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7bdca9d5-d500-4d7d-8c52-5fd47baf4c0c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "853c4192-4311-43e1-bfbb-b11b14911852",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a542bac9-7bc1-4da7-9a09-96f69e23cc21",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a9d4b653-6915-42af-98b2-5758c4ceee56",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c1b68a96-3c48-49ea-a6c0-9b27359f9c19",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cc3502b5-30cc-4473-ad48-42d51a6ef6d1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cfb525cc-5494-401d-a82b-2539ca46a561",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d63a3fb8-9452-4e9d-a60a-54be68d5998c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e358d692-23c0-4a31-9eb6-ecc13a8d7735",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f005e783-57d4-4837-88ad-dbe7faee1c51",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f3c544dc-673c-4ef3-accb-53229f1ae077",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f7827069-0bf2-4764-af4f-23fae0d181b7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ff73aa03-0090-4464-83ac-f89e233c02bc",
+          "type": "uses"
+        }
+      ],
+      "uuid": "5b30f717-1d7b-4e91-a97d-be361d00aa5e",
+      "value": "CanisterWorm - S9042"
+    },
+    {
       "description": "[Pay2Key](https://attack.mitre.org/software/S0556) is a ransomware written in C++ that has been used by [Fox Kitten](https://attack.mitre.org/groups/G0117) since at least July 2020 including campaigns against Israeli companies. [Pay2Key](https://attack.mitre.org/software/S0556) has been incorporated with a leak site to display stolen sensitive information to further pressure victims into payment.(Citation: ClearkSky Fox Kitten February 2020)(Citation: Check Point Pay2Key November 2020)",
       "meta": {
         "external_id": "S0556",
@@ -43879,6 +44489,10 @@
         },
         {
           "dest-uuid": "b3d682b6-98f2-4fb0-aa3b-b4df007ca70a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c92e3d68-2349-49e4-a341-7edca2deff96",
           "type": "uses"
         },
         {
@@ -46525,6 +47139,100 @@
       ],
       "uuid": "dcac85c1-6485-4790-84f6-de5e6f6b91dd",
       "value": "PowerStallion - S0393"
+    },
+    {
+      "description": "[Kali365](https://attack.mitre.org/software/S9044) is a Phishing-as-a-Service (PHaaS) kit first observed in April 2026 that generates victim-targeted lures across multiple operating systems to induce users into copying and pasting actor-controlled commands for local execution.(Citation: Artic Wolf Labs Kali365 Device Code April 2026)(Citation: FBI IC3 Alert I-052126 Kali365 May 2026)(Citation: Huntress Kali365 Device Code June 2026)(Citation: SpyCloud Kali365 June 2026)  [Kali365](https://attack.mitre.org/software/S9044) incorporates on-demand device code generation and mirrors the copy-paste execution tradecraft associated with ClickFix. (Citation: Huntress Kali365 Device Code June 2026) Operators have used [Kali365](https://attack.mitre.org/software/S9044) to harvest victims' OAuth tokens and session cookies through adversary-in-the-middle (AiTM) interception, enabling account takeover.(Citation: Artic Wolf Labs Kali365 Device Code April 2026)(Citation: Artic Wolf Kali365 Device Code OAuth June 2026)(Citation: FBI IC3 Alert I-052126 Kali365 May 2026)(Citation: Huntress Kali365 Device Code June 2026)(Citation: SpyCloud Kali365 June 2026)  [Kali365](https://attack.mitre.org/software/S9044) PHaaS was first observed in April 2026.(Citation: Artic Wolf Labs Kali365 Device Code April 2026)  [Kali365](https://attack.mitre.org/software/S9044) has also been affiliated with other branding to include Octopi365 and Freedom365.(Citation: Huntress Kali365 Device Code June 2026)",
+      "meta": {
+        "external_id": "S9044",
+        "mitre_platforms": [
+          "IaaS",
+          "macOS",
+          "Windows"
+        ],
+        "refs": [
+          "https://arcticwolf.com/resources/blog/kali365-expands-into-aws-microsoft-okta-xerox-max-messenger/",
+          "https://arcticwolf.com/resources/blog/token-bingo-dont-let-your-code-be-the-winner/",
+          "https://attack.mitre.org/software/S9044",
+          "https://spycloud.com/blog/kali365-anatomy-of-a-microsoft365-phishing-as-a-service-kit/",
+          "https://www.huntress.com/blog/kali365-device-code-phishing-kit",
+          "https://www.ic3.gov/PSA/2026/PSA260521"
+        ],
+        "synonyms": [
+          "Kali365"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "035bb001-ab69-4a0b-9f6c-2de8b09e1b9d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0cf55441-b176-4332-89e7-2c4c7799d0ff",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "0f4a0c76-ab2d-4cb0-85d3-3f0efb8cba0d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "10ffac09-e42d-4f56-ab20-db94c67d76ff",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2b742742-28c3-4e1b-bab7-8350d6300fa7",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2e34237d-8574-43f6-aace-ae2915de8597",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4bc31b94-045b-4752-8920-aebaebdb6470",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "544b0346-29ad-41e1-a808-501bb4193f47",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "6a6f9892-c46a-46db-b331-c09a99200fcf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "731f4f55-b6d0-41d1-a7a9-072a66389aea",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "830c9528-df21-472c-8c14-a036bf17d665",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "837f9164-50af-4ac0-8219-379d8a74cefc",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "890c9858-598c-401d-a4d5-c67ebcdd703a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "df8b2a25-8bdf-4856-953c-a04372b1c161",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e261a979-f354-41a8-963e-6cadac27c4bf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ef67e13e-5598-4adc-bdb2-998225874fa9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f005e783-57d4-4837-88ad-dbe7faee1c51",
+          "type": "uses"
+        }
+      ],
+      "uuid": "f5a56c26-e192-489d-a77e-a8b38fd70eee",
+      "value": "Kali365 - S9044"
     },
     {
       "description": "[MESSAGETAP](https://attack.mitre.org/software/S0443) is a data mining malware family deployed by [APT41](https://attack.mitre.org/groups/G0096) into telecommunications networks to monitor and save SMS traffic from specific phone numbers, IMSI numbers, or that contain specific keywords. (Citation: FireEye MESSAGETAP October 2019)",
@@ -51628,7 +52336,7 @@
       "value": "DynoWiper - S9038"
     },
     {
-      "description": "[LazyWiper](https://attack.mitre.org/software/S9039) is a destructive malware observed targeting a manufacturing sector company during the [2025 Poland Wiper Attacks](https://attack.mitre.org/campaigns/C0063). [LazyWiper](https://attack.mitre.org/software/S9039) is a native Windows PowerShell script that is believed to have been generated by a large language model (LLM). [LazyWiper](https://attack.mitre.org/software/S9039) overwrites files on the system using the C# function `WriteRandomBytes()` and can targets multiple specific file types by their extensions.(Citation: CERT Polska)",
+      "description": "[LazyWiper](https://attack.mitre.org/software/S9039) is a destructive malware observed targeting a manufacturing sector company during the [2025 Poland Wiper Attacks](https://attack.mitre.org/campaigns/C0063). [LazyWiper](https://attack.mitre.org/software/S9039) is a native Windows PowerShell script that is believed to have been generated by a large language model (LLM). [LazyWiper](https://attack.mitre.org/software/S9039) overwrites files on the system using the C# function `WriteRandomBytes()` and can target multiple specific file types by their extensions.(Citation: CERT Polska)",
       "meta": {
         "external_id": "S9039",
         "mitre_platforms": [
@@ -65920,5 +66628,5 @@
       "value": "Embargo - S1247"
     }
   ],
-  "version": 39
+  "version": 40
 }

--- a/clusters/mitre-tool.json
+++ b/clusters/mitre-tool.json
@@ -5642,5 +5642,5 @@
       "value": "attrib - S1176"
     }
   ],
-  "version": 37
+  "version": 38
 }

--- a/galaxies/mitre-attack-pattern.json
+++ b/galaxies/mitre-attack-pattern.json
@@ -207,5 +207,5 @@
   "namespace": "mitre-attack",
   "type": "mitre-attack-pattern",
   "uuid": "c4e851fa-775f-11e7-8163-b774922098cd",
-  "version": 15
+  "version": 16
 }


### PR DESCRIPTION
Hello, and thank you for maintaining misp-galaxy :)

Since [MITRE ATT&CK v19.2](https://attack.mitre.org/resources/updates/updates-august-2026/) was released on August 6, I updated Galaxy using `gen-mitre.py`. 

I have confirmed that the following two tests pass:
* `./jq_all_the_things.sh`
* `./validate.sh`

Thank you for your time.