### PR TITLE
[medium] fix: gen_adoc_galaxy.sh scp's stale a.html/a.pdf to production when the build fails

### DIFF
--- a/tools/gen_adoc_galaxy.sh
+++ b/tools/gen_adoc_galaxy.sh
@@ -1,7 +1,19 @@
-python3 adoc_galaxy.py >a.txt
-asciidoctor -a allow-uri-read a.txt
-asciidoctor-pdf -a allow-uri-read a.txt
-cp a.html ../../misp-website/static/galaxy.html
-cp a.pdf ../../misp-website/static/galaxy.pdf
-scp -l 81920 a.html circl@cpab.circl.lu:/var/www/nwww.circl.lu/doc/misp-galaxy/index.html
-scp -l 81920 a.pdf  circl@cpab.circl.lu:/var/www/nwww.circl.lu/doc/misp-galaxy/galaxy.pdf
+#!/bin/bash
+set -euo pipefail
+
+cd "${0%/*}"
+
+# Build into a scratch directory so a failed run cannot leave stale artifacts
+# behind for the copy/scp steps below to publish.
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+python3 adoc_galaxy.py > "${workdir}/a.txt"
+asciidoctor -a allow-uri-read -o "${workdir}/a.html" "${workdir}/a.txt"
+asciidoctor-pdf -a allow-uri-read -o "${workdir}/a.pdf" "${workdir}/a.txt"
+
+# Every step above succeeded (set -e), so these artifacts are current.
+cp "${workdir}/a.html" ../../misp-website/static/galaxy.html
+cp "${workdir}/a.pdf"  ../../misp-website/static/galaxy.pdf
+scp -l 81920 "${workdir}/a.html" circl@cpab.circl.lu:/var/www/nwww.circl.lu/doc/misp-galaxy/index.html
+scp -l 81920 "${workdir}/a.pdf"  circl@cpab.circl.lu:/var/www/nwww.circl.lu/doc/misp-galaxy/galaxy.pdf


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `gen_adoc_galaxy.sh` scp's stale `a.html`/`a.pdf` to production when the build fails.

- **Problem** — `tools/gen_adoc_galaxy.sh` is executable but has no shebang and no `set -e`, so if `adoc_galaxy.py` or either asciidoctor step fails, `a.html` and `a.pdf` left over from a previous run are still copied into `misp-website` and scp'd to `nwww.circl.lu`. It also leaves untracked `a.txt`/`a.html`/`a.pdf` in the tree, tripping the git-cleanliness gate in `validate_all.sh`.
- **Fix** — Add `#!/bin/bash` and `set -euo pipefail`, `cd` to the script directory, and build into a `mktemp -d` scratch dir with a cleanup trap.
- **Effect** — A failed regeneration aborts instead of silently republishing yesterday's galaxy documentation, and the working tree stays clean.
<!-- /bluf -->

## Problem

`tools/gen_adoc_galaxy.sh` is marked executable (`100755`) but has **no shebang** and **no `set -e`**:

```bash
python3 adoc_galaxy.py >a.txt
asciidoctor -a allow-uri-read a.txt
asciidoctor-pdf -a allow-uri-read a.txt
cp a.html ../../misp-website/static/galaxy.html
cp a.pdf ../../misp-website/static/galaxy.pdf
scp -l 81920 a.html circl@cpab.circl.lu:/var/www/nwww.circl.lu/doc/misp-galaxy/index.html
scp -l 81920 a.pdf  circl@cpab.circl.lu:/var/www/nwww.circl.lu/doc/misp-galaxy/galaxy.pdf
```

Three consequences:

1. **Stale artifacts get published.** If `adoc_galaxy.py` or either asciidoctor step fails, `a.html` and `a.pdf` from a *previous* run are still sitting in `tools/`, and the `cp`/`scp` lines happily copy them to the MISP website and to `nwww.circl.lu`. A failed regeneration silently republishes yesterday's documentation.
2. **No shebang** on an executable file means the interpreter is whatever the caller happens to be.
3. The intermediate `a.txt` / `a.html` / `a.pdf` are written into the working tree and are **not in `.gitignore`**, so running this script leaves the repo dirty and trips the `git status --porcelain` cleanliness gate in `validate_all.sh` for unrelated reasons.

## Fix

- Add `#!/bin/bash` and `set -euo pipefail`, so any failing step aborts before anything is copied or uploaded.
- `cd "${0%/*}"` so the relative `../../misp-website/` path means the same thing regardless of where the script is invoked from.
- Build into a `mktemp -d` scratch directory with a cleanup `trap`, passing `-o` to asciidoctor. Stale output from an earlier run can no longer exist, and the working tree stays clean — which also removes the need for `.gitignore` entries.

By the time the `cp`/`scp` lines run, `set -e` guarantees every generation step succeeded and the artifacts are from *this* run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

