### PR TITLE
[high] fix(sigma): tolerate Sigma rules without a logsource block

### DIFF
--- a/tools/sigma/sigma-to-galaxy.py
+++ b/tools/sigma/sigma-to-galaxy.py
@@ -211,10 +211,11 @@ def parse_sigma_to_cluster(jsonData, sigmaFile, sigmaPath):
         "https://github.com/SigmaHQ/sigma/tree/master/rules%s/%s"
         % (sigmaPath.replace("\\", "/"), sigmaFile)
     )  # this value only works if you set the path like it was cloned from github
-    valueData["meta"]["logsource.category"] = jsonData.get("logsource").get(
+    logsource = jsonData.get("logsource") or {}
+    valueData["meta"]["logsource.category"] = logsource.get(
         "category", "No established category"
     )
-    valueData["meta"]["logsource.product"] = jsonData.get("logsource").get(
+    valueData["meta"]["logsource.product"] = logsource.get(
         "product", "No established product"
     )
     return valueData

--- a/tools/sigma/test_sigma_to_galaxy.py
+++ b/tools/sigma/test_sigma_to_galaxy.py
@@ -1,0 +1,60 @@
+"""
+Regression tests for tools/sigma/sigma-to-galaxy.py
+
+Run manually with: python3 tools/sigma/test_sigma_to_galaxy.py
+(The repository gate ./validate_all.sh only validates JSON files.)
+"""
+
+import importlib.util
+import os
+import sys
+
+MODULE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sigma-to-galaxy.py")
+
+spec = importlib.util.spec_from_file_location("sigma_to_galaxy", MODULE_PATH)
+sigma_to_galaxy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sigma_to_galaxy)
+
+
+def test_rule_without_logsource():
+    """A Sigma rule with no logsource block must degrade to defaults, not crash."""
+    valueData = sigma_to_galaxy.parse_sigma_to_cluster(
+        {"title": "No logsource rule", "id": "d1e4a0d0-0000-0000-0000-000000000000"},
+        "no_logsource.yml",
+        "/windows",
+    )
+    assert valueData["meta"]["logsource.category"] == "No established category"
+    assert valueData["meta"]["logsource.product"] == "No established product"
+
+
+def test_rule_with_empty_logsource():
+    """An empty (None) logsource block must also degrade to defaults."""
+    valueData = sigma_to_galaxy.parse_sigma_to_cluster(
+        {"title": "Empty logsource rule", "logsource": None}, "empty.yml", "/windows"
+    )
+    assert valueData["meta"]["logsource.category"] == "No established category"
+    assert valueData["meta"]["logsource.product"] == "No established product"
+
+
+def test_rule_with_logsource():
+    """A complete logsource block is still read correctly."""
+    valueData = sigma_to_galaxy.parse_sigma_to_cluster(
+        {"title": "Full rule", "logsource": {"category": "process_creation", "product": "windows"}},
+        "full.yml",
+        "/windows",
+    )
+    assert valueData["meta"]["logsource.category"] == "process_creation"
+    assert valueData["meta"]["logsource.product"] == "windows"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            try:
+                func()
+                print("PASS: %s" % name)
+            except Exception as exc:
+                failures += 1
+                print("FAIL: %s: %r" % (name, exc))
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A Sigma rule with no `logsource` block no longer aborts the whole galaxy generation run

- **Problem** — `parse_sigma_to_cluster()` in `tools/sigma/sigma-to-galaxy.py` calls `jsonData.get("logsource").get(...)`, which raises `AttributeError` on `NoneType` for any Sigma rule with a missing or empty `logsource` block — common for correlation and meta rules. The exception is uncaught, so one such rule aborts the entire generation run.
- **Fix** — Resolve the mapping once as `jsonData.get("logsource") or {}`, so both fields fall back to the defaults the code already declares.
- **Effect** — Output is byte-identical for rules that carry a log source, and generation no longer crashes on rules that do not.
<!-- /bluf -->

## Problem

`tools/sigma/sigma-to-galaxy.py`, in `parse_sigma_to_cluster()` (line 214 before this change), read the log source fields as:

```python
valueData["meta"]["logsource.category"] = jsonData.get("logsource").get(
    "category", "No established category"
)
valueData["meta"]["logsource.product"] = jsonData.get("logsource").get(
    "product", "No established product"
)
```

`jsonData.get("logsource")` returns `None` whenever a Sigma rule has no `logsource:` block, or has one that is present but empty/null (YAML parses `logsource:` with no children as `None`). Calling `.get()` on that raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

The exception is not caught, so a single such rule anywhere in the rules tree aborts the whole galaxy generation run rather than skipping or defaulting. `logsource` is optional in practice for correlation-style and meta rules, so this is reachable with real input. Every other field read in the same function already degrades gracefully to a default.

## Fix

Resolve the mapping once and coerce a missing/empty value to an empty dict:

```python
logsource = jsonData.get("logsource") or {}
valueData["meta"]["logsource.category"] = logsource.get(
    "category", "No established category"
)
valueData["meta"]["logsource.product"] = logsource.get(
    "product", "No established product"
)
```

Both fields then fall back to the same default strings the code already declares, so output for rules that do carry a log source is byte-identical, and rules without one produce `"No established category"` / `"No established product"` instead of crashing. `or {}` (rather than `if is not None`) also covers the empty-block case. This matches how the surrounding fields in `parse_sigma_to_cluster()` already tolerate absent keys.

## Testing

Repository gate: `./validate_all.sh` — passes, ending with `If you see this message, all is probably well.`

Regression test added: `tools/sigma/test_sigma_to_galaxy.py`, covering `test_rule_without_logsource`, `test_rule_with_empty_logsource`, and `test_rule_with_logsource`.

The repo has no Python test harness, and `validate_all.sh` only jq/jsonschema-validates JSON files, so this test is not executed by the gate. It is run manually with:

```
python3 tools/sigma/test_sigma_to_galaxy.py
```

Fail-without-fix was proven by reverting only the source file from the checkout (no `git stash`): with the source reverted the run reported `FAIL: test_rule_with_empty_logsource: AttributeError("'NoneType' object has no attribute 'get'")` and the same for `test_rule_without_logsource` (exit 1); with the fix restored all three pass (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

