### PR TITLE
[medium] fix: schema_clusters.json silently accepts any related entry (keywords on the array, not items)

### DIFF
--- a/clusters/android.json
+++ b/clusters/android.json
@@ -59,15 +59,15 @@
         "refs": [
           "https://www.bleepingcomputer.com/news/security/researchers-discover-new-android-banking-trojan/",
           "https://www.threatfabric.com/blogs/new_android_trojan_targeting_over_60_banks_and_social_apps.html"
+        ],
+        "synonyms": [
+          "Red Alert 2",
+          "Red Alert 2.0"
         ]
       },
       "related": [
         {
           "dest-uuid": "e9aaab46-abb1-4390-b37b-d0457d05b28f",
-          "synonyms": [
-            "Red Alert 2",
-            "Red Alert 2.0"
-          ],
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -4936,5 +4936,5 @@
       "value": "Mirax"
     }
   ],
-  "version": 24
+  "version": 25
 }

--- a/clusters/microsoft-activity-group.json
+++ b/clusters/microsoft-activity-group.json
@@ -1651,20 +1651,6 @@
           "type": "uses"
         },
         {
-          "dest-uuid": "",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "uses"
-        },
-        {
-          "dest-uuid": "",
-          "tags": [
-            "estimative-language:likelihood-probability=\"likely\""
-          ],
-          "type": "uses"
-        },
-        {
           "dest-uuid": "0125ef58-2675-426f-90eb-0b189961199a",
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
@@ -3775,5 +3761,5 @@
       "value": "ZIRCONIUM"
     }
   ],
-  "version": 23
+  "version": 24
 }

--- a/clusters/ransomware.json
+++ b/clusters/ransomware.json
@@ -5657,6 +5657,11 @@
     {
       "description": "Ransomware EXE was replaced to neutralize threat",
       "meta": {
+        "payment-method": "Bitcoin",
+        "price": "1-2 / 7 after 1 week",
+        "refs": [
+          "https://id-ransomware.blogspot.com/2016/05/booyah-ransomware-1-2-btc.html"
+        ],
         "synonyms": [
           "Salami"
         ]
@@ -5664,11 +5669,6 @@
       "related": [
         {
           "dest-uuid": "b95aa3fb-9f32-450e-8058-67d94f196913",
-          "payment-method": "Bitcoin",
-          "price": "1-2 / 7 after 1 week",
-          "refs": [
-            "https://id-ransomware.blogspot.com/2016/05/booyah-ransomware-1-2-btc.html"
-          ],
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -42417,5 +42417,5 @@
       "value": "crpx0"
     }
   ],
-  "version": 172
+  "version": 173
 }

--- a/clusters/surveillance-vendor.json
+++ b/clusters/surveillance-vendor.json
@@ -851,12 +851,14 @@
     },
     {
       "description": "REDLattice is a mission-focused provider of full spectrum cyber capabilities and technology solutions for customers in the U.S. national security, defense and commercial communities. REDLattice helps its customers deliver mission success by rapidly designing, developing, and implementing cutting edge applications and engineering solutions for some of their most complex challenges. The Company’s subject matter experts in vulnerability research (VR), reverse engineering (RE), tool development, malware analysis, and advanced operational capabilities help to develop the next generation of cyber tools and solutions to the battlespace.",
+      "meta": {
+        "refs": [
+          "https://citizenlab.ca/2025/03/a-first-look-at-paragons-proliferating-spyware-operations/"
+        ]
+      },
       "related": [
         {
           "dest-uuid": "6eae15ff-9d8b-4549-98b5-1d605dddc5b6",
-          "refs": [
-            "https://citizenlab.ca/2025/03/a-first-look-at-paragons-proliferating-spyware-operations/"
-          ],
           "tags": [
             "estimative-language:likelihood-probability=\"likely\""
           ],
@@ -9875,5 +9877,5 @@
       "value": "Zignal Labs"
     }
   ],
-  "version": 11
+  "version": 12
 }

--- a/schema_clusters.json
+++ b/schema_clusters.json
@@ -47,24 +47,29 @@
           },
           "related": {
             "type": "array",
-            "additionalProperties": false,
             "items": {
-              "type": "object"
-            },
-            "properties": {
-              "dest-uuid": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
-              },
-              "tags": {
-                "type": "array",
-                "uniqueItems": true,
-                "items": {
+              "type": "object",
+              "properties": {
+                "dest-uuid": {
+                  "type": "string",
+                  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                },
+                "type": {
                   "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
                 }
-              }
+              },
+              "required": [
+                "dest-uuid",
+                "type"
+              ],
+              "additionalProperties": false
             }
           },
           "meta": {


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `schema_clusters.json` misplaces its `related` keywords, so any related entry validates today

- **Problem** — In `schema_clusters.json` the `properties` and `additionalProperties: false` keywords on `related` sit on the array node beside `items` rather than inside it, so JSON Schema skips them and the only rule enforced is "each item is an object" — `dest-uuid` may be a non-string or absent, and any key at all is accepted.
- **Fix** — Move those keywords inside `items` and add `required: [dest-uuid, type]`, then correct the four entries in `android.json`, `microsoft-activity-group.json`, `ransomware.json` and `surveillance-vendor.json` where value-level metadata (`refs`, `synonyms`, `payment-method`, `price`) was written one level too deep.
- **Effect** — Validation rejects malformed `related` entries instead of waving them through.
<!-- /bluf -->

## Problem

`schema_clusters.json` looks like it constrains `related` entries, but it does not. `properties` and `additionalProperties: false` sit on the **array** node, as siblings of `items`, while `items` is left bare:

```json
"related": {
  "type": "array",
  "additionalProperties": false,     <-- applies to the array, i.e. to nothing
  "items": { "type": "object" },     <-- the only constraint that actually runs
  "properties": { "dest-uuid": ..., "type": ..., "tags": ... }   <-- also ignored
}
```

In JSON Schema, `properties` and `additionalProperties` apply to an *object* instance. The instance here is an array, so both keywords match nothing and are silently skipped. The one rule in force is "each item is an object" — **`dest-uuid` need not be a string, or present at all, and any key whatsoever is accepted.**

Demonstrated against both schemas with `{"dest-uuid": 12345, "totally-bogus-key": "x"}`:

```
committed  -> ACCEPTS a bogus related entry
fixed      -> REJECTS: 12345 is not of type 'string'
```

Three records have already drifted through the gap. I enumerated every key used across all 64,683 `related` entries in the repo:

```
  dest-uuid          64683
  type               64683
  tags               19421
  refs                   2   <- ransomware.json, surveillance-vendor.json
  synonyms               1   <- android.json
  payment-method         1   <- ransomware.json
  price                  1   <- ransomware.json
```

`dest-uuid`, `type` and `tags` are the intended vocabulary. The other four are value-level metadata that was written one level too deep.

## Fix

**Schema** — move `properties` and `additionalProperties: false` inside `items` where they take effect, add `required: ["dest-uuid", "type"]` (both are present on all 64,683 entries, so this codifies existing practice), and constrain `dest-uuid` with a UUID `pattern`.

**Data** — the stray keys are migrated to the value's `meta`, where they belong, rather than deleted:

| cluster | value | moved |
|---|---|---|
| `android.json` | RedAlert2 | `related.synonyms` → `meta.synonyms` |
| `ransomware.json` | Booyah | `related.refs`, `related.payment-method`, `related.price` → `meta.*` |
| `surveillance-vendor.json` | RedLattice | `related.refs` → `meta.refs` |

`microsoft-activity-group.json` had two `related` entries on **NOBELIUM** with `"dest-uuid": ""` — they point at nothing and would fail the new pattern, so they are removed.

All four touched clusters get a `version` bump so instances pick the corrections up.

## Verification

```
=== every related entry in the repo vs the new items subschema ===
  64681 related entries, 0 failures

=== full-schema validation ===
  android.json                       OK
  ransomware.json                    OK
  surveillance-vendor.json           OK
  microsoft-activity-group.json      OK
  threat-actor.json                  OK
  uavs.json                          OK
  tidal-tactic.json                  OK
  mitre-attack-pattern.json          OK

=== schema itself ===
  check_schema passed
```

(64,681 rather than 64,683 — the two empty-`dest-uuid` NOBELIUM entries are gone.)

## Note

This makes the schema *structurally* enforce `related`. It does not check that a `dest-uuid` resolves to a cluster that exists — 2,214 edges currently point at unknown uuids. That is a referential-integrity check for CI, submitted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

