### PR TITLE
fix: tools/sigma/update.sh can truncate clusters/sigma-rules.json to 0 bytes

### DIFF
--- a/tools/sigma/update.sh
+++ b/tools/sigma/update.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
+set -euo pipefail
+
+# Always operate relative to this script, so `rm -rf sigma` and the clone
+# cannot land outside tools/sigma when invoked from another directory.
+cd "${0%/*}"
+
 rm -rf sigma
-git clone https://github.com/SigmaHQ/sigma 
+git clone https://github.com/SigmaHQ/sigma
 python3 sigma-to-galaxy.py -r -p ./sigma/rules
-cat sigma-cluster.json | jq -S . >../../clusters/sigma-rules.json
+
+# Write through a temp file: a failure in sigma-to-galaxy.py or jq must not
+# truncate the committed cluster.
+tmp="$(mktemp ../../clusters/sigma-rules.json.XXXXXX)"
+if jq -S . sigma-cluster.json > "${tmp}"; then
+    mv "${tmp}" ../../clusters/sigma-rules.json
+else
+    rm -f "${tmp}"
+    echo "ERROR: jq failed on sigma-cluster.json, clusters/sigma-rules.json left unchanged" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem

`tools/sigma/update.sh` regenerates the committed 4.5 MB `clusters/sigma-rules.json`:

```bash
#!/bin/bash
rm -rf sigma
git clone https://github.com/SigmaHQ/sigma
python3 sigma-to-galaxy.py -r -p ./sigma/rules
cat sigma-cluster.json | jq -S . >../../clusters/sigma-rules.json
```

Two problems compound:

1. **No `set -e`.** If the clone or `sigma-to-galaxy.py` fails, the script still runs line 5 — against a stale or missing `sigma-cluster.json`.
2. **`>` truncates the target before `jq` ever runs.** So when jq then fails to parse its input, the committed cluster has already been emptied to 0 bytes. There is no recovery path; the good content is simply gone from the working tree.

## Reproduction

```
committed cluster before: 50 bytes
--- OLD: cat sigma-cluster.json | jq -S . > sigma-rules.json ---
jq: parse error: Unfinished JSON term at EOF at line 1, column 10
    rc=5  after: 0 bytes          <-- committed cluster destroyed
--- NEW: temp file + mv on success ---
jq: parse error: Unfinished JSON term at EOF at line 1, column 10
    ERROR: jq failed, cluster left unchanged
    rc=1  after: 50 bytes         <-- intact
```

## Fix

- `set -euo pipefail` so an earlier failure stops the script instead of falling through to the write.
- Write jq's output to a temp file and `mv` it into place only on success, so a parse failure cannot truncate the cluster.
- `cd "${0%/*}"` — the sibling `tools/fetch_malpedia.sh` already does this. Without it, running `update.sh` from the repository root makes `rm -rf sigma` and the `git clone` operate on the *repository root*, not on `tools/sigma/`.
- Drop the `cat |` UUOC by passing the filename to `jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
