### PR TITLE
[low] ci: require a version bump when a cluster or galaxy's content changes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
+      with:
+        # chk_version_bump.py diffs against the base branch, so it needs more
+        # than the default single-commit checkout.
+        fetch-depth: 0
 
     - name: Set up Python ${{matrix.python-version}}
       uses: actions/setup-python@v2
@@ -32,6 +36,15 @@ jobs:
 
     - name: Validate files
       run: ./validate_all.sh
+
+    - name: Check version was bumped for changed galaxies
+      run: |
+        # GITHUB_BASE_REF is set by Actions on pull_request and holds the base
+        # branch name; it is not attacker-controlled text interpolated into the
+        # script. On push it is empty, so fall back to the default branch.
+        base="${GITHUB_BASE_REF:-main}"
+        git fetch --no-tags --depth=1 origin "$base"
+        python3 tools/chk_version_bump.py --baseline FETCH_HEAD
 
     - name: Install Python dependencies
       run: python -m pip install poetry

--- a/tools/chk_version_bump.py
+++ b/tools/chk_version_bump.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Check that a cluster or galaxy whose content changed also bumped `version`.
+
+MISP synchronises galaxies by version: an instance only re-imports a file
+whose version is higher than the one it already holds. So content that
+changes without the version moving never reaches instances that already have
+the old copy -- the edit is committed here and invisible everywhere else.
+
+It happens routinely. Walking first-parent history and comparing each file's
+content with `version` removed, 685 commits across 70 files changed content
+without bumping (threat-actor 315, ransomware 76, tool 53, rat 29).
+
+This compares the working tree against a baseline revision and only looks at
+files the change actually touches, so it never fails for history it did not
+cause.
+
+    tools/chk_version_bump.py                     # vs origin/main
+    tools/chk_version_bump.py --baseline HEAD~1
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+WATCHED_DIRS = ("clusters", "galaxies")
+
+
+def _repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _git(root, *args):
+    return subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
+
+
+def _content_without_version(doc):
+    """A stable rendering of the document with `version` removed."""
+    trimmed = {k: v for k, v in doc.items() if k != "version"}
+    return json.dumps(trimmed, sort_keys=True, ensure_ascii=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--baseline", default="origin/main",
+                        help="revision to compare against (default: origin/main)")
+    args = parser.parse_args()
+    root = _repo_root()
+
+    changed = _git(root, "diff", "--name-only", args.baseline, "--", *WATCHED_DIRS)
+    if changed.returncode != 0:
+        print("Could not diff against %r:\n%s" % (args.baseline, changed.stderr.strip()))
+        return 0
+    paths = [p for p in changed.stdout.split() if p.endswith(".json")]
+
+    if not paths:
+        print("No cluster or galaxy files changed against %s." % args.baseline)
+        return 0
+
+    problems, ok = [], []
+    for rel in paths:
+        path = os.path.join(root, rel)
+        if not os.path.exists(path):
+            continue  # deleted
+        with open(path, encoding="utf-8") as f:
+            new = json.load(f)
+        blob = _git(root, "show", "%s:%s" % (args.baseline, rel))
+        if blob.returncode != 0:
+            ok.append((rel, "new file", None, new.get("version")))
+            continue
+        old = json.loads(blob.stdout)
+
+        if _content_without_version(old) == _content_without_version(new):
+            continue  # only the version (or nothing) changed
+
+        old_v, new_v = old.get("version"), new.get("version")
+        if isinstance(old_v, (int, float)) and isinstance(new_v, (int, float)) and new_v > old_v:
+            ok.append((rel, "bumped", old_v, new_v))
+        else:
+            problems.append((rel, old_v, new_v))
+
+    for rel, why, old_v, new_v in ok:
+        print("  OK    %-56s %s (%s -> %s)" % (rel, why, old_v, new_v))
+    for rel, old_v, new_v in problems:
+        print("  FAIL  %-56s content changed, version %s -> %s" % (rel, old_v, new_v))
+
+    if problems:
+        print("\n%d file(s) changed content without increasing `version`.\n"
+              "MISP only re-imports a galaxy whose version is higher than the one an\n"
+              "instance already holds, so these edits will not reach existing instances."
+              % len(problems))
+        return 1
+
+    if not ok:
+        print("No content changes in clusters/ or galaxies/.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** CI now requires a `version` bump whenever a cluster or galaxy's content changes in a PR

- **Problem** — MISP only re-imports a galaxy or cluster file whose `version` is higher than the one an instance holds, but nothing here enforces that: 685 commits across 70 files changed content without bumping `version`, so those edits never reached instances with the old copy.
- **Fix** — Add `tools/chk_version_bump.py`, which re-serialises each changed file with `version` removed, compares it to the base branch and requires a strict increase when content differs, wired into `.github/workflows/pytest.yml`.
- **Effect** — A content edit without a bump is caught in review; only files a PR touches are inspected, so the backlog does not turn CI permanently red.
- **Cost** — Contributors must bump `version` on any content change to a cluster or galaxy, or the PR fails CI.
<!-- /bluf -->

## Problem

MISP synchronises galaxies by `version`: an instance only re-imports a file whose version is **higher** than the one it already holds. So content that changes without the version moving is committed here and never reaches any instance that already has the old copy — the edit is invisible everywhere it matters, and nothing warns about it.

It happens routinely. Walking first-parent history and hashing each file's content with `version` removed (so the ~429 pure-reformat commits are excluded):

```
685 commits across 70 files changed content without bumping `version`
  threat-actor.json  315
  ransomware.json     76
  tool.json           53
  rat.json            29
  target-information  15
  attck4fraud         11
  malpedia            10
  ...
```

## Fix

`tools/chk_version_bump.py` compares the working tree against a baseline revision. For each changed cluster or galaxy it re-serialises the document **with `version` removed** and compares that against the baseline's; if the content differs, `version` must have strictly increased.

Two properties keep it from being noisy:

- It only inspects files the change actually touches, so it never fails for history it did not cause — no backfill needed and no permanently-red CI.
- Ignoring `version` when comparing content means a version-only bump is not mistaken for a content change, and a reformat that leaves content identical does not demand a bump.

The CI step runs it against the PR's base branch. `GITHUB_BASE_REF` is an Actions-provided branch name rather than user-authored text, and it is read as an environment variable rather than interpolated into the script.

## Verification

All four cases:

```
=== 1. clean tree: nothing changed, must PASS ===
No cluster or galaxy files changed against origin/main.
   exit=0

=== 2. content changed, version NOT bumped: must FAIL ===
  FAIL  clusters/tea-matrix.json    content changed, version 2 -> 2
   exit=1

=== 3. same content change WITH a version bump: must PASS ===
  OK    clusters/tea-matrix.json    bumped (2 -> 3)
   exit=0

=== 4. version bumped but content identical: must PASS (no false positive) ===
No content changes in clusters/ or galaxies/.
   exit=0
```

The workflow YAML parses and the step is ordered after `validate_all.sh`.

## Note

Two clusters currently sit *below* a version they have already published (`tidal-software.json` at 1 against a historic 2, `nace.json` at 2 against a historic 2.1), which this check cannot see because it only looks at the diff. That is fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

