### PR TITLE
[high] fix: tidal-software and nace sit below an already-published version, so they never sync

### DIFF
--- a/clusters/nace.json
+++ b/clusters/nace.json
@@ -35054,5 +35054,5 @@
       "value": "9900"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/tidal-software.json
+++ b/clusters/tidal-software.json
@@ -36486,5 +36486,5 @@
       "value": "ZxxZ"
     }
   ],
-  "version": 1
+  "version": 3
 }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Two clusters sit below an already-published `version`, so instances never sync them.

- **Problem** — MISP only re-imports a galaxy cluster when its `version` is higher than the one an instance already holds. `clusters/tidal-software.json` is at 1 at HEAD but was previously published at 2, and `clusters/nace.json` is at 2 but was published at 2.1, so instances holding those historic revisions silently ignore every change since.
- **Fix** — Bump both files to `version` 3, one above the highest either has ever carried, with no content changes.
- **Effect** — Every instance re-imports both clusters regardless of which historic version it is holding.
<!-- /bluf -->

## Problem

MISP gates galaxy synchronisation on the `version` field: an instance only re-imports a cluster whose version is **higher** than the one it already holds. Two clusters currently sit at a version that has already been published with different content, so those instances will never pick up their current state.

Walking every revision of each file on `origin/main` and reading the `version` out of each blob:

```
clusters/tidal-software.json  HEAD=1  historic_max=2    revisions=16
    version sequence (newest first): [1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1]
clusters/nace.json            HEAD=2  historic_max=2.1  revisions=3
    version sequence (newest first): [2, 1, 2.1]
```

- **`tidal-software.json`** was published at version 2, then dropped back to 1 and has stayed there through 11 further revisions. Any instance that saw version 2 ignores everything since.
- **`nace.json`** was published at `2.1` — a float, which `schema_clusters.json` would reject today (`"version": {"type": "integer"}`) — then went to 1, then to 2. An instance holding 2.1 ignores the current file.

I checked the other clusters the audit flagged for in-branch version decreases (`atrm.json`, `threat-actor.json`, `tidal-references.json`); all three are at or above their historic maximum at HEAD and need nothing.

## Fix

Bump both to **3**, one above the highest version either file has ever carried, so every instance re-imports regardless of which historic revision it holds. No content changes.

Both files re-validate against `schema_clusters.json`.

## Note

The underlying gap — content can change without the version moving — is not addressed here. That is submitted separately as a CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

