### PR TITLE
fix: jq_all_the_things.sh truncates files to 0 bytes on a jq parse error

### DIFF
--- a/jq_all_the_things.sh
+++ b/jq_all_the_things.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Seeds sponge, from moreutils
-
 # Validate all JSONs first in cluster and galaxy
 
 folders=( clusters/*.json galaxy/*.json )
@@ -15,20 +13,36 @@ do
 done
 
 set -e
+set -o pipefail
 set -x
+
+# Beautify a JSON file in place, but only if jq actually succeeded.
+# Writing through a temp file means a jq failure leaves the original intact
+# instead of truncating it to 0 bytes.
+beautify() {
+    local target="$1"
+    shift
+    local tmp
+    tmp="$(mktemp "${target}.XXXXXX")"
+    if jq "$@" . "${target}" > "${tmp}"; then
+        mv "${tmp}" "${target}"
+    else
+        rm -f "${tmp}"
+        echo "ERROR: jq failed on ${target}, left unchanged" >&2
+        return 1
+    fi
+}
 
 for dir in clusters/*.json
 do
-    python3 tools/add_missing_uuid.py -f ${dir}
-    # Beautify it
-    cat ${dir} | jq --sort-keys . | sponge ${dir}
+    python3 tools/add_missing_uuid.py -f "${dir}"
+    beautify "${dir}" --sort-keys
 done
 
 for dir in galaxies/*.json
 do
-    # Beautify it
-    cat ${dir} | jq --sort-keys . | sponge ${dir}
+    beautify "${dir}" --sort-keys
 done
 
-cat schema_clusters.json | jq . | sponge schema_clusters.json
-cat schema_galaxies.json | jq . | sponge schema_galaxies.json
+beautify schema_clusters.json
+beautify schema_galaxies.json


### PR DESCRIPTION
## Problem

The beautify loops rewrite every cluster, galaxy and schema file in place:

```bash
set -e
cat ${dir} | jq --sort-keys . | sponge ${dir}
```

A shell pipeline reports the exit status of its **last** command. That is `sponge`, which succeeds at writing whatever it received — including nothing. So when `jq` fails to parse a file, `jq` writes no output, `sponge` truncates the source file to **0 bytes**, and the pipeline still returns 0. `set -e` never fires and the loop carries on through the remaining files.

The `set -x` trace shows the jq parse error scrolling past, but the script exits 0 and the file is already gone.

## Reproduction

```
before: 10 bytes
--- OLD: cat | jq | sponge (set -e active) ---
    jq: parse error: Unfinished JSON term at EOF at line 1, column 10
    pipeline rc=0  after: 0 bytes        <-- source file destroyed, script continues
--- NEW: beautify() temp-file + pipefail ---
    jq: parse error: Unfinished JSON term at EOF at line 1, column 10
    ERROR: jq failed on .../bad.json, left unchanged
    rc=1  after: 10 bytes                <-- original intact, script stops
```

## Fix

- `set -o pipefail` so a failure anywhere in a pipeline is not masked.
- A `beautify()` helper that writes `jq` output to a temp file and only `mv`s it over the target when jq succeeded, so a parse failure cannot destroy the input. It also drops the `cat |` UUOC by passing the filename to `jq` directly.
- Quote `"${dir}"` at the call sites so a path containing a space is not silently skipped.

## Verification

Running the rewritten script over the full repository (131 clusters + 131 galaxies + both schemas) leaves `git status` reporting **only this script as modified** — byte-identical output to the `sponge` version on every data file.

`sponge` was the script's only use of moreutils in the repo (`grep -rn sponge` over `*.sh` and `*.yml` now returns nothing), so the stale "Seeds sponge, from moreutils" header comment is removed. The CI `apt install moreutils` step is left alone.

## Note

The syntax gate at the top of this script has a separate defect — it globs `galaxy/*.json` when the directory is `galaxies/`, so galaxy files are never checked. That is submitted as its own PR; the two hunks are disjoint and merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
