### PR TITLE
fix(rmm-tool): deduplicate RMM galaxy entries and merge LOLRMM records

### DIFF
--- a/clusters/rmm-tool.json
+++ b/clusters/rmm-tool.json
@@ -3080,39 +3080,8 @@
         "installation_paths": [
           "hsloader.exe",
           "ihcserver.exe",
-          "instanthousecall.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://instanthousecall.com/features/",
-          "https://instanthousecall.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/instant_housecall_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/instant_housecall_processes_sigma.yml"
-        ]
-      },
-      "uuid": "effbe985-ec78-53cc-8495-c20d41da6a47",
-      "value": "Instant Housecall"
-    },
-    {
-      "description": "Instant Housecall is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of Instant Housecall RMM tool",
-          "Detects potential processes activity of Instant Housecall RMM tool"
-        ],
-        "domains": [
-          "*.instanthousecall.com",
-          "secure.instanthousecall.com",
-          "*.instanthousecall.net",
-          "instanthousecall.com"
-        ],
-        "installation_paths": [
-          "hsloader.exe",
-          "InstantHousecall.exe",
-          "ihcserver.exe",
-          "instanthousecall.exe"
+          "instanthousecall.exe",
+          "InstantHousecall.exe"
         ],
         "last_modified": "2024-08-02",
         "refs": [
@@ -3263,39 +3232,6 @@
           "https://www.islonline.com/",
           "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_network_sigma.yml",
           "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_processes_sigma.yml"
-        ]
-      },
-      "uuid": "68a3e0bd-82e3-5d0f-a38f-7869086a93f9",
-      "value": "ISL Online"
-    },
-    {
-      "description": "ISL Online is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of ISL Online RMM tool",
-          "Detects potential processes activity of ISL Online RMM tool"
-        ],
-        "domains": [
-          "*.islonline.com",
-          "*.islonline.net"
-        ],
-        "installation_paths": [
-          "islalwaysonmonitor.exe",
-          "isllight.exe",
-          "isllightservice.exe",
-          "ISLLightClient.exe",
-          "C:\\Program Files (x86)\\ISL Online\\ISL Light*",
-          "*\\ISL Online\\ISL Light*",
-          "*\\ISLLight.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://help.islonline.com/19818/165940",
-          "https://www.islonline.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/isl_online_processes_sigma.yml"
         ],
         "supported_os": [
           "Windows"
@@ -3355,31 +3291,6 @@
         "domains": [
           "*.itsupport247.net",
           "itsupport247.net"
-        ],
-        "installation_paths": [
-          "saazapsc.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://control.itsupport247.net/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/itsupport247__connectwise__network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/itsupport247__connectwise__processes_sigma.yml"
-        ]
-      },
-      "uuid": "3b24327a-9190-58fa-92be-1e25551784bf",
-      "value": "ITSupport247 (ConnectWise)"
-    },
-    {
-      "description": "ITSupport247 (ConnectWise) is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of ITSupport247 (ConnectWise) RMM tool",
-          "Detects potential processes activity of ITSupport247 (ConnectWise) RMM tool"
-        ],
-        "domains": [
-          "*.itsupport247.net"
         ],
         "installation_paths": [
           "saazapsc.exe"
@@ -3864,35 +3775,6 @@
         ],
         "supported_os": [
           "Windows"
-        ]
-      },
-      "uuid": "4ac3c901-7484-5345-9b2f-10fc29c6f007",
-      "value": "Level.io"
-    },
-    {
-      "description": "Level.io is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of Level.io RMM tool",
-          "Detects potential processes activity of Level.io RMM tool"
-        ],
-        "domains": [
-          "level.io",
-          "*.level.io"
-        ],
-        "installation_paths": [
-          "level-windows-amd64.exe",
-          "level.exe",
-          "level-remote-control-ffmpeg.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://docs.level.io/1.0/admin-guides/troubleshooting-agent-issues",
-          "https://level.io/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/level.io_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/level.io_processes_sigma.yml"
         ]
       },
       "uuid": "4ac3c901-7484-5345-9b2f-10fc29c6f007",
@@ -4767,47 +4649,6 @@
       "value": "N-Able Advanced Monitoring Agent"
     },
     {
-      "description": "N-Able Advanced Monitoring Agent is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of N-Able Advanced Monitoring Agent RMM tool",
-          "Detects potential processes activity of N-Able Advanced Monitoring Agent RMM tool"
-        ],
-        "domains": [
-          "*remote.management",
-          "*.logicnow.com",
-          "*systemmonitor.us",
-          "*systemmonitor.eu.com",
-          "*system-monitor.com",
-          "systemmonitor.us.cdn.cloudflare.net",
-          "*cloudbackup.management",
-          "*systemmonitor.co.uk",
-          "*.n-able.com",
-          "*.beanywhere.com",
-          "*.swi-tc.com"
-        ],
-        "installation_paths": [
-          "Agent_*_RW.exe",
-          "BASEClient.exe",
-          "BASupApp.exe",
-          "BASupSrvc.exe",
-          "BASupSrvcCnfg.exe",
-          "BASupTSHelper.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://documentation.n-able.com/takecontrol/troubleshooting/Content/kb/Take-Control-Standalone-Ports-and-Domains-Firewall-and-AV-Exclusions.htm",
-          "https://www.n-able.com/features/advanced-monitoring-agent",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/n-able_advanced_monitoring_agent_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/n-able_advanced_monitoring_agent_processes_sigma.yml"
-        ]
-      },
-      "uuid": "5d737702-8d5f-5227-8190-804e376af333",
-      "value": "N-Able Advanced Monitoring Agent"
-    },
-    {
       "description": "N-ABLE Remote Access Software is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
       "meta": {
         "category": "RMM",
@@ -5120,42 +4961,13 @@
         ],
         "domains": [
           "*.netsupportmanager.com",
-          "netsupportmanager.com"
+          "netsupportmanager.com",
+          "geo.netsupportsoftware.com"
         ],
         "installation_paths": [
           "pcictlui.exe",
           "pcicfgui.exe",
           "client32.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://www.netsupportmanager.com/resources/",
-          "https://www.netsupportmanager.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/netsupport_manager_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/netsupport_manager_processes_sigma.yml"
-        ]
-      },
-      "uuid": "5d21c239-3e5f-5051-980a-04d7034701c8",
-      "value": "NetSupport Manager"
-    },
-    {
-      "description": "NetSupport Manager is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of NetSupport Manager RMM tool",
-          "Detects potential processes activity of NetSupport Manager RMM tool"
-        ],
-        "domains": [
-          "geo.netsupportsoftware.com",
-          "netsupportmanager.com",
-          "*.netsupportmanager.com"
-        ],
-        "installation_paths": [
-          "pcictlui.exe",
-          "client32.exe",
-          "pcicfgui.exe"
         ],
         "last_modified": "2024-08-02",
         "refs": [
@@ -7381,37 +7193,6 @@
         ],
         "supported_os": [
           "windows"
-        ]
-      },
-      "uuid": "c315bd0f-fe30-5d42-88f0-810e6d5032a4",
-      "value": "SimpleHelp"
-    },
-    {
-      "description": "SimpleHelp is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.",
-      "meta": {
-        "category": "RMM",
-        "created": "2024-08-02",
-        "detection_descriptions": [
-          "Detects potential network activity of SimpleHelp RMM tool",
-          "Detects potential processes activity of SimpleHelp RMM tool"
-        ],
-        "domains": [
-          "user_managed",
-          "simple-help.com"
-        ],
-        "installation_paths": [
-          "simplehelpcustomer.exe",
-          "simpleservice.exe",
-          "simplegatewayservice.exe",
-          "remote access.exe",
-          "windowslauncher.exe"
-        ],
-        "last_modified": "2024-08-02",
-        "refs": [
-          "https://simple-help.com/remote-support",
-          "https://simple-help.com/",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_network_sigma.yml",
-          "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_processes_sigma.yml"
         ]
       },
       "uuid": "c315bd0f-fe30-5d42-88f0-810e6d5032a4",

--- a/tools/gen_lolrmm.py
+++ b/tools/gen_lolrmm.py
@@ -126,8 +126,23 @@ def build_meta(entry):
     return meta
 
 
+def merge_clusters(existing, incoming):
+    """Merge duplicate LOLRMM records without discarding useful indicators."""
+    if len(incoming.get("description", "")) > len(existing.get("description", "")):
+        existing["description"] = incoming["description"]
+
+    existing_meta = existing.setdefault("meta", {})
+    for key, value in incoming.get("meta", {}).items():
+        if key not in existing_meta:
+            existing_meta[key] = value
+        elif isinstance(value, list) and isinstance(existing_meta[key], list):
+            existing_meta[key] = clean_list(existing_meta[key] + value)
+        elif key == "last_modified" and value > existing_meta[key]:
+            existing_meta[key] = value
+
+
 def build_cluster_values(entries):
-    values = []
+    values_by_name = {}
     for entry in entries:
         name = str(entry.get("Name", "")).strip()
         if not name:
@@ -145,8 +160,16 @@ def build_cluster_values(entries):
         if meta:
             cluster["meta"] = meta
 
-        values.append(cluster)
+        # LOLRMM occasionally contains two records for the same product. Since
+        # UUIDs are derived from names, emitting both creates invalid duplicate
+        # galaxy elements. Merge their complementary metadata instead.
+        normalized_name = name.casefold()
+        if normalized_name in values_by_name:
+            merge_clusters(values_by_name[normalized_name], cluster)
+        else:
+            values_by_name[normalized_name] = cluster
 
+    values = list(values_by_name.values())
     values.sort(key=lambda c: c["value"].lower())
     return values
 


### PR DESCRIPTION
### Motivation

- LOLRMM source data sometimes contains multiple records for the same product which produced duplicate cluster entries and deterministic UUID collisions in `clusters/rmm-tool.json`.
- The generator should preserve complementary indicators (domains, installation paths, refs, detections) instead of dropping one of the duplicates.

### Description

- Added `merge_clusters(existing, incoming)` to `tools/gen_lolrmm.py` to merge duplicate LOLRMM records by retaining the longer description, combining list metadata without duplicates, and preferring the newest `last_modified` value.
- Updated `build_cluster_values` in `tools/gen_lolrmm.py` to deduplicate case-insensitively by product name and merge metadata for duplicate entries so deterministic UUIDs are no longer emitted twice.
- Applied the deduplication to `clusters/rmm-tool.json`, consolidating duplicate product records and preserving combined domains, installation paths, refs, detection descriptions, and supported OS fields (example: `Instant Housecall` and `NetSupport Manager` now aggregate indicators previously split across records).
- The change reduces the RMM cluster count to a single canonical entry per product while keeping the richer set of indicators useful for detection and hunting.

### Testing

- Ran a syntax check with `python -m py_compile tools/gen_lolrmm.py` which succeeded.
- Executed an inline regression script using `build_cluster_values` to assert case-insensitive merging, richer-description selection, metadata union, and newest `last_modified` preference which passed (`deduplication regression check passed`).
- Verified uniqueness assertions for names and UUIDs with a small script against `clusters/rmm-tool.json`, confirming there are no duplicate names or UUIDs (result: `288 unique RMM records`).
- Ran repository validation with `./validate_all.sh` which completed and validated the updated cluster and galaxy files without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a951f0039bc8325b12a1104d1cdb21a)