### PR TITLE
fix: 7 duplicated entries (same uuid and name) in clusters/rmm-tool.json

### DIFF
--- a/clusters/rmm-tool.json
+++ b/clusters/rmm-tool.json
@@ -3080,39 +3080,8 @@
         "installation_paths": [
           "hsloader.exe",
           "ihcserver.exe",
-          "instanthousecall.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://instanthousecall.com/features/",
-          "https://instanthousecall.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/instant_housecall_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/instant_housecall_processes_sigma.yml"
-        ]
-      },
-      "uuid": "effbe985-ec78-53cc-8495-c20d41da6a47",
-      "value": "Instant Housecall"
-    },
-    {
-      "description": "Instant Housecall is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of Instant Housecall RMM tool",
-          "Detects potential processes activity of Instant Housecall RMM tool"
-        ],
-        "domains": [
-          "*.instanthousecall.com",
-          "secure.instanthousecall.com",
-          "*.instanthousecall.net",
-          "instanthousecall.com"
-        ],
-        "installation_paths": [
-          "hsloader.exe",
-          "InstantHousecall.exe",
-          "ihcserver.exe",
-          "instanthousecall.exe"
+          "instanthousecall.exe",
+          "InstantHousecall.exe"
         ],
         "last_modified": "2024-08-02",
         "refs": [
@@ -3263,39 +3232,6 @@
           "https://www.islonline.com/",
           "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_network_sigma.yml",
           "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_processes_sigma.yml"
-        ]
-      },
-      "uuid": "68a3e0bd-82e3-5d0f-a38f-7869086a93f9",
-      "value": "ISL Online"
-    },
-    {
-      "description": "ISL Online is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of ISL Online RMM tool",
-          "Detects potential processes activity of ISL Online RMM tool"
-        ],
-        "domains": [
-          "*.islonline.com",
-          "*.islonline.net"
-        ],
-        "installation_paths": [
-          "islalwaysonmonitor.exe",
-          "isllight.exe",
-          "isllightservice.exe",
-          "ISLLightClient.exe",
-          "C:\\Program Files (x86)\\ISL Online\\ISL Light*",
-          "*\\ISL Online\\ISL Light*",
-          "*\\ISLLight.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://help.islonline.com/19818/165940",
-          "https://www.islonline.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_processes_sigma.yml"
         ],
         "supported_os": [
           "Windows"
@@ -3355,31 +3291,6 @@
         "domains": [
           "*.itsupport247.net",
           "itsupport247.net"
-        ],
-        "installation_paths": [
-          "saazapsc.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://control.itsupport247.net/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/itsupport247__connectwise__network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/itsupport247__connectwise__processes_sigma.yml"
-        ]
-      },
-      "uuid": "3b24327a-9190-58fa-92be-1e25551784bf",
-      "value": "ITSupport247 (ConnectWise)"
-    },
-    {
-      "description": "ITSupport247 (ConnectWise) is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of ITSupport247 (ConnectWise) RMM tool",
-          "Detects potential processes activity of ITSupport247 (ConnectWise) RMM tool"
-        ],
-        "domains": [
-          "*.itsupport247.net"
         ],
         "installation_paths": [
           "saazapsc.exe"
@@ -3864,35 +3775,6 @@
         ],
         "supported_os": [
           "Windows"
-        ]
-      },
-      "uuid": "4ac3c901-7484-5345-9b2f-10fc29c6f007",
-      "value": "Level.io"
-    },
-    {
-      "description": "Level.io is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of Level.io RMM tool",
-          "Detects potential processes activity of Level.io RMM tool"
-        ],
-        "domains": [
-          "level.io",
-          "*.level.io"
-        ],
-        "installation_paths": [
-          "level-windows-amd64.exe",
-          "level.exe",
-          "level-remote-control-ffmpeg.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://docs.level.io/1.0/admin-guides/troubleshooting-agent-issues",
-          "https://level.io/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/level.io_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/level.io_processes_sigma.yml"
         ]
       },
       "uuid": "4ac3c901-7484-5345-9b2f-10fc29c6f007",
@@ -4767,47 +4649,6 @@
       "value": "N-Able Advanced Monitoring Agent"
     },
     {
-      "description": "N-Able Advanced Monitoring Agent is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of N-Able Advanced Monitoring Agent RMM tool",
-          "Detects potential processes activity of N-Able Advanced Monitoring Agent RMM tool"
-        ],
-        "domains": [
-          "*remote.management",
-          "*.logicnow.com",
-          "*systemmonitor.us",
-          "*systemmonitor.eu.com",
-          "*system-monitor.com",
-          "systemmonitor.us.cdn.cloudflare.net",
-          "*cloudbackup.management",
-          "*systemmonitor.co.uk",
-          "*.n-able.com",
-          "*.beanywhere.com",
-          "*.swi-tc.com"
-        ],
-        "installation_paths": [
-          "Agent_*_RW.exe",
-          "BASEClient.exe",
-          "BASupApp.exe",
-          "BASupSrvc.exe",
-          "BASupSrvcCnfg.exe",
-          "BASupTSHelper.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://documentation.n-able.com/takecontrol/troubleshooting/Content/kb/Take-Control-Standalone-Ports-and-Domains-Firewall-and-AV-Exclusions.htm",
-          "https://www.n-able.com/features/advanced-monitoring-agent",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/n-able_advanced_monitoring_agent_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/n-able_advanced_monitoring_agent_processes_sigma.yml"
-        ]
-      },
-      "uuid": "5d737702-8d5f-5227-8190-804e376af333",
-      "value": "N-Able Advanced Monitoring Agent"
-    },
-    {
       "description": "N-ABLE Remote Access Software is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
       "meta": {
         "category": "RMM",
@@ -5120,42 +4961,13 @@
         ],
         "domains": [
           "*.netsupportmanager.com",
-          "netsupportmanager.com"
+          "netsupportmanager.com",
+          "geo.netsupportsoftware.com"
         ],
         "installation_paths": [
           "pcictlui.exe",
           "pcicfgui.exe",
           "client32.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://www.netsupportmanager.com/resources/",
-          "https://www.netsupportmanager.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/netsupport_manager_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/netsupport_manager_processes_sigma.yml"
-        ]
-      },
-      "uuid": "5d21c239-3e5f-5051-980a-04d7034701c8",
-      "value": "NetSupport Manager"
-    },
-    {
-      "description": "NetSupport Manager is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of NetSupport Manager RMM tool",
-          "Detects potential processes activity of NetSupport Manager RMM tool"
-        ],
-        "domains": [
-          "geo.netsupportsoftware.com",
-          "netsupportmanager.com",
-          "*.netsupportmanager.com"
-        ],
-        "installation_paths": [
-          "pcictlui.exe",
-          "client32.exe",
-          "pcicfgui.exe"
         ],
         "last_modified": "2024-08-02",
         "refs": [
@@ -7347,7 +7159,7 @@
       "meta": {
         "author": "Phyo Paing Htun",
         "category": "RMM",
-        "created": "2025-03-05",
+        "created": "2024-08-02",
         "detection_descriptions": [
           "Detects potential network activity of SimpleHelp RMM tool",
           "Detects potential processes activity of SimpleHelp RMM tool"
@@ -7381,37 +7193,6 @@
         ],
         "supported_os": [
           "windows"
-        ]
-      },
-      "uuid": "c315bd0f-fe30-5d42-88f0-810e6d5032a4",
-      "value": "SimpleHelp"
-    },
-    {
-      "description": "SimpleHelp is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of SimpleHelp RMM tool",
-          "Detects potential processes activity of SimpleHelp RMM tool"
-        ],
-        "domains": [
-          "user_managed",
-          "simple-help.com"
-        ],
-        "installation_paths": [
-          "simplehelpcustomer.exe",
-          "simpleservice.exe",
-          "simplegatewayservice.exe",
-          "remote access.exe",
-          "windowslauncher.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://simple-help.com/remote-support",
-          "https://simple-help.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_processes_sigma.yml"
         ]
       },
       "uuid": "c315bd0f-fe30-5d42-88f0-810e6d5032a4",
@@ -8967,5 +8748,5 @@
       "value": "Zoho Assist"
     }
   ],
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Problem

`clusters/rmm-tool.json` carries 295 values but only **288 distinct UUIDs**. Seven tools appear twice, each pair sharing both the same `uuid` and the same `value`:

- Instant Housecall
- ISL Online
- ITSupport247 (ConnectWise)
- Level.io
- N-Able Advanced Monitoring Agent
- NetSupport Manager
- SimpleHelp

The schema's `uniqueItems` on `values` did not catch this because the two copies are not byte-identical — each pair differs slightly in `meta`. For example SimpleHelp has one copy with `author: Phyo Paing Htun`, `ports: ["443"]`, `created: 2025-03-05` and an extra Huntress reference, and one copy without any of them.

This is the only duplicate-UUID-within-a-file case and the only duplicate-value-name case anywhere in the repository.

Downstream this matters: `tools/mkdocs/modules/galaxy.py` keys clusters by uuid, so one copy of each pair is silently dropped and never renders on the documentation site.

## Fix

Merge each pair into a single value, taking the **union** of both copies so nothing is lost:

- list-valued `meta` fields (`domains`, `installation_paths`, `refs`, `detection_descriptions`, `supported_os`, `ports`) are unioned order-preservingly
- `created` takes the earliest date, `last_modified` the latest
- any other scalar present in only one copy is kept (e.g. SimpleHelp's `author`)
- `description` was identical in all seven pairs, so it is untouched
- `version` 1 → 2

## Verification

```
before: 295 values, 7 duplicated uuids
after : 288 values, 0 duplicated uuids, 0 duplicated names, version=2

original values: 295 -> new: 288
distinct uuids in original: 288
content lost or altered: 0
```

Every list entry, description and scalar from **both** copies of all seven pairs is present in the merged value — verified field by field against `origin/main`. The file re-validates against `schema_clusters.json`.

Date resolution, for the one pair where the dates differed:

```
SimpleHelp   created=2024-08-02  last_modified=2025-03-05
             (from ['2025-03-05','2024-08-02'] / ['2025-03-05','2024-08-02'])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
