### PR TITLE
[high] fix: add_missing_attribution-confidence.py is 100% non-functional (dict has no .set)

### DIFF
--- a/tools/add_missing_attribution-confidence.py
+++ b/tools/add_missing_attribution-confidence.py
@@ -9,18 +9,18 @@ parser = argparse.ArgumentParser(description='Add missing attribution-confidence
 parser.add_argument("-f", "--filename", required=True, help="name of the cluster")
 args = parser.parse_args()
 
-with open(args.filename) as json_file:
+with open(args.filename, encoding='utf-8') as json_file:
     data = json.load(json_file)
-    json_file.close()
 
     for value in data['values']:
         if value.get('meta'):
             if not value.get('meta').get('attribution-confidence') and (value.get('meta').get('cfr-suspected-state-sponsor') or value.get('meta').get('country')):
-                value.set('meta')['attribution-confidence'] = "50"
+                value.get('meta')['attribution-confidence'] = "50"
             elif value.get('meta').get('attribution-confidence')  and (value.get('meta').get('cfr-suspected-state-sponsor') or value.get('meta').get('country')):
                 value.get('meta')['attribution-confidence'] = str(value.get('meta').get('attribution-confidence'))
 
 
 
-with open(args.filename, 'w') as json_file:
+with open(args.filename, 'w', encoding='utf-8') as json_file:
     json.dump(data, json_file, indent=2, sort_keys=True, ensure_ascii=False)
+    json_file.write('\n')


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `add_missing_attribution-confidence.py` crashes on `dict.set()` and has never completed a run.

- **Problem** — `tools/add_missing_attribution-confidence.py` calls `value.set('meta')` on a plain dict, which has no `.set()`, and that line is the only thing the tool exists to do — assign the default confidence of 50. Against the current `clusters/threat-actor.json`, 319 of 1,043 values with `meta` take that branch.
- **Fix** — Correct the call to `value.get('meta')`, add `utf-8` encoding to the read and the write, emit a trailing newline and drop a redundant `close()`.
- **Effect** — The tool runs to completion, and the write, which already used `ensure_ascii=False`, no longer truncates the file before raising under a C locale.
<!-- /bluf -->

## Problem

`tools/add_missing_attribution-confidence.py` calls a method that does not exist on a dict:

```python
if not value.get('meta').get('attribution-confidence') and (...):
    value.set('meta')['attribution-confidence'] = "50"      # <-- dicts have no .set()
elif value.get('meta').get('attribution-confidence') and (...):
    value.get('meta')['attribution-confidence'] = str(...)  # <-- the correct form, two lines down
```

The `.set(...)` line is the *only* thing this tool exists to do — assign the default confidence — so the tool dies the first time a value needs one:

```
value.set('meta')['attribution-confidence'] = "50"
^^^^^^^^^
AttributeError: 'dict' object has no attribute 'set'. Did you mean: 'get'?
exit=1
```

Measured against the current `clusters/threat-actor.json`: of 1,043 values with `meta`, **319 take the crashing branch**. The tool has never completed a run.

## Fix

- `value.set('meta')` → `value.get('meta')`, matching the working form on the next branch.
- Add `encoding='utf-8'` to both the read and the write. The write already passes `ensure_ascii=False`, so under a C locale it would raise `UnicodeEncodeError` *after* opening the file for writing — i.e. after truncating it.
- Emit a trailing newline, matching the committed formatting of every cluster file.
- Drop the redundant `json_file.close()` inside the `with` block.

## Verification

```
=== run the fixed tool ===
  exit=0

=== what changed ===
  attribution-confidence added         : 319
  attribution-confidence coerced to str: 0
  any other field changed              : 0
  values total unchanged               : True

=== schema + idempotence ===
  baseline:        0 failures against schema_clusters.json
  after the tool:  0 failures against schema_clusters.json
  second run is a no-op: yes
```

Only `attribution-confidence` is ever touched; no other field on any of the 1,043 values changes, and a second run is a byte-for-byte no-op.

## Scope

This PR fixes the tool only. It does **not** commit the 319 resulting `attribution-confidence` entries to `clusters/threat-actor.json` — that is a data change for a maintainer to make deliberately (and would want a `version` bump), not a side effect of a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

