### PR TITLE
[critical] fix: ransomlook_update.py truncates clusters/ransomware.json then fails to write

### DIFF
--- a/tools/ransomware/ransomlook_update.py
+++ b/tools/ransomware/ransomlook_update.py
@@ -7,9 +7,8 @@ from pathlib import Path
 
 # open clusters/ransomware
 ransompath = Path(__file__).parent.parent.parent / 'clusters' / 'ransomware.json'
-ransomware_galaxy = ransompath.open("r")
-ransom_galaxy = json.load(ransomware_galaxy)
-ransomware_galaxy.close()
+with ransompath.open("r", encoding="utf-8") as ransomware_galaxy:
+    ransom_galaxy = json.load(ransomware_galaxy)
 
 # get groups names from ransomlook
 ransomlook_groups = requests.get("https://www.ransomlook.io/api/groups")
@@ -147,6 +146,14 @@ print("\nTotal modified :" + str(len(updated) + len(created)))
 ransom_galaxy['version'] = ransom_galaxy['version'] + 1
 
 tojson = json.dumps(ransom_galaxy, indent=2, ensure_ascii=False)
-ransomware_galaxy = ransompath.open("w+")
-ransomware_galaxy.write(tojson)
-ransomware_galaxy.close()
+
+# Serialise to a temp file next to the target and replace it only once the
+# write has completed. `ransompath.open("w+")` truncated clusters/ransomware.json
+# before writing a byte, and without an explicit encoding the ensure_ascii=False
+# payload raises UnicodeEncodeError under a non-UTF-8 locale -- destroying the
+# cluster with no recovery path.
+tmppath = ransompath.with_suffix(".json.tmp")
+with tmppath.open("w", encoding="utf-8") as ransomware_galaxy:
+    ransomware_galaxy.write(tojson)
+    ransomware_galaxy.write("\n")  # match jq_all_the_things.sh formatting
+tmppath.replace(ransompath)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `ransomlook_update.py` can truncate `clusters/ransomware.json` to 0 bytes and then fail to write

- **Problem** — `tools/ransomware/ransomlook_update.py` opens `clusters/ransomware.json` with `open("w+")`, truncating the committed cluster before anything is written, and passes no `encoding=` while serialising with `ensure_ascii=False`; under a C/POSIX locale the write then raises `UnicodeEncodeError` on non-ASCII group names, leaving a 0-byte cluster file and a traceback with no recovery path.
- **Fix** — Serialise to a temp file alongside the target and atomically `Path.replace()` it into position, with explicit utf-8 on both the read and the write.
- **Effect** — Running the updater can no longer destroy the ransomware cluster.
<!-- /bluf -->

## Problem

`tools/ransomware/ransomlook_update.py` writes the updated cluster like this:

```python
tojson = json.dumps(ransom_galaxy, indent=2, ensure_ascii=False)
ransomware_galaxy = ransompath.open("w+")
ransomware_galaxy.write(tojson)
ransomware_galaxy.close()
```

Two problems compound into data loss:

1. **`open("w+")` truncates `clusters/ransomware.json` before a single byte is written.** From that moment the committed cluster only exists in the process's memory.
2. **No `encoding=`, while `json.dumps` was given `ensure_ascii=False`.** The payload therefore contains non-ASCII characters (ransomware group names routinely do), and Python encodes it with the locale default. Under a `POSIX`/`C` locale that is ASCII, so `write()` raises `UnicodeEncodeError` — *after* the truncation.

The result is a 0-byte `clusters/ransomware.json` and a traceback, with no recovery path.

The read at the top of the file has the same missing `encoding=` and would fail to parse the cluster's non-ASCII content under the same locale.

## Reproduction

```
committed cluster: 110 bytes

=== OLD: ransompath.open('w+') with no encoding, under a C locale ===
  raised UnicodeEncodeError: 'ascii' codec can't encode character '\xe7' ...
  cluster after: 0 bytes  <-- truncated by open('w+') before the failure

=== NEW: temp file with explicit utf-8, then replace ===
  wrote OK
  cluster after: 110 bytes
  content round-trips: True
  byte-identical to the committed form: True
```

## Fix

- Serialise to a temp file alongside the target and `Path.replace()` it into place, so the cluster is only ever replaced by a complete, successfully written file. `replace()` is atomic on the same filesystem.
- `encoding="utf-8"` on both the read and the write, so the result does not depend on the caller's locale.
- Emit a trailing newline, matching the formatting `jq_all_the_things.sh` produces and every committed cluster has.
- Use `with` for the read instead of manual `open`/`close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

