### PR TITLE
fix: build.sh rsync --delete's to the live site even when the build failed

### DIFF
--- a/tools/mkdocs/build.sh
+++ b/tools/mkdocs/build.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
+set -euo pipefail
+
+cd "${0%/*}"
 
 requirements_path="requirements.txt"
 
-pip freeze > installed.txt
-diff -u <(sort $requirements_path) <(sort installed.txt)
-
-if [ $? -eq 0 ]; then
-    echo "All dependencies are installed with correct versions."
-else
-    echo "Dependencies missing or with incorrect versions. Please install all dependencies from $requirements_path into your environment."
-    rm installed.txt # Clean up
-#    exit 1
+# Report any requirement that is missing or version-mismatched in the current
+# environment. `pip freeze` lists everything installed, so a plain diff against
+# requirements.txt is noise in any real virtualenv -- check containment instead.
+missing="$(comm -23 <(LC_ALL=C sort -u "$requirements_path") <(pip freeze | LC_ALL=C sort -u))"
+if [ -n "$missing" ]; then
+    echo "Dependencies missing or with incorrect versions. Please install all dependencies from $requirements_path into your environment:" >&2
+    echo "$missing" >&2
+    exit 1
 fi
-
-rm installed.txt # Clean up
+echo "All dependencies are installed with correct versions."
 
 python3 generator.py
-cd ./site/ || exit
-mkdocs build
-rsync --include ".*" -avh --delete -rz --checksum site/ circl@cppz.circl.lu:/var/www/misp-galaxy.org
+(cd ./site/ && mkdocs build)
+
+# Only publish once the generator and the mkdocs build have both succeeded --
+# `rsync --delete` against the live site is destructive, and an aborted build
+# would otherwise mirror an empty or partial tree onto misp-galaxy.org.
+if [ ! -d site/site ] || [ -z "$(ls -A site/site)" ]; then
+    echo "ERROR: site/site is missing or empty after mkdocs build; refusing to rsync --delete to production." >&2
+    exit 1
+fi
+
+rsync --include ".*" -avh --delete -rz --checksum site/site/ circl@cppz.circl.lu:/var/www/misp-galaxy.org


### PR DESCRIPTION
## Problem

`tools/mkdocs/build.sh` ends with a destructive publish to the live documentation site:

```bash
python3 generator.py
cd ./site/ || exit
mkdocs build
rsync --include ".*" -avh --delete -rz --checksum site/ circl@cppz.circl.lu:/var/www/misp-galaxy.org
```

There is no `set -e`. If `generator.py` raises, or `mkdocs build` fails, the script carries straight on to `rsync --delete` — mirroring an empty or half-built tree onto **misp-galaxy.org** and deleting whatever was there.

The dependency gate above it cannot help, because it is disabled:

```bash
diff -u <(sort $requirements_path) <(sort installed.txt)
if [ $? -eq 0 ]; then
    ...
else
    ...
    rm installed.txt
#    exit 1          <-- commented out
fi
```

The `exit 1` is commented out for a reason: the check diffs `requirements.txt` against a **full** `pip freeze`, so it mismatches in any environment that has anything else installed. Measured here:

```
=== OLD dep gate: diff -u requirements.txt vs FULL pip freeze ===
  diff rc=1   (non-zero => reports 'dependencies missing')
  packages pip freeze has that requirements.txt does not: 109
  -> in any venv with extra packages the gate ALWAYS fails

=== NEW dep gate: containment (requirements minus installed) ===
  requirements not satisfied here: 47
  -> counts only genuine gaps; extra installed packages are ignored
```

`rm installed.txt` also runs twice (line 12 and line 16); the second fails on the mismatch path.

## Fix

- `set -euo pipefail` and `cd "${0%/*}"`.
- Replace the `diff`-against-`pip freeze` gate with a **containment** check (`comm -23`, `LC_ALL=C` so both sides collate identically). It reports only genuinely missing or version-mismatched requirements and ignores extra installed packages — which makes it correct enough to re-enable, so `exit 1` is live again.
- Remove the duplicated `rm installed.txt`; the temp file is no longer written at all.
- Run `mkdocs build` in a subshell so the working directory is unambiguous, then **verify `site/site` exists and is non-empty before the rsync**. An aborted build now fails loudly instead of publishing an empty tree.

The rsync source path is unchanged in effect: previously `site/` relative to a cwd of `tools/mkdocs/site`, now `site/site/` relative to `tools/mkdocs` — the same directory, which is where mkdocs writes (`tools/mkdocs/site/mkdocs.yml` sets no `site_dir`, so the default `site` applies relative to the config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
