### PR TITLE
Adds SilkParasite threat actor and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Category: *threat-actor* - source: *https://www.publicsafety.gc.ca/cnt/_xml/lstd
 
 [Threat Actor](https://www.misp-galaxy.org/threat-actor) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign. threat-actor-classification meta can be used to clarify the understanding of the threat-actor if also considered as operation, campaign or activity group.
 
-Category: *actor* - source: *MISP Project* - total: *1043* elements
+Category: *actor* - source: *MISP Project* - total: *1044* elements
 
 [[HTML](https://www.misp-galaxy.org/threat-actor)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json)]
 

--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Category: *tmss* - source: *https://github.com/microsoft/Threat-matrix-for-stora
 
 [Tool](https://www.misp-galaxy.org/tool) - threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.
 
-Category: *tool* - source: *MISP Project* - total: *613* elements
+Category: *tool* - source: *MISP Project* - total: *620* elements
 
 [[HTML](https://www.misp-galaxy.org/tool)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/tool.json)]
 

--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Category: *threat-actor* - source: *https://www.publicsafety.gc.ca/cnt/_xml/lstd
 
 [Threat Actor](https://www.misp-galaxy.org/threat-actor) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign. threat-actor-classification meta can be used to clarify the understanding of the threat-actor if also considered as operation, campaign or activity group.
 
-Category: *actor* - source: *MISP Project* - total: *1041* elements
+Category: *actor* - source: *MISP Project* - total: *1042* elements
 
 [[HTML](https://www.misp-galaxy.org/threat-actor)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json)]
 
@@ -920,7 +920,7 @@ Category: *tmss* - source: *https://github.com/microsoft/Threat-matrix-for-stora
 
 [Tool](https://www.misp-galaxy.org/tool) - threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.
 
-Category: *tool* - source: *MISP Project* - total: *613* elements
+Category: *tool* - source: *MISP Project* - total: *620* elements
 
 [[HTML](https://www.misp-galaxy.org/tool)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/tool.json)]
 

--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Category: *threat-actor* - source: *https://www.publicsafety.gc.ca/cnt/_xml/lstd
 
 [Threat Actor](https://www.misp-galaxy.org/threat-actor) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign. threat-actor-classification meta can be used to clarify the understanding of the threat-actor if also considered as operation, campaign or activity group.
 
-Category: *actor* - source: *MISP Project* - total: *1041* elements
+Category: *actor* - source: *MISP Project* - total: *1043* elements
 
 [[HTML](https://www.misp-galaxy.org/threat-actor)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json)]
 

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -24159,6 +24159,18 @@
       },
       "uuid": "0e982626-1472-4b89-b5c5-b2ffb5ce81da",
       "value": "Larva-26010"
+    },
+    {
+      "description": "ZeroBytes is a hacker who claimed responsibility for an attack on France's DGFiP's Professional Cadastral Data Server (SPDC), alleging the extraction of a dataset containing personal information for over 2 million individuals. The claimed dataset includes names, birth details, addresses, and property rights, potentially linking individuals to real estate assets.",
+      "meta": {
+        "country": "FR",
+        "refs": [
+          "https://presse.economie.gouv.fr/acces-illegitime-au-systeme-dinformation-de-la-direction-generale-des-finances-publiques/",
+          "https://www.bleepingcomputer.com/news/security/french-tax-authority-data-breach-affects-678-000-individuals/"
+        ]
+      },
+      "uuid": "6035b10d-0cd0-4a73-9df9-75ff5f944034",
+      "value": "ZeroBytes"
     }
   ],
   "version": 349

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -24147,7 +24147,18 @@
       },
       "uuid": "743a82e5-bdbc-4355-88fd-65471a4540db",
       "value": "Conference Crew"
+    },
+    {
+      "description": "SilkParasite is an activity cluster tracked by Bitdefender across Central Asia, primarily targeting government and telecommunications entities in Kyrgyzstan, Uzbekistan and Kazakhstan. Bitdefender assesses a China-nexus with medium confidence and states explicitly that it does not believe the evidence supports attribution to a named group, so this is recorded as an activity cluster rather than as an established actor. Observed tooling spans seven implant families: five named by Bitdefender (DriveSilkRAT, CookiETagRAT, NomadRAT, GoginRAT, NodeEdgeRAT) plus SpiceRAT, previously reported by Cisco Talos in connection with SneakyChef, and BloodAlchemy, a lineage descended from ShadowPad and Deed RAT. The operators favour DLL sideloading and cloud services as command-and-control channels, and register domains impersonating local hosting providers.",
+      "meta": {
+        "country": "CN",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+      "value": "SilkParasite"
     }
   ],
-  "version": 349
+  "version": 350
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -24151,6 +24151,28 @@
       "value": "Conference Crew"
     },
     {
+      "description": "Larva-26010 targets web servers and MS-SQL servers in Korea to install SoftEther VPN, using the systems as VPN servers. After the initial breach, the actor installs a web shell or SQLShell for control, followed by the SoftEther installation. The threat actor has not exhibited additional malicious behavior beyond installing backdoor accounts or web shells. It appears they are preparing to utilize the infected systems as C&C servers in the future.",
+      "meta": {
+        "refs": [
+          "https://asec.ahnlab.com/en/94995/"
+        ]
+      },
+      "uuid": "0e982626-1472-4b89-b5c5-b2ffb5ce81da",
+      "value": "Larva-26010"
+    },
+    {
+      "description": "ZeroBytes is a hacker who claimed responsibility for an attack on France's DGFiP's Professional Cadastral Data Server (SPDC), alleging the extraction of a dataset containing personal information for over 2 million individuals. The claimed dataset includes names, birth details, addresses, and property rights, potentially linking individuals to real estate assets.",
+      "meta": {
+        "country": "FR",
+        "refs": [
+          "https://presse.economie.gouv.fr/acces-illegitime-au-systeme-dinformation-de-la-direction-generale-des-finances-publiques/",
+          "https://www.bleepingcomputer.com/news/security/french-tax-authority-data-breach-affects-678-000-individuals/"
+        ]
+      },
+      "uuid": "6035b10d-0cd0-4a73-9df9-75ff5f944034",
+      "value": "ZeroBytes"
+    },
+    {
       "description": "SilkParasite is an activity cluster tracked by Bitdefender across Central Asia, primarily targeting government and telecommunications entities in Kyrgyzstan, Uzbekistan and Kazakhstan. Bitdefender assesses a China-nexus with medium confidence and states explicitly that it does not believe the evidence supports attribution to a named group, so this is recorded as an activity cluster rather than as an established actor. Observed tooling spans seven implant families: five named by Bitdefender (DriveSilkRAT, CookiETagRAT, NomadRAT, GoginRAT, NodeEdgeRAT) plus SpiceRAT, previously reported by Cisco Talos in connection with SneakyChef, and BloodAlchemy, a lineage descended from ShadowPad and Deed RAT. The operators favour DLL sideloading and cloud services as command-and-control channels, and register domains impersonating local hosting providers.",
       "meta": {
         "country": "CN",

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -24147,6 +24147,16 @@
       },
       "uuid": "743a82e5-bdbc-4355-88fd-65471a4540db",
       "value": "Conference Crew"
+    },
+    {
+      "description": "Larva-26010 targets web servers and MS-SQL servers in Korea to install SoftEther VPN, using the systems as VPN servers. After the initial breach, the actor installs a web shell or SQLShell for control, followed by the SoftEther installation. The threat actor has not exhibited additional malicious behavior beyond installing backdoor accounts or web shells. It appears they are preparing to utilize the infected systems as C&C servers in the future.",
+      "meta": {
+        "refs": [
+          "https://asec.ahnlab.com/en/94995/"
+        ]
+      },
+      "uuid": "0e982626-1472-4b89-b5c5-b2ffb5ce81da",
+      "value": "Larva-26010"
     }
   ],
   "version": 349

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -24171,7 +24171,18 @@
       },
       "uuid": "6035b10d-0cd0-4a73-9df9-75ff5f944034",
       "value": "ZeroBytes"
+    },
+    {
+      "description": "SilkParasite is an activity cluster tracked by Bitdefender across Central Asia, primarily targeting government and telecommunications entities in Kyrgyzstan, Uzbekistan and Kazakhstan. Bitdefender assesses a China-nexus with medium confidence and states explicitly that it does not believe the evidence supports attribution to a named group, so this is recorded as an activity cluster rather than as an established actor. Observed tooling spans seven implant families: five named by Bitdefender (DriveSilkRAT, CookiETagRAT, NomadRAT, GoginRAT, NodeEdgeRAT) plus SpiceRAT, previously reported by Cisco Talos in connection with SneakyChef, and BloodAlchemy, a lineage descended from ShadowPad and Deed RAT. The operators favour DLL sideloading and cloud services as command-and-control channels, and register domains impersonating local hosting providers.",
+      "meta": {
+        "country": "CN",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+      "value": "SilkParasite"
     }
   ],
-  "version": 349
+  "version": 350
 }

--- a/clusters/threat-actor.json
+++ b/clusters/threat-actor.json
@@ -3250,7 +3250,8 @@
           "https://packetstormsecurity.com/news/view/35790/Recent-OT-And-Espionage-Attacks-Linked-To-Russias-Sandworm-Now-Named-APT44.html",
           "https://cloud.google.com/blog/topics/threat-intelligence/apt44-unearthing-sandworm?linkId=9627235",
           "https://services.google.com/fh/files/misc/apt44-unearthing-sandworm.pdf",
-          "https://cloud.google.com/blog/topics/threat-intelligence/updated-cyber-threat-actor-naming-system/"
+          "https://cloud.google.com/blog/topics/threat-intelligence/updated-cyber-threat-actor-naming-system/",
+          "https://cert.gov.ua/article/4279195"
         ],
         "synonyms": [
           "Quedagh",
@@ -3267,7 +3268,8 @@
           "Seashell Blizzard",
           "UAC-0082",
           "APT44",
-          "SANDWORM RELIC"
+          "SANDWORM RELIC",
+          "UAC-0145"
         ],
         "targeted-sector": [
           "Electric",

--- a/clusters/tool.json
+++ b/clusters/tool.json
@@ -11254,7 +11254,163 @@
       ],
       "uuid": "6d26e384-8dcc-4ef1-941b-b84c826ea68d",
       "value": "CoolClient"
+    },
+    {
+      "description": "CookiETagRAT is a C++ remote access trojan used by the SilkParasite activity cluster, observed by Bitdefender in Central Asia. It hides its command-and-control exchange inside HTTP Cookie and ETag headers, so the traffic carries no distinctive body and inspection that looks only at payloads sees ordinary web requests. Delivery relies on DLL sideloading through renamed legitimate binaries.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "0b49a769-99ce-4279-8664-d5410471a04c",
+      "value": "CookiETagRAT"
+    },
+    {
+      "description": "DriveSilkRAT is a remote access trojan used by the SilkParasite activity cluster, observed by Bitdefender in Central Asia. Two lineages exist: an original .NET implementation and a later C++ rewrite. Its distinguishing trait is command and control over Google Drive, which places the traffic inside a service most networks already allow and cannot easily distinguish from legitimate use. Delivery relies on DLL sideloading through renamed legitimate binaries.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "96422a8c-ae49-41c6-9f85-56d8f03fd871",
+      "value": "DriveSilkRAT"
+    },
+    {
+      "description": "GoginRAT is a remote access trojan written in Go, used by the SilkParasite activity cluster and observed by Bitdefender in Central Asia. Bitdefender notes development artefacts across this cluster's newer implants that suggest AI-assisted coding, including test functions left in shipped builds and placeholder cryptographic material such as a literal change_this_key. Delivery relies on DLL sideloading through renamed legitimate binaries.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "28d502d5-db8a-4fb9-81eb-422e573ea40a",
+      "value": "GoginRAT"
+    },
+    {
+      "description": "HelpLoader is the loader component that delivers SpiceRAT, named by Cisco Talos in June 2024. It is sideloaded by a renamed legitimate executable and is responsible for decrypting and running the implant, which never touches disk in its final form. Reported in campaigns attributed to SneakyChef, and observed again in August 2026 by Bitdefender within the SilkParasite activity cluster.",
+      "meta": {
+        "date": "June 2024.",
+        "refs": [
+          "https://blog.talosintelligence.com/sneakychef-spicerat-suncrypt/",
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "cdf4506e-09ea-4eb8-b898-b1b5381aa343",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        },
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "35cef3a8-5e19-4aa5-b512-9460ed025e5e",
+      "value": "HelpLoader"
+    },
+    {
+      "description": "NodeEdgeRAT is a remote access trojan written in JavaScript and running on Node.js, used by the SilkParasite activity cluster and observed by Bitdefender in Central Asia. Its command-and-control infrastructure includes domains impersonating legitimate regional hosting providers, a pattern that makes the traffic plausible to a local defender.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "620b78ec-bf00-468d-a0eb-0ff18a8bcd40",
+      "value": "NodeEdgeRAT"
+    },
+    {
+      "description": "NomadRAT is a C++ remote access trojan used by the SilkParasite activity cluster, observed by Bitdefender against government and telecommunications targets in Central Asia. Delivery relies on DLL sideloading through renamed legitimate binaries, the pattern shared across this cluster's tooling.",
+      "meta": {
+        "date": "August 2026.",
+        "refs": [
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "e693625b-0d70-4acd-b08d-49e7320db974",
+      "value": "NomadRAT"
+    },
+    {
+      "description": "SpiceRAT is a remote access trojan first reported by Cisco Talos in June 2024, in a campaign attributed to SneakyChef targeting government agencies and think tanks in EMEA and Asia. It is delivered through two chains, one using a LNK file and one using an HTA, both loading the implant by DLL sideloading through a renamed legitimate executable; Talos names the loader component HelpLoader. Bitdefender observed SpiceRAT again in August 2026 as part of the SilkParasite activity cluster in Central Asia, alongside implants of that cluster's own.",
+      "meta": {
+        "date": "June 2024.",
+        "refs": [
+          "https://blog.talosintelligence.com/sneakychef-spicerat-suncrypt/",
+          "https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "cdf4506e-09ea-4eb8-b898-b1b5381aa343",
+          "tags": [
+            "estimative-language:likelihood-probability=\"very-likely\""
+          ],
+          "type": "used-by"
+        },
+        {
+          "dest-uuid": "33420fce-ac3e-4164-a1f5-ccc3d43657c2",
+          "tags": [
+            "estimative-language:likelihood-probability=\"likely\""
+          ],
+          "type": "used-by"
+        }
+      ],
+      "uuid": "80f5eb4e-cf4e-49dd-bf59-10f9f7258ff3",
+      "value": "SpiceRAT"
     }
   ],
-  "version": 180
+  "version": 181
 }


### PR DESCRIPTION
Bitdefender published SilkParasite on 19 August 2026: an activity cluster
targeting government and telecom entities in Kyrgyzstan, Uzbekistan and
Kazakhstan. This adds the cluster and seven implant families, none of which
were in the corpus.

threat-actor:
- SilkParasite — recorded as an activity cluster rather than a group.
  Bitdefender assesses a China-nexus with medium confidence and states
  explicitly that it does not believe the evidence supports attribution to a
  named group; the description says so.

tool, named by Bitdefender in this report:
- DriveSilkRAT — .NET then C++, C2 over Google Drive
- CookiETagRAT — C++, C2 hidden in HTTP Cookie and ETag headers
- NomadRAT — C++
- GoginRAT — Go
- NodeEdgeRAT — JavaScript on Node.js

tool, previously reported and still missing from the corpus:
- SpiceRAT — Cisco Talos, June 2024, attributed to SneakyChef
- HelpLoader — the loader Talos names alongside SpiceRAT

SpiceRAT and HelpLoader carry two used-by relations each: very-likely to
SneakyChef, which is the primary Talos attribution, and likely to
SilkParasite, where Bitdefender observes them. The lower confidence on the
second reflects the cluster's own medium-confidence footing, not a doubt
about the observation. The five Bitdefender families are very-likely to
SilkParasite.

BloodAlchemy is also used by this cluster but already exists in the malpedia
galaxy, which is generated upstream and not edited here.

Near names a reviewer will notice, none of which are the same thing:
CookieBag vs CookiETagRAT, MadRAT vs NomadRAT, GoGra vs GoginRAT, NodeRAT vs
NodeEdgeRAT. The Go-prefixed collisions are a naming convention for
Go-written malware rather than a lineage.

https://www.bitdefender.com/en-us/blog/businessinsights/silkparasite-tracking-china-nexus-apt-across-central-asia