### PR TITLE
[critical] fix: update_README_with_index.py truncates README.md to 21 lines if a heading is renamed

### DIFF
--- a/tools/update_README_with_index.py
+++ b/tools/update_README_with_index.py
@@ -43,27 +43,40 @@ for f in galaxies_fnames:
     output.append(f"\n[[HTML](https://www.misp-galaxy.org/{link})] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/{f})]\n\n")
 
 # update the README.md
-readme_out = []
 readme_marker_start = '# Available Galaxy - clusters'
 readme_marker_end = '# Online documentation'
-with open('../README.md', 'r') as f:
-    skip = False
-    for line in f:
-        if not skip:
-            readme_out.append(line)
-        if line.strip() == readme_marker_start:
-            skip = True
-        if line.strip() == readme_marker_end:
-            # append the index
-            readme_out.append("\n")
-            readme_out += output
-            readme_out.append("\n")
-            readme_out.append(line)
-            # stop skipping
-            skip = False
+with open('../README.md', 'r', encoding='utf-8') as f:
+    readme_lines = f.readlines()
 
+# Locate both markers up front. The generated index replaces everything
+# between them, so if either is missing -- renamed heading, reordered
+# README -- the rebuild would silently truncate the file from the start
+# marker onwards. Refuse to write instead.
+start_idx = end_idx = None
+for i, line in enumerate(readme_lines):
+    stripped = line.strip()
+    if stripped == readme_marker_start and start_idx is None:
+        start_idx = i
+    elif stripped == readme_marker_end and start_idx is not None:
+        end_idx = i
+        break
 
-with open('../README.md', 'w') as f:
+if start_idx is None or end_idx is None:
+    missing = readme_marker_start if start_idx is None else readme_marker_end
+    raise SystemExit(
+        f"ERROR: marker {missing!r} not found in ../README.md (start={start_idx}, "
+        f"end={end_idx}). README.md left unchanged -- the index is inserted "
+        f"between {readme_marker_start!r} and {readme_marker_end!r}, so both "
+        f"headings must be present, in that order."
+    )
+
+readme_out = readme_lines[:start_idx + 1]
+readme_out.append("\n")
+readme_out += output
+readme_out.append("\n")
+readme_out += readme_lines[end_idx:]
+
+with open('../README.md', 'w', encoding='utf-8') as f:
     f.write(''.join(readme_out))
 
 print("README.md updated with the index of the galaxies.")


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `update_README_with_index.py` can silently truncate `README.md` to 21 lines and still exit 0.

- **Problem** — `tools/update_README_with_index.py` rebuilds the galaxy index by streaming `README.md` and skipping lines between two exact heading markers, clearing its skip flag only on a literal match of `# Online documentation`. Rename, reword or move that heading above the start marker and everything after `# Available Galaxy - clusters` is dropped, then written back unconditionally with exit 0.
- **Fix** — Locate both markers up front, refuse to write with a non-zero exit if either is missing or out of order, rebuild by slicing, and add `utf-8` encoding.
- **Effect** — Maintainers get a clear error instead of a silently gutted `README.md`.
<!-- /bluf -->

## Problem

`tools/update_README_with_index.py` rebuilds the galaxy index in `README.md` by streaming the file and skipping everything between two heading markers:

```python
readme_marker_start = '# Available Galaxy - clusters'
readme_marker_end = '# Online documentation'
with open('../README.md', 'r') as f:
    skip = False
    for line in f:
        if not skip:
            readme_out.append(line)
        if line.strip() == readme_marker_start:
            skip = True
        if line.strip() == readme_marker_end:
            ...
            skip = False
```

`skip` is only ever cleared by an **exact** match on `# Online documentation`. If that heading is renamed, reworded, or moved above the start marker, `skip` stays `True` for the rest of the file — so every line after `# Available Galaxy - clusters` is dropped. The script then overwrites `README.md` unconditionally, with no check that it produced anything sensible, and **exits 0**.

## Reproduction

Renaming the end heading to `# Docs online` and running the committed script:

```
README lines before: 1005
  -- committed version --
     exit=0  README lines after: 21      <-- README destroyed, exit code says success
  -- fixed version --
     exit=1  README lines after: 1005    <-- refused, README intact
     stderr: ERROR: marker '# Online documentation' not found in ../README.md (start=20, end=None). README.md left unchanged...
```

## Fix

Read the file once, locate **both** markers up front, and refuse to write if either is missing (or if the end marker does not follow the start marker). The rebuild then becomes a straightforward slice — `[:start+1] + index + [end:]` — with no streaming state machine to get stuck in.

Also adds `encoding='utf-8'` to the README read and write.

## Verification

Running the fixed script against the real repository leaves `README.md` **byte-identical** — the rewrite is output-equivalent to the original on the happy path, and confirms the committed index is not stale:

```
=== fixed tool on the real README ===
  exit=0
  README.md changed: no
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

