### PR TITLE
fix: generator.py reports success when relation pages fail to write

### DIFF
--- a/tools/mkdocs/generator.py
+++ b/tools/mkdocs/generator.py
@@ -184,6 +184,12 @@ if __name__ == "__main__":
         with ThreadPoolExecutor(
             max_workers=(multiprocessing.cpu_count() * 4)
         ) as executor:
-            executor.map(write_relations_table, galaxy.clusters.values())
+            # executor.map returns a lazy iterator: an exception raised in a
+            # worker is stored in its Future and only re-raised when that
+            # result is consumed. Discarding the iterator therefore swallows
+            # every failure, and the build reports success with relation
+            # pages silently missing. Draining it propagates the first one.
+            for _ in executor.map(write_relations_table, galaxy.clusters.values()):
+                pass
 
     print(f"Finished in {time.time() - start_time} seconds")


### PR DESCRIPTION
## Problem

The relations pages are written through a thread pool whose result is thrown away:

```python
with ThreadPoolExecutor(max_workers=(multiprocessing.cpu_count() * 4)) as executor:
    executor.map(write_relations_table, galaxy.clusters.values())
```

`ThreadPoolExecutor.map` returns a **lazy iterator**. An exception raised inside a worker is captured in that worker's `Future` and only re-raised when the corresponding result is consumed. Nothing consumes it here, so every failure in `write_relations_table` is silently discarded — the `with` block exits cleanly, the loop moves to the next galaxy, and the script prints `Finished in ... seconds` and exits 0 with relation pages missing.

Note the contrast a few lines above, where the same file *does* consume its results and would surface a failure:

```python
with Pool(processes=multiprocessing.cpu_count()) as pool:
    result = pool.map(get_cluster_relationships, tasks)
```

## Reproduction

A worker that raises on one of six items:

```
=== committed form: executor.map(...) result discarded ===
  no exception raised -- build would report success
  workers that ran: 6

=== fixed form: iterator drained ===
  raised: RuntimeError: write_relations_table failed for cluster 3
  workers that ran: 5
```

## Fix

Drain the iterator so the first worker exception propagates and the build fails loudly instead of shipping an incomplete site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
