### PR TITLE
Add CoolClient backdoor to tool galaxy and update version/count

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Category: *tmss* - source: *https://github.com/microsoft/Threat-matrix-for-stora
 
 [Tool](https://www.misp-galaxy.org/tool) - threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.
 
-Category: *tool* - source: *MISP Project* - total: *612* elements
+Category: *tool* - source: *MISP Project* - total: *613* elements
 
 [[HTML](https://www.misp-galaxy.org/tool)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/tool.json)]
 

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -11231,7 +11231,30 @@
       },
       "uuid": "e3de66ff-1ec1-4097-ba11-9764a23bdf69",
       "value": "C2Looper"
+    },
+    {
+      "description": "CoolClient is a modular backdoor used by Mustang Panda. The name is not a vendor label: it comes from the developers' own build paths, recovered by Sophos in November 2022 from PDB strings such as G:\\project\\木马\\Cool\\Client\\hijack_export\\libvlc\\Release\\libvlc.pdb, where 木马 means trojan. Sophos documented the campaign without attributing it, noting that Mustang Panda and LuminousMoth artefacts found alongside were collateral of the USB worm's indiscriminate file collection rather than evidence of collusion; Trend Micro attributed the backdoor to Mustang Panda in 2023, Symantec observed it against telecom operators in Asia in June 2024, and Kaspersky has tracked it since 2025. It is delivered by DLL sideloading through a renamed legitimate binary, persists as a service, terminates security software, and supports file read and delete, clipboard and active-window monitoring, and second-stage delivery. Kaspersky's August 2026 analysis describes a variant that installs a kernel-mode rootkit driver signed with an expired Nanjing Ranyi Technology Co., Ltd. certificate, hooking nsiproxy to hide the C2 addresses from local network tooling. Note that only Kaspersky labels samples Rootkit.Win64.CoolClient; other engines report the driver as Etset or generic rootkit detections.",
+      "meta": {
+        "date": "November 2022.",
+        "refs": [
+          "https://news.sophos.com/en-us/2022/11/03/family-tree-dll-sideloading-cases-may-be-related/",
+          "https://www.trendmicro.com/en_gb/research/23/c/earth-preta-updated-stealthy-strategies.html",
+          "https://securelist.com/honeymyte-updates-coolclient-uses-browser-stealers-and-scripts/118664/",
+          "https://securelist.com/honeymyte-coolclient-driver-rootkit/121028/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "78bf726c-a9e6-11e8-9e43-77249a2f7339",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "6d26e384-8dcc-4ef1-941b-b84c826ea68d",
+      "value": "CoolClient"
     }
   ],
-  "version": 179
+  "version": 180
 }


### PR DESCRIPTION
Add CoolClient to the tool galaxy

CoolClient is a modular backdoor used by Mustang Panda, documented since 2022 and absent from the corpus.

The name is not a vendor label: Sophos recovered it in November 2022 from the developers' own build paths (G:\project\木马\Cool\Client\...). Sophos documented the campaign without attributing it, and explicitly noted that Mustang Panda and LuminousMoth artefacts found alongside were collateral of the USB worm's indiscriminate file collection rather than evidence of collusion. Trend Micro attributed the backdoor to Mustang Panda in 2023, Symantec observed it against Asian telecom operators in June 2024, and Kaspersky has tracked it since 2025 — hence the very-likely tag rather than almost-certain, since the vendor who named it never attributed it.

Note on detections: only Kaspersky labels samples Rootkit.Win64.CoolClient; other engines report the kernel driver as Etset or generically.