### PR TITLE
[high] fix: graph.js mouseover throws for all MITRE ATT&CK galaxies (invalid CSS selector)

### DIFF
--- a/tools/mkdocs/site/docs/01_attachements/javascripts/graph.js
+++ b/tools/mkdocs/site/docs/01_attachements/javascripts/graph.js
@@ -4,6 +4,17 @@ document$.subscribe(function () {
     // const NODE_COLOR = "#69b3a2";
     const Parent_Node_COLOR = "#ff0000";
 
+    // Galaxy names go into a CSS class and into the selector that looks it up
+    // again. Only [A-Za-z0-9_-] is safe there: 17 of the 131 galaxy names
+    // contain "&", "/", "(" or ")" -- every "MITRE ATT&CK *" galaxy among
+    // them -- and those produce a selector that makes querySelectorAll throw
+    // a DOMException, aborting the handler that issued it.
+    // Both the class attribute and the selectors go through this one function
+    // so they cannot drift apart.
+    function galaxyClass(name) {
+        return "galaxy-" + String(name).replace(/[^A-Za-z0-9_-]+/g, "-");
+    }
+
 
     function applyTableFilter(tf) {
         var valuesToSelect = ['1', '2', '3'];
@@ -125,7 +136,7 @@ document$.subscribe(function () {
             d3.select(this)
                 .attr("r", parseFloat(d3.select(this).attr("r")) + 5)
                 .style("opacity", 1);
-            d3.selectAll(".legend-text.galaxy-" + d.galaxy.replace(/\s+/g, '-').replace(/[\s.]/g, '-'))
+            d3.selectAll(".legend-text." + galaxyClass(d.galaxy))
                 .style("font-weight", "bold")
                 .style("font-size", "14px");
             link.filter(l => l.source.id === d.id || l.target.id === d.id)
@@ -145,7 +156,7 @@ document$.subscribe(function () {
                 node.style("opacity", 1);
                 link.style("opacity", 1);
                 d3.select(this).attr("r", d => d.id === Parent_Node.id ? NODE_RADIUS + 5 : NODE_RADIUS);
-                d3.selectAll(".legend-text.galaxy-" + d.galaxy.replace(/\s+/g, '-').replace(/[\s.]/g, '-'))
+                d3.selectAll(".legend-text." + galaxyClass(d.galaxy))
                     .style("font-weight", "normal")
                     .style("font-size", "12px");
                 link.filter(l => l.source.id === d.id || l.target.id === d.id)
@@ -227,7 +238,7 @@ document$.subscribe(function () {
             .style("text-anchor", "start")
             .style("fill", "grey")
             .style("font-size", "12px")
-            .attr("class", d => "legend-text galaxy-" + d.name.replace(/\s+/g, '-').replace(/[\s.]/g, '-'))
+            .attr("class", d => "legend-text " + galaxyClass(d.name))
             .text(d => d.name.length > maxCharLength ? d.name.substring(0, maxCharLength) + "..." : d.name)
             .on("mouseover", mouseoverEffect)
             .on("mouseout", mouseoutEffect);
@@ -238,7 +249,7 @@ document$.subscribe(function () {
             link.style("opacity", 0.1);
 
             // Highlight elements associated with the hovered galaxy
-            svg.selectAll(".galaxy-" + d.name.replace(/\s+/g, '-').replace(/[\s.]/g, '-'))
+            svg.selectAll("." + galaxyClass(d.name))
                 .each(function () {
                     d3.select(this).style("opacity", 1); // Increase opacity for related elements
                 });
@@ -329,7 +340,7 @@ document$.subscribe(function () {
             .attr("fill", function (d, i) {
                 return d.id === Parent_Node.id ? Parent_Node_COLOR : colorScale(d.galaxy);
             })
-            .attr("class", d => "node galaxy-" + d.galaxy.replace(/\s+/g, '-').replace(/[\s.]/g, '-'));
+            .attr("class", d => "node " + galaxyClass(d.galaxy));
 
         initializeNodeInteractions(node, link, tooltip, simulation, links, Parent_Node, NODE_RADIUS);
         createGalaxyColorLegend(svg, width, galaxies, colorScale, node, link, tooltip);
@@ -366,7 +377,7 @@ document$.subscribe(function () {
                             .attr("fill", function (d, i) {
                                 return d.id === Parent_Node.id ? Parent_Node_COLOR : colorScale(d.galaxy);
                             })
-                            .attr("class", d => "node galaxy-" + d.galaxy.replace(/\s+/g, '-').replace(/[\s.]/g, '-')),
+                            .attr("class", d => "node " + galaxyClass(d.galaxy)),
                         update => update,
                         exit => exit.remove()
                     );


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `graph.js` mouseover throws for every MITRE ATT&CK galaxy because the CSS selector is invalid

- **Problem** — `graph.js` builds a CSS class from a galaxy name with an expression that only strips whitespace and dots, then queries with the same expression, so any other character goes into the selector raw and `document.querySelectorAll` throws a `DOMException` that aborts the mouseover handler. 17 of the 131 galaxy names hit this, including every MITRE ATT&CK galaxy (the ampersand), plus names containing parentheses and a slash.
- **Fix** — Introduce one `galaxyClass()` helper replacing every character outside `[A-Za-z0-9_-]`, used at all six assign and select sites so the two cannot drift.
- **Effect** — Node highlight, legend emphasis and link highlighting work again on the galaxies people browse most.
<!-- /bluf -->

## Problem

`graph.js` builds a CSS class from a galaxy name and later looks it up with a selector built the same way — six sites, all carrying a copy of the same expression:

```js
d3.selectAll(".legend-text.galaxy-" + d.galaxy.replace(/\s+/g, '-').replace(/[\s.]/g, '-'))
```

Only whitespace and `.` are replaced. Everything else goes into the selector untouched, and a class selector may only contain `[A-Za-z0-9_-]` (plus non-ASCII and escapes). `document.querySelectorAll` throws a `DOMException` on anything else, which aborts the handler that called it.

**17 of the 131 galaxy names produce an invalid selector** — including every `MITRE ATT&CK *` galaxy:

```
"MITRE ATT&CK Techniques"     -> .galaxy-MITRE-ATT&CK-Techniques      (&)
"MITRE ATT&CK Groups"         -> .galaxy-MITRE-ATT&CK-Groups          (&)
"Concealment Layers ... (CLOAK)" -> .galaxy-...-Knowledge-(CLOAK)     ( and )
"UAVs/UCAVs"                  -> .galaxy-UAVs/UCAVs                   (/)
```

15 names contain `&`, one contains `()`, one contains `/`. Hovering a node in any of those galaxies throws, so the mouseover highlight, the legend emphasis and the link highlighting all stop working for exactly the galaxies people use most.

## Fix

One `galaxyClass()` helper that replaces every character outside `[A-Za-z0-9_-]`, used at all six sites — the three that *assign* the class and the three that *select* on it — so the two can no longer drift apart.

All 131 galaxy names are ASCII (checked), so no non-ASCII identifiers are being flattened, and no stylesheet hardcodes these class names (`grep -rn "galaxy-" stylesheets/` is empty), so renaming them affects nothing else.

## Verification

```
galaxies: 131
invalid class selectors -- committed expression: 17
invalid class selectors -- galaxyClass()       : 0

  "MITRE ATT&CK Analytics"
      before: .galaxy-MITRE-ATT&CK-Analytics
      after : .galaxy-MITRE-ATT-CK-Analytics
  "UAVs/UCAVs"
      before: .galaxy-UAVs/UCAVs
      after : .galaxy-UAVs-UCAVs
```

`node --check graph.js` passes, and no hand-rolled copy of the expression remains in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

