### PR TITLE
Unify naming of the MITRE galaxies (namespace / name / description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,161 +348,161 @@ Category: *misinformation-pattern* - source: *https://github.com/misinfosecproje
 
 [[HTML](https://www.misp-galaxy.org/misinfosec-amitt-misinformation-pattern)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/misinfosec-amitt-misinformation-pattern.json)]
 
-## Analytics
+## MITRE ATT&CK Analytics
 
-[Analytics](https://www.misp-galaxy.org/mitre-analytic) - ATT&CK Analytics
+[MITRE ATT&CK Analytics](https://www.misp-galaxy.org/mitre-analytic) - Detection analytics from MITRE ATT&CK.
 
 Category: *attack-pattern* - source: *https://attack.mitre.org/analytics/* - total: *1969* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-analytic)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-analytic.json)]
 
-## MITRE ATLAS Attack Pattern
+## MITRE ATLAS Techniques
 
-[MITRE ATLAS Attack Pattern](https://www.misp-galaxy.org/mitre-atlas-attack-pattern) - MITRE ATLAS Attack Pattern - Adversarial Threat Landscape for Artificial-Intelligence Systems
+[MITRE ATLAS Techniques](https://www.misp-galaxy.org/mitre-atlas-attack-pattern) - Techniques from MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems).
 
 Category: *attack-pattern* - source: *https://github.com/mitre-atlas/atlas-navigator-data* - total: *91* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-atlas-attack-pattern)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-atlas-attack-pattern.json)]
 
-## MITRE ATLAS Course of Action
+## MITRE ATLAS Mitigations
 
-[MITRE ATLAS Course of Action](https://www.misp-galaxy.org/mitre-atlas-course-of-action) - MITRE ATLAS Mitigation - Adversarial Threat Landscape for Artificial-Intelligence Systems
+[MITRE ATLAS Mitigations](https://www.misp-galaxy.org/mitre-atlas-course-of-action) - Mitigations from MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems).
 
 Category: *course-of-action* - source: *https://github.com/mitre-atlas/atlas-navigator-data* - total: *26* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-atlas-course-of-action)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-atlas-course-of-action.json)]
 
-## Attack Pattern
+## MITRE ATT&CK Techniques
 
-[Attack Pattern](https://www.misp-galaxy.org/mitre-attack-pattern) - ATT&CK tactic
+[MITRE ATT&CK Techniques](https://www.misp-galaxy.org/mitre-attack-pattern) - Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise and Mobile).
 
 Category: *attack-pattern* - source: *https://github.com/mitre/cti* - total: *1266* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-attack-pattern)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-attack-pattern.json)]
 
-## Course of Action
+## MITRE ATT&CK Mitigations
 
-[Course of Action](https://www.misp-galaxy.org/mitre-course-of-action) - ATT&CK Mitigation
+[MITRE ATT&CK Mitigations](https://www.misp-galaxy.org/mitre-course-of-action) - Mitigations from MITRE ATT&CK.
 
 Category: *course-of-action* - source: *https://github.com/mitre/cti* - total: *282* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-course-of-action)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-course-of-action.json)]
 
-## MITRE D3FEND
+## MITRE D3FEND Techniques
 
-[MITRE D3FEND](https://www.misp-galaxy.org/mitre-d3fend) - A knowledge graph of cybersecurity countermeasures.
+[MITRE D3FEND Techniques](https://www.misp-galaxy.org/mitre-d3fend) - Defensive countermeasure techniques from MITRE D3FEND.
 
 Category: *d3fend* - source: *https://d3fend.mitre.org/* - total: *171* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-d3fend)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-d3fend.json)]
 
-## mitre-data-component
+## MITRE ATT&CK Data Components
 
-[mitre-data-component](https://www.misp-galaxy.org/mitre-data-component) - Data components are parts of data sources. 
+[MITRE ATT&CK Data Components](https://www.misp-galaxy.org/mitre-data-component) - Data components from MITRE ATT&CK, refining data sources into the specific properties relevant to detection.
 
 Category: *data-component* - source: *https://github.com/mitre/cti* - total: *118* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-data-component)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-data-component.json)]
 
-## mitre-data-source
+## MITRE ATT&CK Data Sources
 
-[mitre-data-source](https://www.misp-galaxy.org/mitre-data-source) - Data sources represent the various subjects/topics of information that can be collected by sensors/logs. 
+[MITRE ATT&CK Data Sources](https://www.misp-galaxy.org/mitre-data-source) - Data sources from MITRE ATT&CK, representing the information that can be collected by sensors and logs.
 
 Category: *data-source* - source: *https://github.com/mitre/cti* - total: *40* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-data-source)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-data-source.json)]
 
-## Detection Strategies
+## MITRE ATT&CK Detection Strategies
 
-[Detection Strategies](https://www.misp-galaxy.org/mitre-detection-strategy) - ATT&CK Detection Strategies
+[MITRE ATT&CK Detection Strategies](https://www.misp-galaxy.org/mitre-detection-strategy) - Detection strategies from MITRE ATT&CK.
 
 Category: *attack-pattern* - source: *https://attack.mitre.org/detectionstrategies/* - total: *823* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-detection-strategy)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-detection-strategy.json)]
 
-## MITRE Engage Framework
+## MITRE Engage
 
-[MITRE Engage Framework](https://www.misp-galaxy.org/mitre-engage-framework) - This galaxy contains all parts of the MITRE Engage framework, including Activities, Approaches, Goals, and Vulnerabilities.
+[MITRE Engage](https://www.misp-galaxy.org/mitre-engage-framework) - Activities, approaches, goals and vulnerabilities from the MITRE Engage framework.
 
 Category: *engage* - source: *https://engage.mitre.org* - total: *77* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-engage-framework)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-engage-framework.json)]
 
-## MITRE Fight Fraud Framework
+## MITRE Fight Fraud Framework Techniques
 
-[MITRE Fight Fraud Framework](https://www.misp-galaxy.org/mitre-fraud-framework) - MITRE Fight Fraud Framework (F3) matrix of fraud techniques.
+[MITRE Fight Fraud Framework Techniques](https://www.misp-galaxy.org/mitre-fraud-framework) - Fraud techniques from the MITRE Fight Fraud Framework (F3).
 
 Category: *attack-pattern* - source: *https://ctid.mitre.org/fraud/* - total: *123* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-fraud-framework)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-fraud-framework.json)]
 
-## Assets
+## MITRE ATT&CK ICS Assets
 
-[Assets](https://www.misp-galaxy.org/mitre-ics-assets) - A list of asset categories that are commonly found in industrial control systems.
+[MITRE ATT&CK ICS Assets](https://www.misp-galaxy.org/mitre-ics-assets) - Assets from MITRE ATT&CK for ICS.
 
 Category: *asset* - source: *https://collaborate.mitre.org/attackics/index.php/All_Assets* - total: *7* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-ics-assets)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-assets.json)]
 
-## Groups
+## MITRE ATT&CK ICS Groups
 
-[Groups](https://www.misp-galaxy.org/mitre-ics-groups) - Groups are sets of related intrusion activity that are tracked by a common name in the security community. Groups are also sometimes referred to as campaigns or intrusion sets. Some groups have multiple names associated with the same set of activities due to various organizations tracking the same set of activities by different names. Groups are mapped to publicly reported technique use and referenced in the ATT&CK for ICS knowledge base. Groups are also mapped to reported software used during intrusions.
+[MITRE ATT&CK ICS Groups](https://www.misp-galaxy.org/mitre-ics-groups) - Adversary groups from MITRE ATT&CK for ICS.
 
 Category: *actor* - source: *https://collaborate.mitre.org/attackics/index.php/Groups* - total: *10* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-ics-groups)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-groups.json)]
 
-## Levels
+## MITRE ATT&CK ICS Levels
 
-[Levels](https://www.misp-galaxy.org/mitre-ics-levels) - Based on the Purdue Model to aid ATT&CK for ICS users to understand which techniques are applicable to their environment.
+[MITRE ATT&CK ICS Levels](https://www.misp-galaxy.org/mitre-ics-levels) - Purdue model levels used by MITRE ATT&CK for ICS.
 
 Category: *level* - source: *https://collaborate.mitre.org/attackics/index.php/All_Levels* - total: *3* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-ics-levels)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-levels.json)]
 
-## Software
+## MITRE ATT&CK ICS Software
 
-[Software](https://www.misp-galaxy.org/mitre-ics-software) - Software is a generic term for custom or commercial code, operating system utilities, open-source software, or other tools used to conduct behavior modeled in ATT&CK for ICS.
+[MITRE ATT&CK ICS Software](https://www.misp-galaxy.org/mitre-ics-software) - Software from MITRE ATT&CK for ICS.
 
 Category: *tool* - source: *https://collaborate.mitre.org/attackics/index.php/Software* - total: *17* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-ics-software)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-software.json)]
 
-## Tactics
+## MITRE ATT&CK ICS Tactics
 
-[Tactics](https://www.misp-galaxy.org/mitre-ics-tactics) - A list of all 11 tactics in ATT&CK for ICS
+[MITRE ATT&CK ICS Tactics](https://www.misp-galaxy.org/mitre-ics-tactics) - Tactics from MITRE ATT&CK for ICS.
 
 Category: *tactic* - source: *https://collaborate.mitre.org/attackics/index.php/All_Tactics* - total: *9* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-ics-tactics)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-tactics.json)]
 
-## Techniques
+## MITRE ATT&CK ICS Techniques
 
-[Techniques](https://www.misp-galaxy.org/mitre-ics-techniques) - A list of Techniques in ATT&CK for ICS.
+[MITRE ATT&CK ICS Techniques](https://www.misp-galaxy.org/mitre-ics-techniques) - Techniques from MITRE ATT&CK for ICS.
 
 Category: *attack-pattern* - source: *https://collaborate.mitre.org/attackics/index.php/All_Techniques* - total: *78* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-ics-techniques)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-techniques.json)]
 
-## Intrusion Set
+## MITRE ATT&CK Groups
 
-[Intrusion Set](https://www.misp-galaxy.org/mitre-intrusion-set) - Name of ATT&CK Group
+[MITRE ATT&CK Groups](https://www.misp-galaxy.org/mitre-intrusion-set) - Adversary groups tracked by MITRE ATT&CK.
 
 Category: *actor* - source: *https://github.com/mitre/cti* - total: *193* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-intrusion-set)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-intrusion-set.json)]
 
-## Malware
+## MITRE ATT&CK Malware
 
-[Malware](https://www.misp-galaxy.org/mitre-malware) - Name of ATT&CK software
+[MITRE ATT&CK Malware](https://www.misp-galaxy.org/mitre-malware) - Malicious software tracked by MITRE ATT&CK.
 
 Category: *tool* - source: *https://github.com/mitre/cti* - total: *854* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-malware)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-malware.json)]
 
-## mitre-tool
+## MITRE ATT&CK Tools
 
-[mitre-tool](https://www.misp-galaxy.org/mitre-tool) - Name of ATT&CK software
+[MITRE ATT&CK Tools](https://www.misp-galaxy.org/mitre-tool) - Legitimate tools abused by adversaries, tracked by MITRE ATT&CK.
 
 Category: *tool* - source: *https://github.com/mitre/cti* - total: *97* elements
 

--- a/clusters/mitre-analytic.json
+++ b/clusters/mitre-analytic.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "ATT&CK Analytics",
-  "name": "Analytics",
+  "description": "Detection analytics from MITRE ATT&CK.",
+  "name": "MITRE ATT&CK Analytics",
   "source": "https://attack.mitre.org/analytics/",
   "type": "x-mitre-analytic",
   "uuid": "05a12632-d650-4a29-a6e4-4450381754a1",
@@ -27646,5 +27646,5 @@
       "value": "Analytic 1999 - AN1999"
     }
   ],
-  "version": 3
+  "version": 4
 }

--- a/clusters/mitre-atlas-attack-pattern.json
+++ b/clusters/mitre-atlas-attack-pattern.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "MITRE ATLAS Attack Pattern - Adversarial Threat Landscape for Artificial-Intelligence Systems",
-  "name": "MITRE ATLAS Attack Pattern",
+  "description": "Techniques from MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems).",
+  "name": "MITRE ATLAS Techniques",
   "source": "https://github.com/mitre-atlas/atlas-navigator-data",
   "type": "mitre-atlas-attack-pattern",
   "uuid": "95e55c7e-68a9-453b-9677-020c8fc06333",
@@ -1809,5 +1809,5 @@
       "value": "Discover AI Model Outputs"
     }
   ],
-  "version": 14
+  "version": 15
 }

--- a/clusters/mitre-atlas-course-of-action.json
+++ b/clusters/mitre-atlas-course-of-action.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "course-of-action",
-  "description": "MITRE ATLAS Mitigation - Adversarial Threat Landscape for Artificial-Intelligence Systems",
-  "name": "MITRE ATLAS Course of Action",
+  "description": "Mitigations from MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems).",
+  "name": "MITRE ATLAS Mitigations",
   "source": "https://github.com/mitre-atlas/atlas-navigator-data",
   "type": "mitre-atlas-course-of-action",
   "uuid": "951d5a45-43c2-422b-90af-059014f15714",
@@ -1076,5 +1076,5 @@
       "value": "Maintain AI Dataset Provenance"
     }
   ],
-  "version": 13
+  "version": 14
 }

--- a/clusters/mitre-attack-pattern.json
+++ b/clusters/mitre-attack-pattern.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "ATT&CK tactic",
-  "name": "Attack Pattern",
+  "description": "Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise and Mobile).",
+  "name": "MITRE ATT&CK Techniques",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-attack-pattern",
   "uuid": "dcb864dc-775f-11e7-9fbb-1f41b4996683",
@@ -36050,5 +36050,5 @@
       "value": "Keychain - T1579"
     }
   ],
-  "version": 37
+  "version": 38
 }

--- a/clusters/mitre-course-of-action.json
+++ b/clusters/mitre-course-of-action.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "course-of-action",
-  "description": "ATT&CK Mitigation",
-  "name": "Course of Action",
+  "description": "Mitigations from MITRE ATT&CK.",
+  "name": "MITRE ATT&CK Mitigations",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-course-of-action",
   "uuid": "a8825ae8-6dea-11e7-8d57-7728f3cfe086",
@@ -10482,5 +10482,5 @@
       "value": "Audit - M1047"
     }
   ],
-  "version": 35
+  "version": 36
 }

--- a/clusters/mitre-d3fend.json
+++ b/clusters/mitre-d3fend.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "d3fend",
-  "description": "A knowledge graph of cybersecurity countermeasures.",
-  "name": "MITRE D3FEND",
+  "description": "Defensive countermeasure techniques from MITRE D3FEND.",
+  "name": "MITRE D3FEND Techniques",
   "source": "https://d3fend.mitre.org/",
   "type": "mitre-d3fend",
   "uuid": "b8bd7e45-63bf-4c44-8ab1-c81c82547380",
@@ -34188,5 +34188,5 @@
       "value": "Email Filtering"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-data-component.json
+++ b/clusters/mitre-data-component.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "data-component",
-  "description": "Data components are parts of data sources. ",
-  "name": "mitre-data-component",
+  "description": "Data components from MITRE ATT&CK, refining data sources into the specific properties relevant to detection.",
+  "name": "MITRE ATT&CK Data Components",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-data-component",
   "uuid": "d2c1cf9e-c581-4a70-b1c5-12e6de3f0e83",
@@ -1425,5 +1425,5 @@
       "value": "Application State - DC0123"
     }
   ],
-  "version": 8
+  "version": 9
 }

--- a/clusters/mitre-data-source.json
+++ b/clusters/mitre-data-source.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "data-source",
-  "description": "Data sources represent the various subjects/topics of information that can be collected by sensors/logs. ",
-  "name": "mitre-data-source",
+  "description": "Data sources from MITRE ATT&CK, representing the information that can be collected by sensors and logs.",
+  "name": "MITRE ATT&CK Data Sources",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-data-source",
   "uuid": "5fc9f2b7-3fff-437e-80aa-4dac402be0e5",
@@ -751,5 +751,5 @@
       "value": "Certificate - DS0037"
     }
   ],
-  "version": 8
+  "version": 9
 }

--- a/clusters/mitre-detection-strategy.json
+++ b/clusters/mitre-detection-strategy.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "ATT&CK Detection Strategies",
-  "name": "Detection Strategies",
+  "description": "Detection strategies from MITRE ATT&CK.",
+  "name": "MITRE ATT&CK Detection Strategies",
   "source": "https://attack.mitre.org/detectionstrategies/",
   "type": "x-mitre-detection-strategy",
   "uuid": "2f73f25d-0cc3-47ff-b17d-c984933c71df",
@@ -21046,5 +21046,5 @@
       "value": "Detect Social Engineering - DET0899"
     }
   ],
-  "version": 4
+  "version": 5
 }

--- a/clusters/mitre-engage-framework.json
+++ b/clusters/mitre-engage-framework.json
@@ -5,8 +5,8 @@
     "m3c4n1sm0"
   ],
   "category": "engage",
-  "description": "This galaxy contains all parts of the MITRE Engage framework, including Activities, Approaches, Goals, and Vulnerabilities.",
-  "name": "MITRE Engage Framework",
+  "description": "Activities, approaches, goals and vulnerabilities from the MITRE Engage framework.",
+  "name": "MITRE Engage",
   "source": "https://engage.mitre.org",
   "type": "engage-framework",
   "uuid": "5dbec788-99ca-4bd7-a96f-ad0601c0f281",
@@ -872,5 +872,5 @@
       "value": "EAV0032 - Vulnerability to MitM on Physical Process Control"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/mitre-fraud-framework.json
+++ b/clusters/mitre-fraud-framework.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "MITRE Fight Fraud Framework (F3) matrix of fraud techniques.",
-  "name": "MITRE Fight Fraud Framework",
+  "description": "Fraud techniques from the MITRE Fight Fraud Framework (F3).",
+  "name": "MITRE Fight Fraud Framework Techniques",
   "source": "https://ctid.mitre.org/fraud/",
   "type": "mitre-fraud-framework",
   "uuid": "9ef31655-ceaf-5808-aae9-26106b03b7b6",
@@ -2147,5 +2147,5 @@
       "value": "Email Spoofing"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-ics-assets.json
+++ b/clusters/mitre-ics-assets.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "asset",
-  "description": "A list of asset categories that are commonly found in industrial control systems.",
-  "name": "Assets",
+  "description": "Assets from MITRE ATT&CK for ICS.",
+  "name": "MITRE ATT&CK ICS Assets",
   "source": "https://collaborate.mitre.org/attackics/index.php/All_Assets",
   "type": "mitre-ics-assets",
   "uuid": "0594fbc2-6267-479b-85a3-c4be8e044454",
@@ -283,5 +283,5 @@
       "value": "Safety Instrumented System/Protection Relay"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-ics-groups.json
+++ b/clusters/mitre-ics-groups.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "actor",
-  "description": "Groups are sets of related intrusion activity that are tracked by a common name in the security community. Groups are also sometimes referred to as campaigns or intrusion sets. Some groups have multiple names associated with the same set of activities due to various organizations tracking the same set of activities by different names. Groups are mapped to publicly reported technique use and referenced in the ATT&CK for ICS knowledge base. Groups are also mapped to reported software used during intrusions.",
-  "name": "Groups",
+  "description": "Adversary groups from MITRE ATT&CK for ICS.",
+  "name": "MITRE ATT&CK ICS Groups",
   "source": "https://collaborate.mitre.org/attackics/index.php/Groups",
   "type": "mitre-ics-groups",
   "uuid": "8fb1c036-8904-4d4b-82d5-0286da77eb7e",
@@ -311,5 +311,5 @@
       "value": "XENOTIME"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/mitre-ics-levels.json
+++ b/clusters/mitre-ics-levels.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "level",
-  "description": "Based on the Purdue Model to aid ATT&CK for ICS users to understand which techniques are applicable to their environment.",
-  "name": "Levels",
+  "description": "Purdue model levels used by MITRE ATT&CK for ICS.",
+  "name": "MITRE ATT&CK ICS Levels",
   "source": "https://collaborate.mitre.org/attackics/index.php/All_Levels",
   "type": "mitre-ics-levels",
   "uuid": "952bcf79-eccd-45ac-9769-f61886bd0264",
@@ -49,5 +49,5 @@
       "value": "Level 2"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-ics-software.json
+++ b/clusters/mitre-ics-software.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "tool",
-  "description": "Software is a generic term for custom or commercial code, operating system utilities, open-source software, or other tools used to conduct behavior modeled in ATT&CK for ICS.",
-  "name": "Software",
+  "description": "Software from MITRE ATT&CK for ICS.",
+  "name": "MITRE ATT&CK ICS Software",
   "source": "https://collaborate.mitre.org/attackics/index.php/Software",
   "type": "mitre-ics-software",
   "uuid": "7d259f36-6e80-472e-9a42-9d4a83519825",
@@ -449,5 +449,5 @@
       "value": "WannaCry"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-ics-tactics.json
+++ b/clusters/mitre-ics-tactics.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "tactic",
-  "description": "A list of all 11 tactics in ATT&CK for ICS",
-  "name": "Tactics",
+  "description": "Tactics from MITRE ATT&CK for ICS.",
+  "name": "MITRE ATT&CK ICS Tactics",
   "source": "https://collaborate.mitre.org/attackics/index.php/All_Tactics",
   "type": "mitre-ics-tactics",
   "uuid": "ae92140f-7816-45b6-aa7c-9ff3e8536f10",
@@ -274,5 +274,5 @@
       "value": "Initial Access"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-ics-techniques.json
+++ b/clusters/mitre-ics-techniques.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "A list of Techniques in ATT&CK for ICS.",
-  "name": "Techniques",
+  "description": "Techniques from MITRE ATT&CK for ICS.",
+  "name": "MITRE ATT&CK ICS Techniques",
   "source": "https://collaborate.mitre.org/attackics/index.php/All_Techniques",
   "type": "mitre-ics-techniques",
   "uuid": "633e91db-adf8-458e-a09e-7ee0eb588bf3",
@@ -2034,5 +2034,5 @@
       "value": "Wireless Compromise"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-intrusion-set.json
+++ b/clusters/mitre-intrusion-set.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "actor",
-  "description": "Name of ATT&CK Group",
-  "name": "Intrusion Set",
+  "description": "Adversary groups tracked by MITRE ATT&CK.",
+  "name": "MITRE ATT&CK Groups",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-intrusion-set",
   "uuid": "10df003c-7831-11e7-bdb9-971cdd1218df",
@@ -28368,5 +28368,5 @@
       "value": "ShinyHunters - G1057"
     }
   ],
-  "version": 41
+  "version": 42
 }

--- a/clusters/mitre-malware.json
+++ b/clusters/mitre-malware.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "tool",
-  "description": "Name of ATT&CK software",
-  "name": "Malware",
+  "description": "Malicious software tracked by MITRE ATT&CK.",
+  "name": "MITRE ATT&CK Malware",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-malware",
   "uuid": "d752161c-78f6-11e7-a0ea-bfa79b407ce4",
@@ -66628,5 +66628,5 @@
       "value": "Embargo - S1247"
     }
   ],
-  "version": 40
+  "version": 41
 }

--- a/clusters/mitre-tool.json
+++ b/clusters/mitre-tool.json
@@ -3,8 +3,8 @@
     "MITRE"
   ],
   "category": "tool",
-  "description": "Name of ATT&CK software",
-  "name": "mitre-tool",
+  "description": "Legitimate tools abused by adversaries, tracked by MITRE ATT&CK.",
+  "name": "MITRE ATT&CK Tools",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-tool",
   "uuid": "d700dc5c-78f6-11e7-a476-5f748c8e4fe0",
@@ -5642,5 +5642,5 @@
       "value": "attrib - S1176"
     }
   ],
-  "version": 38
+  "version": 39
 }

--- a/galaxies/mitre-analytic.json
+++ b/galaxies/mitre-analytic.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK Analytics",
+  "description": "Detection analytics from MITRE ATT&CK.",
   "icon": "shield-alt",
-  "name": "Analytics",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Analytics",
+  "namespace": "mitre",
   "type": "x-mitre-analytic",
   "uuid": "d1d9bd9e-f9f1-4a58-a0e6-7661439aa7ff",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-atlas-attack-pattern.json
+++ b/galaxies/mitre-atlas-attack-pattern.json
@@ -1,5 +1,5 @@
 {
-  "description": "MITRE ATLAS Attack Pattern - Adversarial Threat Landscape for Artificial-Intelligence Systems",
+  "description": "Techniques from MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems).",
   "icon": "map",
   "kill_chain_order": {
     "mitre-atlas": [
@@ -19,9 +19,9 @@
       "impact"
     ]
   },
-  "name": "MITRE ATLAS Attack Pattern",
-  "namespace": "mitre-atlas",
+  "name": "MITRE ATLAS Techniques",
+  "namespace": "mitre",
   "type": "mitre-atlas-attack-pattern",
   "uuid": "3f3d21aa-d8a1-4f8f-b31e-fc5425eec821",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-atlas-course-of-action.json
+++ b/galaxies/mitre-atlas-course-of-action.json
@@ -1,9 +1,9 @@
 {
-  "description": "MITRE ATLAS Mitigation - Adversarial Threat Landscape for Artificial-Intelligence Systems",
+  "description": "Mitigations from MITRE ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems).",
   "icon": "link",
-  "name": "MITRE ATLAS Course of Action",
-  "namespace": "mitre-atlas",
+  "name": "MITRE ATLAS Mitigations",
+  "namespace": "mitre",
   "type": "mitre-atlas-course-of-action",
   "uuid": "29d13ede-9667-415c-bb75-b34a4bd89a81",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-attack-pattern.json
+++ b/galaxies/mitre-attack-pattern.json
@@ -1,5 +1,5 @@
 {
-  "description": "ATT&CK Tactic",
+  "description": "Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise and Mobile).",
   "icon": "map",
   "kill_chain_order": {
     "attack-Containers": [
@@ -203,9 +203,9 @@
       "compromise"
     ]
   },
-  "name": "Attack Pattern",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Techniques",
+  "namespace": "mitre",
   "type": "mitre-attack-pattern",
   "uuid": "c4e851fa-775f-11e7-8163-b774922098cd",
-  "version": 16
+  "version": 17
 }

--- a/galaxies/mitre-course-of-action.json
+++ b/galaxies/mitre-course-of-action.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK Mitigation",
+  "description": "Mitigations from MITRE ATT&CK.",
   "icon": "link",
-  "name": "Course of Action",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Mitigations",
+  "namespace": "mitre",
   "type": "mitre-course-of-action",
   "uuid": "6fcb4472-6de4-11e7-b5f7-37771619e14e",
-  "version": 7
+  "version": 8
 }

--- a/galaxies/mitre-d3fend.json
+++ b/galaxies/mitre-d3fend.json
@@ -1,5 +1,5 @@
 {
-  "description": "A knowledge graph of cybersecurity countermeasures.",
+  "description": "Defensive countermeasure techniques from MITRE D3FEND.",
   "icon": "user-shield",
   "kill_chain_order": {
     "Deceive": [
@@ -41,9 +41,9 @@
       "Restore-Object"
     ]
   },
-  "name": "MITRE D3FEND",
+  "name": "MITRE D3FEND Techniques",
   "namespace": "mitre",
   "type": "mitre-d3fend",
   "uuid": "77d1bbfa-2982-4e0a-9238-1dae4a48c5b4",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-data-component.json
+++ b/galaxies/mitre-data-component.json
@@ -1,9 +1,9 @@
 {
-  "description": "Data components are parts of data sources. ",
+  "description": "Data components from MITRE ATT&CK, refining data sources into the specific properties relevant to detection.",
   "icon": "sitemap",
-  "name": "mitre-data-component",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Data Components",
+  "namespace": "mitre",
   "type": "mitre-data-component",
   "uuid": "afff2d74-5d4a-4aa7-995a-3701a2dbe593",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-data-source.json
+++ b/galaxies/mitre-data-source.json
@@ -1,9 +1,9 @@
 {
-  "description": "Data sources represent the various subjects/topics of information that can be collected by sensors/logs. ",
+  "description": "Data sources from MITRE ATT&CK, representing the information that can be collected by sensors and logs.",
   "icon": "sitemap",
-  "name": "mitre-data-source",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Data Sources",
+  "namespace": "mitre",
   "type": "mitre-data-source",
   "uuid": "dca5da28-fdc0-4b37-91cd-989d139d96cf",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-detection-strategy.json
+++ b/galaxies/mitre-detection-strategy.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK Detection Strategies",
+  "description": "Detection strategies from MITRE ATT&CK.",
   "icon": "shield-alt",
-  "name": "Detection Strategies",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Detection Strategies",
+  "namespace": "mitre",
   "type": "x-mitre-detection-strategy",
   "uuid": "241caf7b-a270-4322-913c-fd0a67f4c3e7",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-engage-framework.json
+++ b/galaxies/mitre-engage-framework.json
@@ -1,9 +1,9 @@
 {
-  "description": "This galaxy contains all parts of the MITRE Engage framework, including Activities, Approaches, Goals, and Vulnerabilities.",
+  "description": "Activities, approaches, goals and vulnerabilities from the MITRE Engage framework.",
   "icon": "user-secret",
-  "name": "MITRE Engage Framework",
-  "namespace": "engage",
+  "name": "MITRE Engage",
+  "namespace": "mitre",
   "type": "engage-framework",
   "uuid": "5dbec788-99ca-4bd7-a96f-ad0601c0f281",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-fraud-framework.json
+++ b/galaxies/mitre-fraud-framework.json
@@ -1,5 +1,5 @@
 {
-  "description": "MITRE Fight Fraud Framework (F3) matrix of fraud techniques.",
+  "description": "Fraud techniques from the MITRE Fight Fraud Framework (F3).",
   "icon": "map",
   "kill_chain_order": {
     "mitre-f3": [
@@ -12,9 +12,9 @@
       "monetization"
     ]
   },
-  "name": "MITRE Fight Fraud Framework",
+  "name": "MITRE Fight Fraud Framework Techniques",
   "namespace": "mitre",
   "type": "mitre-fraud-framework",
   "uuid": "592daf62-c72b-5131-8d54-04608f9f277b",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-ics-assets.json
+++ b/galaxies/mitre-ics-assets.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK for ICS Assets",
+  "description": "Assets from MITRE ATT&CK for ICS.",
   "icon": "certificate",
-  "name": "Assets",
-  "namespace": "mitre-attack-ics",
+  "name": "MITRE ATT&CK ICS Assets",
+  "namespace": "mitre",
   "type": "mitre-ics-assets",
   "uuid": "86b19468-784e-4ec9-9af9-f069aa4cf70d",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-ics-groups.json
+++ b/galaxies/mitre-ics-groups.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK for ICS Groups",
+  "description": "Adversary groups from MITRE ATT&CK for ICS.",
   "icon": "skull-crossbones",
-  "name": "Groups",
-  "namespace": "mitre-attack-ics",
+  "name": "MITRE ATT&CK ICS Groups",
+  "namespace": "mitre",
   "type": "mitre-ics-groups",
   "uuid": "abb28bd9-fa79-4815-b5b3-fb138f433e55",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-ics-levels.json
+++ b/galaxies/mitre-ics-levels.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK for ICS Levels",
+  "description": "Purdue model levels used by MITRE ATT&CK for ICS.",
   "icon": "layer-group",
-  "name": "Levels",
-  "namespace": "mitre-attack-ics",
+  "name": "MITRE ATT&CK ICS Levels",
+  "namespace": "mitre",
   "type": "mitre-ics-levels",
   "uuid": "34d60262-0e7d-4c91-859b-de1fa9c54ae7",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-ics-software.json
+++ b/galaxies/mitre-ics-software.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK for ICS Software",
+  "description": "Software from MITRE ATT&CK for ICS.",
   "icon": "file-code",
-  "name": "Software",
-  "namespace": "mitre-attack-ics",
+  "name": "MITRE ATT&CK ICS Software",
+  "namespace": "mitre",
   "type": "mitre-ics-software",
   "uuid": "9443a27f-f8b0-4bc7-ba88-7c023d727932",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-ics-tactics.json
+++ b/galaxies/mitre-ics-tactics.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK for ICS Tactics",
+  "description": "Tactics from MITRE ATT&CK for ICS.",
   "icon": "chess-pawn",
-  "name": "Tactics",
-  "namespace": "mitre-attack-ics",
+  "name": "MITRE ATT&CK ICS Tactics",
+  "namespace": "mitre",
   "type": "mitre-ics-tactics",
   "uuid": "e521606c-3c66-4621-9040-6f0f792fc999",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-ics-techniques.json
+++ b/galaxies/mitre-ics-techniques.json
@@ -1,9 +1,9 @@
 {
-  "description": "ATT&CK for ICS Techniques",
+  "description": "Techniques from MITRE ATT&CK for ICS.",
   "icon": "user-ninja",
-  "name": "Techniques",
-  "namespace": "mitre-attack-ics",
+  "name": "MITRE ATT&CK ICS Techniques",
+  "namespace": "mitre",
   "type": "mitre-ics-techniques",
   "uuid": "99261a7e-2270-40eb-823f-834cc1ad3159",
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-intrusion-set.json
+++ b/galaxies/mitre-intrusion-set.json
@@ -1,9 +1,9 @@
 {
-  "description": "Name of ATT&CK Group",
+  "description": "Adversary groups tracked by MITRE ATT&CK.",
   "icon": "user-secret",
-  "name": "Intrusion Set",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Groups",
+  "namespace": "mitre",
   "type": "mitre-intrusion-set",
   "uuid": "1023f364-7831-11e7-8318-43b5531983ab",
-  "version": 8
+  "version": 9
 }

--- a/galaxies/mitre-malware.json
+++ b/galaxies/mitre-malware.json
@@ -1,9 +1,9 @@
 {
-  "description": "Name of ATT&CK software",
+  "description": "Malicious software tracked by MITRE ATT&CK.",
   "icon": "optin-monster",
-  "name": "Malware",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Malware",
+  "namespace": "mitre",
   "type": "mitre-malware",
   "uuid": "d752161c-78f6-11e7-a0ea-bfa79b407ce4",
-  "version": 6
+  "version": 7
 }

--- a/galaxies/mitre-tool.json
+++ b/galaxies/mitre-tool.json
@@ -1,9 +1,9 @@
 {
-  "description": "Name of ATT&CK software",
+  "description": "Legitimate tools abused by adversaries, tracked by MITRE ATT&CK.",
   "icon": "gavel",
-  "name": "mitre-tool",
-  "namespace": "mitre-attack",
+  "name": "MITRE ATT&CK Tools",
+  "namespace": "mitre",
   "type": "mitre-tool",
   "uuid": "d5cbd1a2-78f6-11e7-a833-7b9bccca9649",
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
Closes #1257

Applies the convention proposed in #<ISSUE> to the 20 non-deprecated `mitre-*` galaxies: `namespace` becomes `mitre`, `name` becomes `MITRE <framework> <object type as MITRE labels it>`, and `description` becomes a single sentence stating the content, framework and scope. Galaxy and cluster names are kept identical, and `version` is bumped on every touched file.

## No tag breaks

MISP tags are `misp-galaxy:<type>="<value>"` and sync is UUID-based, so this PR is display-only. Every changed line in `galaxies/` and `clusters/` belongs to one of four keys:

| Key | Changed lines |
|---|---|
| `name` | 80 |
| `description` | 80 |
| `version` | 80 |
| `namespace` | 36 |

No `value`, `type` or `uuid` line is touched (0 occurrences), and insertions equal deletions (178 / 178), so no value was added or removed.

## Changes

- `galaxies/mitre-*.json`, `clusters/mitre-*.json` — 20 pairs updated (40 files)
- `README.md` — regenerated with `tools/update_README_with_index.py`

The 12 `deprecated` files are untouched.