### PR TITLE
[high] fix: naics, china-defence-universities and gsma-motif galaxy are never written by their generators

### DIFF
--- a/tools/gen_defence_university.py
+++ b/tools/gen_defence_university.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import requests
 import json
+import os
 from bs4 import BeautifulSoup
 import bs4
 import uuid
@@ -178,7 +179,27 @@ def _fetchArticle(url):
     return article
 
 
-def _gen_galaxy(scrape):
+def _load_committed_uuids(path):
+    """Map value -> uuid from the cluster this run is about to overwrite.
+
+    Every entry below is minted with uuid4(), so without this a regeneration
+    would replace all 159 universities with fresh uuids and orphan every
+    `related` edge pointing at them.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            committed = json.load(f)
+    except (FileNotFoundError, ValueError):
+        return {}
+    return {
+        v["value"].strip().casefold(): v["uuid"]
+        for v in committed.get("values", [])
+        if v.get("value") and v.get("uuid")
+    }
+
+
+def _gen_galaxy(scrape, committed_uuids=None):
+    committed_uuids = committed_uuids or {}
     base = {
         "authors": [
             "Australian Strategic Policy Institute"
@@ -204,7 +225,7 @@ def _gen_galaxy(scrape):
             "value": ""
         }
 
-        new_template["uuid"] = str(uuid.uuid4())
+        # placeholder; replaced below once the value is known
 
         new_template["meta"]["refs"].append(uni["url"])
 
@@ -260,6 +281,12 @@ def _gen_galaxy(scrape):
             if uni.get(uni["location"][0]["long"]) != "":
                 new_template["meta"]["long"] = uni["location"][0]["long"]
 
+        # Reuse the uuid already committed for this university; only a
+        # genuinely new entry gets a freshly minted one.
+        new_template["uuid"] = committed_uuids.get(
+            new_template["value"].strip().casefold()
+        ) or str(uuid.uuid4())
+
         base["values"].append(new_template)
 
     return base
@@ -283,12 +310,18 @@ def main():
         else:
             head = "bloop"
 
-    galaxy = _gen_galaxy(articles)
+    cluster_path = os.path.join('..', 'clusters', 'china-defence-universities.json')
+    galaxy = _gen_galaxy(articles, _load_committed_uuids(cluster_path))
 
     print(galaxy)
 
-    with open("china-defence-universities.json", "w") as g:
-        g.write(json.dumps(galaxy, indent=4, sort_keys=True))
+    # Was: open("china-defence-universities.json", "w") -- written into the
+    # current directory, so clusters/china-defence-universities.json was
+    # never updated.
+    with open(cluster_path, 'w', encoding='utf-8') as g:
+        json.dump(galaxy, g, indent=2, sort_keys=True, ensure_ascii=False)
+        g.write('\n')  # match jq_all_the_things.sh formatting
+    print("Wrote %s" % cluster_path)
 
 
 if __name__ == "__main__":

--- a/tools/gen_gsma_motif.py
+++ b/tools/gen_gsma_motif.py
@@ -278,12 +278,13 @@ json_cluster = {
 
 
 # save the Galaxy and Cluster file
-# with open(os.path.join('..', 'galaxies', galaxy_fname), 'w') as f:
-#     # sort_keys, even if it breaks the kill_chain_order , but jq_all_the_things requires sorted keys
-#     json.dump(json_galaxy, f, indent=2, sort_keys=True, ensure_ascii=False)
-#     f.write('\n')  # only needed for the beauty and to be compliant with jq_all_the_things
+# sort_keys only orders dict keys; the kill_chain_order phase *lists* keep
+# their order, so this matches the committed galaxies/gsma-motif.json exactly.
+with open(os.path.join('..', 'galaxies', galaxy_fname), 'w', encoding='utf-8') as f:
+    json.dump(json_galaxy, f, indent=2, sort_keys=True, ensure_ascii=False)
+    f.write('\n')  # only needed for the beauty and to be compliant with jq_all_the_things
 
-with open(os.path.join('..', 'clusters', galaxy_fname), 'w') as f:
+with open(os.path.join('..', 'clusters', galaxy_fname), 'w', encoding='utf-8') as f:
     json.dump(json_cluster, f, indent=2, sort_keys=True, ensure_ascii=False)
     f.write('\n')  # only needed for the beauty and to be compliant with jq_all_the_things
 

--- a/tools/generate_naics_clusters.py
+++ b/tools/generate_naics_clusters.py
@@ -8,6 +8,7 @@
 #Note 3 : New uuids are generated on every run (fixed)
 
 import json
+import os
 import csv
 import uuid
 
@@ -96,7 +97,10 @@ with open('naics.csv', newline='') as csvfile:
 
 galaxy['values']=values
 
-tojson = json.dumps(galaxy, indent=2)
-jsonFile = open("naisc_cluster.json", "w")
-jsonFile.write(tojson)
-jsonFile.close()
+# Was: open("naisc_cluster.json", "w") -- a misspelling of "naics", written
+# into the current directory, so clusters/naics.json was never updated.
+cluster_path = os.path.join('..', 'clusters', 'naics.json')
+with open(cluster_path, 'w', encoding='utf-8') as jsonFile:
+    json.dump(galaxy, jsonFile, indent=2, sort_keys=True, ensure_ascii=False)
+    jsonFile.write('\n')  # match jq_all_the_things.sh formatting
+print("Wrote %s" % cluster_path)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Three generators never write the clusters and galaxy they claim to maintain, and say nothing

- **Problem** — `generate_naics_clusters.py` writes a misspelled `naisc_cluster.json` into the current directory, `gen_defence_university.py` writes `china-defence-universities.json` into the current directory, and `gen_gsma_motif.py` has its galaxy write commented out while still printing success. Maintainers get a stray file in `tools/` and stale `clusters/naics.json`, `clusters/china-defence-universities.json` and the gsma-motif galaxy, with no error.
- **Fix** — Point all three at `../clusters/` and `../galaxies/` with utf-8, `indent=2`, `sort_keys` and a trailing newline, so output already matches `jq_all_the_things.sh`, and make the silent ones print the path written.
- **Effect** — Running a generator actually updates its cluster or galaxy, and says where.
<!-- /bluf -->

## Problem

Three generators do not write to the files they claim to maintain.

**`tools/generate_naics_clusters.py:100`** — writes a *misspelled* filename into the current directory:

```python
jsonFile = open("naisc_cluster.json", "w")   # "naisc", and no path
```

`clusters/naics.json` is never touched. Running the generator produces a stray file in `tools/` and leaves the real cluster untouched — while reporting nothing.

**`tools/gen_defence_university.py:290`** — same shape:

```python
with open("china-defence-universities.json", "w") as g:
```

`clusters/china-defence-universities.json` is never updated.

**`tools/gen_gsma_motif.py:281-284`** — the galaxy write is commented out, but the script still prints a success message:

```python
# with open(os.path.join('..', 'galaxies', galaxy_fname), 'w') as f:
#     # sort_keys, even if it breaks the kill_chain_order, but jq_all_the_things requires sorted keys
#     json.dump(json_galaxy, f, indent=2, sort_keys=True, ensure_ascii=False)

with open(os.path.join('..', 'clusters', galaxy_fname), 'w') as f:   # cluster IS written
    ...
print("All done, please don't forget to ./jq_all_the_things.sh, commit, and then ./validate_all.sh.")
```

So the cluster is regenerated and the galaxy silently is not.

## Fix

All three now write to `../clusters/...` / `../galaxies/...` — the same relative form the other generators in `tools/` use — with `encoding='utf-8'`, `indent=2`, `sort_keys=True` and a trailing newline, so their output already matches what `jq_all_the_things.sh` would produce. The two that were silent now print the path they wrote.

**The commented-out concern in `gen_gsma_motif.py` was unfounded**: `sort_keys` orders dict *keys*, not list elements, so the `kill_chain_order` phase sequence is unaffected. Verified — dumping the committed galaxy with those exact options round-trips byte-identically:

```
galaxies/ write uncommented: True
sort_keys=True round-trip is byte-identical to the committed file: True
kill_chain_order phase order preserved: ['Reconnaissance', 'Resource-Development', 'Initial-Access'] ...
```

### One coupled change

Pointing `gen_defence_university.py` at the real cluster makes its per-entry `uuid.uuid4()` destructive — a first real run would replace all 159 universities with new uuids and orphan every `related` edge. So this PR also has it reuse the uuid already committed for each university, minting a fresh one only for a genuinely new entry:

```
committed values: 159 | uuid map entries: 159
values whose committed uuid would be reused: 159 / 159
```

Without that, the path fix would be a regression rather than a fix.

## Verification

```
=== write paths now point at the committed files ===
  generate_naics_clusters.py    -> clusters/naics.json                        OK
  gen_defence_university.py     -> clusters/china-defence-universities.json   OK
  gen_gsma_motif.py             -> galaxies/gsma-motif.json                   OK
```

No stray current-directory `open()` calls remain (the old paths survive only inside explanatory comments). All three compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

