### PR TITLE
fix: jq_all_the_things.sh never syntax-checks galaxies/ (glob typo)

### DIFF
--- a/jq_all_the_things.sh
+++ b/jq_all_the_things.sh
@@ -4,7 +4,7 @@
 
 # Validate all JSONs first in cluster and galaxy
 
-folders=( clusters/*.json galaxy/*.json )
+folders=( clusters/*.json galaxies/*.json )
 for dir in "${folders[@]}"
 do
   echo validating ${dir}


### PR DESCRIPTION
## Problem

`jq_all_the_things.sh` starts with a JSON syntax gate over every cluster and galaxy file, before the beautify loops rewrite those same files in place with `sponge`:

```bash
folders=( clusters/*.json galaxy/*.json )
```

The directory is `galaxies/`, not `galaxy/`. The glob never matches, so bash leaves it as the literal string `galaxy/*.json` and the loop body runs:

```bash
cat 'galaxy/*.json' | jq . >/dev/null
rc=$?
```

`cat` fails, but `jq` is the last command in the pipeline — it reads empty stdin and exits **0**. So `rc` is 0 and the `if [[ $rc != 0 ]]` guard never fires. **Galaxy files have never been syntax-checked by this script.**

## Reproduction

Scratch tree with a valid cluster and a malformed `galaxies/bad.json`:

```
--- OLD glob (galaxy/) ---
  glob=clusters/ok.json  rc=0
  glob=galaxy/*.json     rc=0     <-- malformed galaxy not checked
--- NEW glob (galaxies/) ---
  glob=clusters/ok.json  rc=0
  glob=galaxies/bad.json rc=5     <-- correctly rejected
```

## Fix

One character class: `galaxy/*.json` → `galaxies/*.json`.

## Note

The beautify loops further down (`cat ${dir} | jq --sort-keys . | sponge ${dir}`) have a related weakness — without `set -o pipefail` the pipeline reports `sponge`'s exit status, so a `jq` failure there truncates the file to 0 bytes while `set -e` stays quiet. That is a separate concern touching different lines and is submitted as its own PR; the two hunks are disjoint and merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
