### PR TITLE
fix: 299 meta values break their markdown table (raw newlines and pipes)

### DIFF
--- a/tools/mkdocs/modules/cluster.py
+++ b/tools/mkdocs/modules/cluster.py
@@ -1,5 +1,19 @@
 import validators
 
+
+def _escape_table_cell(value):
+    """Make a meta value safe to drop into a markdown table cell.
+
+    A raw newline ends the row -- and, because these tables live inside an
+    indented ``??? info`` admonition, it ends the admonition too -- while a
+    raw ``|`` splits the row into extra columns. 223 meta values contain a
+    newline and 76 contain a pipe.
+    """
+    text = str(value)
+    text = text.replace("|", "\\|")
+    return text.replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+
 class Cluster:
     def __init__(self, uuid, galaxy, description=None, value=None, meta=None):
         self.uuid = uuid
@@ -97,9 +111,7 @@ class Cluster:
             entry += f"    |-----------------------------------|-----|\n"
             for meta in sorted(self.meta.keys()):
                 if meta not in excluded_meta:
-                    if meta == 'outcome':
-                        self.meta[meta] = self.meta[meta].replace("\n", ".")
-                    entry += f'    | {meta} | {self.meta[meta]} |\n'
+                    entry += f'    | {meta} | {_escape_table_cell(self.meta[meta])} |\n'
         return entry
 
     def _create_related_entry(self):


### PR DESCRIPTION
## Problem

`Cluster._create_associated_metadata_entry()` drops raw meta values into a markdown table:

```python
for meta in sorted(self.meta.keys()):
    if meta not in excluded_meta:
        if meta == 'outcome':
            self.meta[meta] = self.meta[meta].replace("\n", ".")
        entry += f'    | {meta} | {self.meta[meta]} |\n'
```

Only the `outcome` key is sanitised, and only for newlines. Every other key goes in verbatim:

- a raw **newline** ends the table row — and because these tables are indented inside a `??? info "Associated metadata"` admonition, it ends the admonition too, so the rest of the block escapes into the page body
- a raw **`|`** splits the row into extra columns

Measured over all 232,257 meta cells that reach a table:

```
cells containing a newline: 223 across 3 files
    plot4ai.json 203, first-csirt-services-framework.json 19, scor-detection-signatures.json 1
cells containing a pipe   :  76 across 8 files
    tidal-references.json 40, election-guidelines.json 23, ransomware.json 7, sigma-rules.json 2, ...
```

e.g. `election-guidelines.json` / *Tampering with registrations*:

```
    | kill_chain | ['example-of-threats:setup | party/candidate-registration'] |
```

— four pipes, so the renderer sees a three-column row in a two-column table.

The `outcome` branch also **mutates `self.meta` in place**, editing the parsed cluster data as a side effect of rendering.

## Fix

A single `_escape_table_cell()` helper applied to every value: `|` → `\|`, and newlines → `<br>` (which keeps the content and renders as a line break inside the cell, rather than discarding it as the old `outcome` special case did with `.`). No mutation of `self.meta`.

## Verification

Rendering every value whose meta contains a newline or a pipe, with the committed `cluster.py` loaded from `origin/main` for the "before" column, and counting rows that do not have exactly two columns:

```
values with a newline or pipe in meta: 249
malformed table rows -- committed version: 279
malformed table rows -- fixed version   : 0
```

```
--- before ---
    | kill_chain | ['example-of-threats:setup | party/candidate-registration'] |
--- after ---
    | kill_chain | ['example-of-threats:setup \| party/candidate-registration'] |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
