### PR TITLE
fix: human-kill-chain kill_chain_order keyed on bhadra-framework, so no phase resolves

### DIFF
--- a/clusters/human-kill-chain.json
+++ b/clusters/human-kill-chain.json
@@ -16,7 +16,7 @@
       "description": "Research dating platforms and identify vulnerable profiles",
       "meta": {
         "kill_chain": [
-          "human-layer-kill-chain:Target Profiling"
+          "human-layer-kill-chain:Target profiling"
         ]
       },
       "uuid": "7c2a19e5-9c1e-4d78-9c49-939f40092e5c",
@@ -26,7 +26,7 @@
       "description": "Identify low value target/employee",
       "meta": {
         "kill_chain": [
-          "human-layer-kill-chain:Target Profiling"
+          "human-layer-kill-chain:Target profiling"
         ]
       },
       "uuid": "1c99c4c9-5d88-44bd-bae3-288099d496e6",
@@ -76,7 +76,7 @@
       "description": "Initial contact and emotional connection",
       "meta": {
         "kill_chain": [
-          "human-layer-kill-chain:Trust establishment."
+          "human-layer-kill-chain:Trust establishment"
         ]
       },
       "uuid": "afc9dbeb-7ab3-4ea9-849c-0a73dad1c05d",
@@ -183,5 +183,5 @@
       "value": "Delete profile and online presence"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/galaxies/human-kill-chain.json
+++ b/galaxies/human-kill-chain.json
@@ -2,7 +2,7 @@
   "description": "Human Layer Kill Chain (HKC) framework",
   "icon": "people-arrows",
   "kill_chain_order": {
-    "bhadra-framework": [
+    "human-layer-kill-chain": [
       "Target profiling",
       "Human vulnerability assessment",
       "Personalized attack design",
@@ -17,5 +17,5 @@
   "namespace": "misp",
   "type": "human-layer-kill-chain",
   "uuid": "64a9dcad-93f4-4d95-b7f4-e808a727b20d",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Problem

`galaxies/human-kill-chain.json` declares its phase order under the wrong key:

```json
"kill_chain_order": {
  "bhadra-framework": [ "Target profiling", ... ]
},
"type": "human-layer-kill-chain",
```

The key must match the galaxy's own `type`. It says `bhadra-framework` — a copy-paste from the neighbouring galaxy. Every one of the 17 cluster values tags itself `human-layer-kill-chain:<phase>`, so **not a single kill-chain tag in this galaxy resolves to a declared phase.**

Two of the tags are additionally misspelled against the order: `Target Profiling` (capital P; the order says `Target profiling`) and `Trust establishment.` with a trailing period.

Measured before the fix — all 9 distinct tags across 17 values:

```
'human-layer-kill-chain:Action Manipulation'            x2   resolves=False
'human-layer-kill-chain:Emotional triggering'           x2   resolves=False
'human-layer-kill-chain:Human vulnerability assessment' x2   resolves=False
'human-layer-kill-chain:Operational Cleanup'            x1   resolves=False
'human-layer-kill-chain:Personalized attack design'     x2   resolves=False
'human-layer-kill-chain:Sustained engagement'           x3   resolves=False
'human-layer-kill-chain:Target Profiling'               x2   resolves=False
'human-layer-kill-chain:Trust establishment'            x2   resolves=False
'human-layer-kill-chain:Trust establishment.'           x1   resolves=False
```

## Fix

- Rename the `kill_chain_order` key to this galaxy's `type`, `human-layer-kill-chain`. Contents are untouched.
- Correct the three mistagged cluster values to match the declared phases (`Target Profiling` ×2 → `Target profiling`, `Trust establishment.` ×1 → `Trust establishment`). The declared order is treated as authoritative, so no phase names change.
- Bump both `version` fields (galaxy 1 → 2, cluster 1 → 2) so MISP instances actually pick the correction up.

## Verification

```
galaxy kill_chain_order key -> ['human-layer-kill-chain']
cluster tags rewritten: {'...:Target Profiling': 2, '...:Trust establishment.': 1}
unresolved tags after fix: 0 []
```

Both files re-validate against `schema_galaxies.json` / `schema_clusters.json` (0 failures), and the diff is 6 lines across the two files with formatting unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
