### PR TITLE
[high] fix(tools): bump cluster version in del_duplicate_uuids on dedup

### DIFF
--- a/tests/test_del_duplicate_uuids.py
+++ b/tests/test_del_duplicate_uuids.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# coding=utf-8
+"""
+    Tests for tools/del_duplicate_uuids.py
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / 'tools' / 'del_duplicate_uuids.py'
+
+
+def write_cluster(path, uuids, version=3):
+    data = {
+        'name': 'Test cluster',
+        'type': 'test',
+        'uuid': '9b8b0d0a-1b7e-4a8f-9c7f-0d5a6b7c8d9e',
+        'description': 'Test cluster',
+        'version': version,
+        'values': [{'value': f'value-{i}', 'uuid': u} for i, u in enumerate(uuids)],
+    }
+    with open(path, 'w') as f:
+        json.dump(data, f)
+    return data
+
+
+def run(path):
+    return subprocess.run([sys.executable, str(SCRIPT), str(path)], capture_output=True, text=True)
+
+
+def test_version_incremented_when_duplicate_removed(tmp_path):
+    path = tmp_path / 'cluster.json'
+    dup = '11111111-1111-1111-1111-111111111111'
+    write_cluster(path, [dup, '22222222-2222-2222-2222-222222222222', dup], version=3)
+
+    assert run(path).returncode == 0
+
+    with open(path) as f:
+        result = json.load(f)
+    assert len(result['values']) == 2
+    assert result['version'] == 4
+
+
+def test_file_untouched_when_no_duplicate(tmp_path):
+    path = tmp_path / 'cluster.json'
+    write_cluster(path, ['11111111-1111-1111-1111-111111111111',
+                         '22222222-2222-2222-2222-222222222222'], version=3)
+    before = path.read_bytes()
+
+    assert run(path).returncode == 0
+
+    assert path.read_bytes() == before
+    with open(path) as f:
+        assert json.load(f)['version'] == 3

--- a/tools/del_duplicate_uuids.py
+++ b/tools/del_duplicate_uuids.py
@@ -18,9 +18,11 @@ for c in data['values']:
     unique_uuid.add(c['uuid'])
     values.append(c)
 
-data['values'] = []
-data['values'] = values
+changed = len(values) != len(data['values'])
 
-with open(sys.argv[1], 'w') as f:
-    json.dump(data, f)
+if changed:
+    data['values'] = values
+    data['version'] += 1
 
+    with open(sys.argv[1], 'w') as f:
+        json.dump(data, f)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `del_duplicate_uuids.py` now bumps `version` on dedup, so deduplications reach MISP instances

- **Problem** — `tools/del_duplicate_uuids.py` drops duplicate entries from a cluster's `values` list and rewrites the file without ever touching `version`, and MISP only re-imports a galaxy file whose `version` is higher than the copy it holds, so a deduplicated cluster never reaches instances holding the old one.
- **Fix** — Track whether a duplicate was actually removed and only then write the file with `version` incremented, matching `tools/gen_east_fraud.py`; unchanged files are left untouched on disk.
- **Effect** — Deduplications now propagate to MISP instances, and a run that finds nothing no longer rewrites the file.
<!-- /bluf -->

## Problem

`tools/del_duplicate_uuids.py` removed duplicate entries from a cluster's `values` list, then rewrote the file unconditionally (lines 21-26 before this change) without ever touching the cluster's `version` field.

Trigger: run the script on any cluster JSON whose `values` list contains two entries sharing the same `uuid`, e.g.

```
{"name": "...", "version": 3, "values": [
  {"value": "a", "uuid": "1111...1111"},
  {"value": "b", "uuid": "2222...2222"},
  {"value": "c", "uuid": "1111...1111"}]}
```

The duplicate is dropped, but the file still says `"version": 3`. Consumers that key on `version` to decide whether to reload a cluster therefore never pick up the deduplication — the content changed under an unchanged version. The mirror case is also wrong: a run that finds no duplicates at all still rewrites (and reserialises) the file.

## Fix

Track whether any duplicate was actually removed, by comparing the length of the filtered list against the original. Only when something was removed does the script assign the new `values`, increment `version`, and write the file back. When there is nothing to remove, the file is left untouched on disk.

This matches the sibling pattern already used by `tools/gen_east_fraud.py`, which bumps `json_data['version'] += 1` (line 106) before writing its cluster out.

## Testing

Repository gate: `./validate_all.sh` — passes, ending with "If you see this message, all is probably well."

Regression test added in `tests/test_del_duplicate_uuids.py`:

- `test_version_incremented_when_duplicate_removed` — the discriminating test. It builds a cluster at version 3 with one duplicated UUID, runs the script, and asserts the duplicate is gone and the version is 4. Reverting the source with `git checkout --` and re-running it fails on the unfixed script with `assert 3 == 4`; it passes with the fix in place.
- `test_file_untouched_when_no_duplicate` — covers the no-change path (file bytes and version unchanged when there is no duplicate). Useful coverage, but not the discriminating test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

