### PR TITLE
[high] harden: graph tooltip renders contributor-supplied names as innerHTML

### DIFF
--- a/tools/mkdocs/site/docs/01_attachements/javascripts/graph.js
+++ b/tools/mkdocs/site/docs/01_attachements/javascripts/graph.js
@@ -117,7 +117,7 @@ document$.subscribe(function () {
             tooltip.transition()
                 .duration(200)
                 .style("opacity", .9);
-            tooltip.html(d.id)
+            tooltip.text(d.id)
                 .style("left", (event.pageX) + "px")
                 .style("top", (event.pageY - 28) + "px");
             node.style("opacity", 0.1);
@@ -247,7 +247,7 @@ document$.subscribe(function () {
             tooltip.transition()
                 .duration(200)
                 .style("opacity", .9);
-            tooltip.html(d.name)
+            tooltip.text(d.name)
                 .style("left", (event.pageX) + "px")
                 .style("top", (event.pageY - 28) + "px");
         }


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The misp-galaxy.org graph tooltip renders contributor-supplied names as `innerHTML`

- **Problem** — `tools/mkdocs/site/docs/01_attachements/javascripts/graph.js` passes contributor-supplied strings to d3's `.html()`, which assigns `innerHTML`: line 120 renders a cluster `value` and line 250 a galaxy `name`, both taken straight from `clusters/*.json` and `galaxies/*.json`, which anyone can change via a pull request.
- **Fix** — Switch both call sites to `.text()`, so the tooltip sets `textContent`.
- **Effect** — Markup landing in those files can no longer be parsed and executed as HTML for site visitors, and PR review stops being the only barrier to script execution.
<!-- /bluf -->

## Problem

The graph tooltip renders contributor-supplied strings through d3's `.html()`, which assigns `innerHTML`:

```js
tooltip.html(d.id)     // line 120 -- d.id is a cluster `value`
tooltip.html(d.name)   // line 250 -- d.name is a galaxy `name`
```

Both come straight from `clusters/*.json` and `galaxies/*.json`, which anyone can change by opening a pull request. Any markup in a cluster value would be parsed and executed as HTML by every visitor to misp-galaxy.org.

## Honest scope: this is hardening, not a live bug

I checked, and there is nothing to clean up in the data today:

```
cluster values: 56131
  values that look like they contain an HTML tag (<[a-zA-Z/!]): 0
  values containing an HTML entity sequence (&foo; / &#N;):     0
```

The 1,720 values containing `<` or `>` are all things like `Other (Action > Environmental > Variety)`, and the 414 containing `&` are `ATT&CK`-style names — none of which forms a tag or a decodable entity, so nothing renders wrongly right now.

The point is that the *only* thing standing between a malicious cluster value and script execution on the published site is PR review. `.text()` removes that dependency, and it is a two-character change.

## Fix

Use `.text()` (sets `textContent`) instead of `.html()` at both tooltip sites. The tooltip displays a plain name; it has never needed markup.

`node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

