### PR TITLE
chg: [mitre] merge the ATT&CK for ICS matrix into the cross-domain galaxies, add MITRE ATT&CK Assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,17 @@ Category: *misinformation-pattern* - source: *https://github.com/misinfosecproje
 
 [MITRE ATT&CK Analytics](https://www.misp-galaxy.org/mitre-analytic) - Detection analytics from MITRE ATT&CK.
 
-Category: *attack-pattern* - source: *https://attack.mitre.org/analytics/* - total: *1969* elements
+Category: *attack-pattern* - source: *https://attack.mitre.org/analytics/* - total: *2066* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-analytic)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-analytic.json)]
+
+## MITRE ATT&CK Assets
+
+[MITRE ATT&CK Assets](https://www.misp-galaxy.org/mitre-asset) - Assets from MITRE ATT&CK, representing the devices and systems that adversaries target.
+
+Category: *asset* - source: *https://github.com/mitre/cti* - total: *18* elements
+
+[[HTML](https://www.misp-galaxy.org/mitre-asset)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-asset.json)]
 
 ## MITRE ATLAS Techniques
 
@@ -374,9 +382,9 @@ Category: *course-of-action* - source: *https://github.com/mitre-atlas/atlas-nav
 
 ## MITRE ATT&CK Techniques
 
-[MITRE ATT&CK Techniques](https://www.misp-galaxy.org/mitre-attack-pattern) - Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise and Mobile).
+[MITRE ATT&CK Techniques](https://www.misp-galaxy.org/mitre-attack-pattern) - Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise, Mobile, PRE and ICS).
 
-Category: *attack-pattern* - source: *https://github.com/mitre/cti* - total: *1266* elements
+Category: *attack-pattern* - source: *https://github.com/mitre/cti* - total: *1396* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-attack-pattern)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-attack-pattern.json)]
 
@@ -392,7 +400,7 @@ Category: *actor* - source: *https://github.com/mitre/cti* - total: *60* element
 
 [MITRE ATT&CK Mitigations](https://www.misp-galaxy.org/mitre-course-of-action) - Mitigations from MITRE ATT&CK.
 
-Category: *course-of-action* - source: *https://github.com/mitre/cti* - total: *282* elements
+Category: *course-of-action* - source: *https://github.com/mitre/cti* - total: *334* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-course-of-action)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-course-of-action.json)]
 
@@ -408,7 +416,7 @@ Category: *d3fend* - source: *https://d3fend.mitre.org/* - total: *171* elements
 
 [MITRE ATT&CK Data Components](https://www.misp-galaxy.org/mitre-data-component) - Data components from MITRE ATT&CK, refining data sources into the specific properties relevant to detection.
 
-Category: *data-component* - source: *https://github.com/mitre/cti* - total: *118* elements
+Category: *data-component* - source: *https://github.com/mitre/cti* - total: *123* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-data-component)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-data-component.json)]
 
@@ -416,7 +424,7 @@ Category: *data-component* - source: *https://github.com/mitre/cti* - total: *11
 
 [MITRE ATT&CK Data Sources](https://www.misp-galaxy.org/mitre-data-source) - Data sources from MITRE ATT&CK, representing the information that can be collected by sensors and logs.
 
-Category: *data-source* - source: *https://github.com/mitre/cti* - total: *40* elements
+Category: *data-source* - source: *https://github.com/mitre/cti* - total: *42* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-data-source)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-data-source.json)]
 
@@ -424,7 +432,7 @@ Category: *data-source* - source: *https://github.com/mitre/cti* - total: *40* e
 
 [MITRE ATT&CK Detection Strategies](https://www.misp-galaxy.org/mitre-detection-strategy) - Detection strategies from MITRE ATT&CK.
 
-Category: *attack-pattern* - source: *https://attack.mitre.org/detectionstrategies/* - total: *823* elements
+Category: *attack-pattern* - source: *https://attack.mitre.org/detectionstrategies/* - total: *920* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-detection-strategy)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-detection-strategy.json)]
 
@@ -443,38 +451,6 @@ Category: *engage* - source: *https://engage.mitre.org* - total: *77* elements
 Category: *attack-pattern* - source: *https://ctid.mitre.org/fraud/* - total: *123* elements
 
 [[HTML](https://www.misp-galaxy.org/mitre-fraud-framework)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-fraud-framework.json)]
-
-## MITRE ATT&CK ICS Assets
-
-[MITRE ATT&CK ICS Assets](https://www.misp-galaxy.org/mitre-ics-assets) - Assets from MITRE ATT&CK for ICS.
-
-Category: *asset* - source: *https://collaborate.mitre.org/attackics/index.php/All_Assets* - total: *7* elements
-
-[[HTML](https://www.misp-galaxy.org/mitre-ics-assets)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-assets.json)]
-
-## MITRE ATT&CK ICS Levels
-
-[MITRE ATT&CK ICS Levels](https://www.misp-galaxy.org/mitre-ics-levels) - Purdue model levels used by MITRE ATT&CK for ICS.
-
-Category: *level* - source: *https://collaborate.mitre.org/attackics/index.php/All_Levels* - total: *3* elements
-
-[[HTML](https://www.misp-galaxy.org/mitre-ics-levels)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-levels.json)]
-
-## MITRE ATT&CK ICS Tactics
-
-[MITRE ATT&CK ICS Tactics](https://www.misp-galaxy.org/mitre-ics-tactics) - Tactics from MITRE ATT&CK for ICS.
-
-Category: *tactic* - source: *https://collaborate.mitre.org/attackics/index.php/All_Tactics* - total: *9* elements
-
-[[HTML](https://www.misp-galaxy.org/mitre-ics-tactics)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-tactics.json)]
-
-## MITRE ATT&CK ICS Techniques
-
-[MITRE ATT&CK ICS Techniques](https://www.misp-galaxy.org/mitre-ics-techniques) - Techniques from MITRE ATT&CK for ICS.
-
-Category: *attack-pattern* - source: *https://collaborate.mitre.org/attackics/index.php/All_Techniques* - total: *78* elements
-
-[[HTML](https://www.misp-galaxy.org/mitre-ics-techniques)] - [[JSON](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-ics-techniques.json)]
 
 ## MITRE ATT&CK Groups
 

--- a/clusters/mitre-analytic.json
+++ b/clusters/mitre-analytic.json
@@ -1525,6 +1525,17 @@
       "value": "Analytic 0901 - AN0901"
     },
     {
+      "description": "Monitor ICS automation network protocols for functions related to reading an asset’s operating mode. In some cases, there may be multiple ways to detect a device’s operating mode, one of which is typically used in the operational environment. Monitor for the operating mode being checked in unexpected ways.",
+      "meta": {
+        "external_id": "AN1900",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0768#AN1900"
+        ]
+      },
+      "uuid": "899d41e8-8d02-45f9-ab8a-3a06f4cc4189",
+      "value": "Analytic 1900 - AN1900"
+    },
+    {
       "description": "Session cookie reuse on unmanaged browsers, devices, or client types deviating from user baseline (e.g., switching from Chrome to curl).",
       "meta": {
         "external_id": "AN0202",
@@ -1920,6 +1931,17 @@
       },
       "uuid": "cc5f309c-6eb0-4f96-ba1a-0f4fd3bc1b79",
       "value": "Analytic 0052 - AN0052"
+    },
+    {
+      "description": "Monitor for new processes engaging in scanning activity or connecting to multiple systems by correlating process creation network data.\n\nMonitor for hosts enumerating network connected resources using non-ICS enterprise protocols.  \n",
+      "meta": {
+        "external_id": "AN2050",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0907#AN2050"
+        ]
+      },
+      "uuid": "51a094bf-b7eb-452a-9b7a-ffac16fce1ac",
+      "value": "Analytic 2050 - AN2050"
     },
     {
       "description": "Once adversaries have provisioned software on a compromised server (ex: for use as a command and control server), internet scans may reveal servers that adversaries have compromised. Consider looking for identifiable patterns such as services listening, certificates in use, SSL/TLS negotiation features, or other response artifacts associated with adversary C2 software.(Citation: ThreatConnect Infrastructure Dec 2020)(Citation: Mandiant SCANdalous Jul 2020)(Citation: Koczwara Beacon Hunting Sep 2021)\nMuch of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Command and Control.",
@@ -5439,6 +5461,28 @@
       "value": "Analytic 1091 - AN1091"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1901",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0769#AN1901"
+        ]
+      },
+      "uuid": "68073351-4e4f-40e4-9394-a9166bb346d7",
+      "value": "Analytic 1901 - AN1901"
+    },
+    {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1910",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0778#AN1910"
+        ]
+      },
+      "uuid": "cbf791b4-5186-4205-ac5a-a56042aaebec",
+      "value": "Analytic 1910 - AN1910"
+    },
+    {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
       "meta": {
         "external_id": "AN2012",
@@ -6124,6 +6168,17 @@
       },
       "uuid": "fb933fd5-5dd8-4879-b2bb-e68bc26ff60d",
       "value": "Analytic 0215 - AN0215"
+    },
+    {
+      "description": "Monitor for anomalies related to discovery related ICS functions, including devices that have not previously used these functions or for functions being sent to many outstations.\nMonitor for new ICS protocol connections to existing assets or for device scanning (i.e., a host connecting to many devices) over ICS and enterprise protocols (e.g., ICMP, DCOM, WinRM). For added context on adversary enterprise procedures and background see [Remote System Discovery](https://attack.mitre.org/techniques/T1018).\n",
+      "meta": {
+        "external_id": "AN2051",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0908#AN2051"
+        ]
+      },
+      "uuid": "f6324642-d17d-49d4-90b2-bab9d229d6fa",
+      "value": "Analytic 2051 - AN2051"
     },
     {
       "description": "Behavioral detection of domain group enumeration via ldapsearch or custom scripts leveraging LDAP over the network.",
@@ -6843,6 +6898,28 @@
       },
       "uuid": "d677a72d-db0e-4332-a467-95b19836ef16",
       "value": "Analytic 0912 - AN0912"
+    },
+    {
+      "description": "Monitor ICS automation protocols for anomalies related to reading point or tag data, such as new assets using these functions, changes in volume or timing, or unusual information being queried. Many protocols provide multiple ways to achieve the same result (e.g., functions with/without an acknowledgment or functions that operate on a single point vs. multiple points). Monitor for changes in the functions used.\nMonitor asset application logs which may provide information about requests for points or tags. Look for anomalies related to reading point or tag data, such as new assets using these functions, changes in volume or timing, or unusual information being queried. Many devices provide multiple ways to achieve the same result (e.g., functions with/without an acknowledgment or functions that operate on a single point vs. multiple points). Monitor for changes in the functions used.",
+      "meta": {
+        "external_id": "AN1920",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0788#AN1920"
+        ]
+      },
+      "uuid": "484023ea-6fea-4f91-b40d-c6d87188cbfe",
+      "value": "Analytic 1920 - AN1920"
+    },
+    {
+      "description": "Monitor executed commands and arguments that may look for details about the network configuration and settings, such as IP and/or MAC addresses, of systems they access or through information discovery of remote systems. Also monitor executed commands and arguments that may attempt to get a listing of network connections to or from the compromised system they are currently accessing or from remote systems by querying for information over the network. Information may also be acquired through Windows system management tools such as [Windows Management Instrumentation](https://attack.mitre.org/techniques/T1047) and [PowerShell](https://attack.mitre.org/techniques/T1059/001).\nMonitor for executed processes (such as ipconfig/ifconfig and arp) with arguments that may look for details about the network configuration and settings, such as IP and/or MAC addresses. Also monitor for executed processes that may attempt to get a listing of network connections to or from the compromised system they are currently accessing or from remote systems by querying for information over the network.\nMonitor for any suspicious attempts to enable script execution on a system. If scripts are not commonly used on a system, but enabled, scripts running out of cycle from patching or other administrator functions are suspicious. Scripts should be captured from the file system when possible to determine their actions and intent.\nMonitor for API calls (such as GetAdaptersInfo() and GetIpNetTable()) that may gather details about the network configuration and settings, such as IP and/or MAC addresses. Also monitor for API calls that may attempt to get a listing of network connections to or from the compromised system they are currently accessing or from remote systems by querying for information over the network. For added context on adversary procedures and background see [System Network Configuration Discovery](https://attack.mitre.org/techniques/T1016) and [System Network Connections Discovery](https://attack.mitre.org/techniques/T1049).",
+      "meta": {
+        "external_id": "AN1902",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0770#AN1902"
+        ]
+      },
+      "uuid": "7aa60595-5a1c-4de2-be60-cc1f9fea2313",
+      "value": "Analytic 1902 - AN1902"
     },
     {
       "description": "Monitoring for modification and execution of login hook scripts or LaunchAgents/LaunchDaemons used for persistence.",
@@ -7909,6 +7986,28 @@
       "value": "Analytic 1390 - AN1390"
     },
     {
+      "description": "Monitor network traffic for hardcoded credential use in protocols that allow unencrypted authentication.\nMonitor logon sessions for hardcoded credential use, when feasible.",
+      "meta": {
+        "external_id": "AN1930",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0798#AN1930"
+        ]
+      },
+      "uuid": "b337bf06-d69b-41e0-8e60-8f24cb718998",
+      "value": "Analytic 1930 - AN1930"
+    },
+    {
+      "description": "Monitor for device alarms produced when device management passwords are changed, although not all devices will produce such alarms.\nMonitor for device credential changes observable in automation or management network protocols.",
+      "meta": {
+        "external_id": "AN1903",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0771#AN1903"
+        ]
+      },
+      "uuid": "d3023733-5874-4746-a947-65925514e382",
+      "value": "Analytic 1903 - AN1903"
+    },
+    {
       "description": "Detects unauthorized access to browser cookie paths (e.g., `~/Library/Application Support/Google/Chrome/Default/Cookies`) or `task_for_pid`/`vm_read` calls to Safari/Chrome memory space.",
       "meta": {
         "external_id": "AN1404",
@@ -8819,6 +8918,17 @@
       "value": "Analytic 1409 - AN1409"
     },
     {
+      "description": "Monitor for newly executed processes related to services specifically designed to accept remote graphical connections, such as RDP and VNC. [Remote Services](https://attack.mitre.org/techniques/T0886) and [Valid Accounts](https://attack.mitre.org/techniques/T0859) may be used to access a host’s GUI.\nMonitor executed commands and arguments related to services specifically designed to accept remote graphical connections, such as RDP and VNC. [Remote Services](https://attack.mitre.org/techniques/T0886) and [Valid Accounts](https://attack.mitre.org/techniques/T0859) may be used to access a host’s GUI.\nMonitor DLL file events, specifically creation of these binary files as well as the loading of DLLs into processes associated with remote graphical connections, such as RDP and VNC. [Remote Services](https://attack.mitre.org/techniques/T0886) may be used to access a host’s GUI.\nMonitor for user accounts logged into systems they would not normally access or abnormal access patterns, such as multiple systems over a relatively short period of time. Correlate use of login activity related to remote services with unusual behavior or other malicious or suspicious activity. [Remote Services](https://attack.mitre.org/techniques/T0886) may be used to access a host’s GUI.",
+      "meta": {
+        "external_id": "AN1904",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0772#AN1904"
+        ]
+      },
+      "uuid": "dc014060-5116-4a2f-bac5-35ac1db8fabb",
+      "value": "Analytic 1904 - AN1904"
+    },
+    {
       "description": "Detection of malicious certificate installation via monitoring execution of the `security add-trusted-cert` command and modifications to system keychains.",
       "meta": {
         "external_id": "AN0155",
@@ -9561,6 +9671,17 @@
       "value": "Analytic 0915 - AN0915"
     },
     {
+      "description": "A manipulated I/O image requires analyzing the application program running on the PLC for specific data block writes. Detecting this requires obtaining and analyzing a PLC’s application program, either directly from the device or from asset management platforms.",
+      "meta": {
+        "external_id": "AN1905",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0773#AN1905"
+        ]
+      },
+      "uuid": "7841eb6b-8a05-4754-b738-a475bfbb89fb",
+      "value": "Analytic 1905 - AN1905"
+    },
+    {
       "description": "Monitors use of archive or encryption tools (zip, openssl) tied to user-scripted activity or binaries writing encoded payloads under /Users or /Volumes.",
       "meta": {
         "external_id": "AN1066",
@@ -9967,6 +10088,17 @@
       "value": "Analytic 1680 - AN1680"
     },
     {
+      "description": "Monitor ICS automation network protocols for functions related to reading an operational process state (e.g., “Read” function codes in protocols like DNP3 or Modbus). In some cases, there may be multiple ways to monitor an operational process’ state, one of which is typically used in the operational environment. Monitor for the operating mode being checked in unexpected ways.\nMonitor applications logs for any access attempts to operational databases (e.g., historians) or other sources of operational data within the ICS environment. These devices should be monitored for adversary collection using techniques relevant to the underlying technologies (e.g., Windows, Linux).",
+      "meta": {
+        "external_id": "AN1860",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0727#AN1860"
+        ]
+      },
+      "uuid": "1be515a0-2656-4b35-a561-e8157169350d",
+      "value": "Analytic 1860 - AN1860"
+    },
+    {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
       "meta": {
         "external_id": "AN1960",
@@ -10119,6 +10251,17 @@
       },
       "uuid": "a180ad2e-e3fa-4cec-a1f0-8baf754d9543",
       "value": "Analytic 1690 - AN1690"
+    },
+    {
+      "description": "Collecting information from the I/O image requires analyzing the application program running on the PLC for specific data block reads. Detecting this requires obtaining and analyzing a PLC’s application program, either directly from the device or from asset management platforms.",
+      "meta": {
+        "external_id": "AN1906",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0774#AN1906"
+        ]
+      },
+      "uuid": "c40ddd75-f2fc-4899-bda1-bff164c96622",
+      "value": "Analytic 1906 - AN1906"
     },
     {
       "description": "Detection of new IAM roles or policies attached to a user/service in AWS/GCP/Azure outside normal patterns or hours, often following account compromise.",
@@ -10359,6 +10502,17 @@
       "value": "Analytic 1780 - AN1780"
     },
     {
+      "description": "Monitor operational process data for write commands for an excessive number of I/O points or manipulating a single value an excessive number of times. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nSome asset application logs may provide information on I/O points related to write commands. Monitor for write commands for an excessive number of I/O points or manipulating a single value an excessive number of times.\nMonitor network traffic for ICS functions related to write commands for an excessive number of I/O points or manipulating a single value an excessive number of times.",
+      "meta": {
+        "external_id": "AN1870",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0737#AN1870"
+        ]
+      },
+      "uuid": "77857bc3-6a38-4826-8109-30facf6c23ec",
+      "value": "Analytic 1870 - AN1870"
+    },
+    {
       "description": "Detects adversary creation of cloud or IdP accounts whose names resemble existing privileged or service accounts. May indicate preparation for privilege escalation or defense evasion.",
       "meta": {
         "external_id": "AN1079",
@@ -10516,6 +10670,17 @@
       "value": "Analytic 1709 - AN1709"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1907",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0775#AN1907"
+        ]
+      },
+      "uuid": "29b6e4b8-878c-4139-aa56-7e1513714d34",
+      "value": "Analytic 1907 - AN1907"
+    },
+    {
       "description": "Use of AWS CLI (`aws iam list-users`, `list-roles`), Azure CLI (`az ad user list`), or GCP CLI (`gcloud iam service-accounts list`) from endpoints or cloud shells where such activity is unexpected.",
       "meta": {
         "external_id": "AN1088",
@@ -10584,6 +10749,17 @@
       },
       "uuid": "4476a312-d2c9-459e-96a3-53ac0b676c52",
       "value": "Analytic 1808 - AN1808"
+    },
+    {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1880",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0747#AN1880"
+        ]
+      },
+      "uuid": "383a1a1c-8ecf-4909-9237-14a1f4fc4179",
+      "value": "Analytic 1880 - AN1880"
     },
     {
       "description": "Bulk enumeration of cloud user email identities through `Get-Recipient`, `Get-Mailbox`, `Get-User`, or Graph API directory listings by abnormal accounts or suspicious sessions.",
@@ -10728,6 +10904,28 @@
       "value": "Analytic 1809 - AN1809"
     },
     {
+      "description": "Monitor asset management systems for device configuration changes which can be used to understand expected parameter settings.\nMonitor device application logs parameter changes, although not all devices will produce such logs.\nMonitor for device alarms produced when parameters are changed, although not all devices will produce such alarms.\nMonitor ICS management protocols for parameter changes, including for unexpected values, changes far exceeding standard values, or for parameters being changed in an unexpected way (e.g., via a new function, at an unusual time).",
+      "meta": {
+        "external_id": "AN1908",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0776#AN1908"
+        ]
+      },
+      "uuid": "48d2023b-469d-4f9f-a4e6-010be72436b9",
+      "value": "Analytic 1908 - AN1908"
+    },
+    {
+      "description": "Monitor for changes made to a large quantity of files for unexpected modifications in both user directories and directories used to store programs and OS components (e.g., C:\\Windows\\System32). \nMonitor for newly executed processes of binaries that could be involved in data destruction activity, such as SDelete.\nMonitor for unexpected deletion of files.\nMonitor executed commands and arguments for binaries that could be involved in data destruction activity, such as SDelete.",
+      "meta": {
+        "external_id": "AN1890",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0758#AN1890"
+        ]
+      },
+      "uuid": "f666f516-f8d0-41f6-9a4c-0ac6c1f6086b",
+      "value": "Analytic 1890 - AN1890"
+    },
+    {
       "description": "Detects adversary use of logon script configuration via Group Policy or user object attributes, followed by script execution post-authentication. Behavior includes modification of script path or file, then process execution under user logon context.",
       "meta": {
         "external_id": "AN0199",
@@ -10796,6 +10994,17 @@
       },
       "uuid": "f8998263-e55f-428f-b8d0-46d9e31277d2",
       "value": "Analytic 0991 - AN0991"
+    },
+    {
+      "description": "Monitor ICS asset application logs that indicate alarm settings have changed, although not all assets will produce such logs.\nConsult asset management systems to understand expected alarm settings.\nData about the industrial process may indicate it is operating outside of expected bounds and could help indicate that that an alarm setting has changed. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor for alarm setting changes observable in automation or management network protocols.",
+      "meta": {
+        "external_id": "AN1909",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0777#AN1909"
+        ]
+      },
+      "uuid": "330166da-bc80-4aca-bd41-cbd6b1742812",
+      "value": "Analytic 1909 - AN1909"
     },
     {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
@@ -11021,6 +11230,17 @@
       },
       "uuid": "d8f9ab20-4c82-42fc-9316-91781fa9e5e1",
       "value": "Analytic 0252 - AN0252"
+    },
+    {
+      "description": "Monitor for anomalies related to discovery related ICS functions, including devices that have not previously used these functions or for functions being sent to many outstations.\n\nMonitor for new ICS protocol connections to existing assets or for device scanning (i.e., a host connecting to many devices) over ICS and enterprise protocols (e.g., ICMP, DCOM, WinRM). For added context on adversary enterprise procedures and background see [Remote System Discovery](https://attack.mitre.org/techniques/T1018).\n",
+      "meta": {
+        "external_id": "AN2052",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0909#AN2052"
+        ]
+      },
+      "uuid": "67861309-0ba7-4713-843e-3def87e396ec",
+      "value": "Analytic 2052 - AN2052"
     },
     {
       "description": "Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on behaviors relating to the use of exploits (i.e. [Exploit Public-Facing Application](https://attack.mitre.org/techniques/T1190), [Exploitation for Client Execution](https://attack.mitre.org/techniques/T1203), [Exploitation for Privilege Escalation](https://attack.mitre.org/techniques/T1068), [Exploitation for Stealth](https://attack.mitre.org/techniques/T1211), [Exploitation for Credential Access](https://attack.mitre.org/techniques/T1212), [Exploitation of Remote Services](https://attack.mitre.org/techniques/T1210), and [Application or System Exploitation](https://attack.mitre.org/techniques/T1499/004)).",
@@ -11529,6 +11749,17 @@
       },
       "uuid": "983e1849-6af7-491e-9605-46b9bf54bbd1",
       "value": "Analytic 2035 - AN2035"
+    },
+    {
+      "description": "Monitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist, alarms may still be visible even if messages are blocked.\n\nMonitor for a loss of network communications, which may indicate this technique is being used.\n\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution but instead may provide additional evidence that the technique has been used and may complement other detections.\n\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\n\nMonitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.\n",
+      "meta": {
+        "external_id": "AN2053",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0910#AN2053"
+        ]
+      },
+      "uuid": "3f052beb-d384-4ebe-b942-2c4ddeb95833",
+      "value": "Analytic 2053 - AN2053"
     },
     {
       "description": "Monitor for creation of WMI EventFilter, EventConsumer, and FilterToConsumerBinding objects through WMI or MOF file execution. Detect command-line execution of `mofcomp.exe`, usage of `Register-WmiEvent` via PowerShell, and anomalous child processes of `WmiPrvSE.exe` that indicate triggered execution. Look for lateral anomalies in process lineage and WMI logging channels.",
@@ -12077,6 +12308,28 @@
       "value": "Analytic 0524 - AN0524"
     },
     {
+      "description": "Unauthorized messages may be detected by reviewing the content of automation protocols, either through detecting based on expected values or comparing to other out of band process data sources. Unauthorized messages may not precisely match legitimate messages which may lead to malformed traffic, although traffic may be malformed for benign reasons. Monitor messages for changes in how they are constructed.\n\nMonitor for anomalous or unexpected messages that may result in changes to the process operation observable via asset application logs (e.g., discrete write, logic and device configuration, mode changes, safety triggers).\n\nConsider monitoring for [Rogue Master](https://attack.mitre.org/techniques/T0848) and [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) activity which may precede this technique.\n",
+      "meta": {
+        "external_id": "AN2045",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0902#AN2045"
+        ]
+      },
+      "uuid": "613b28ef-88dd-4008-8d7e-206ce55a7cde",
+      "value": "Analytic 2045 - AN2045"
+    },
+    {
+      "description": "Monitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist, alarms may still be visible even if Ethernet messages are blocked.\n\nMonitor for a loss of network communications, which may indicate this technique is being used.\n\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution but instead may provide additional evidence that the technique has been used and may complement other detections.\n\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\n\nMonitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.\n",
+      "meta": {
+        "external_id": "AN2054",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0911#AN2054"
+        ]
+      },
+      "uuid": "df7f8849-56a7-4e83-9fd7-a4f25227d960",
+      "value": "Analytic 2054 - AN2054"
+    },
+    {
       "description": "Keylogging on legacy network devices via unauthorized system image modification or remote capture of console keystrokes (telnet, SSH) through altered firmware or man-in-the-middle key sniffing.",
       "meta": {
         "external_id": "AN0246",
@@ -12175,6 +12428,17 @@
       "value": "Analytic 2064 - AN2064"
     },
     {
+      "description": "Monitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.\n\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\n\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\n\nMonitor for a loss of network communications, which may indicate this technique is being used.\n\nMonitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist alarms may still be visible even if messages are blocked.\n\n",
+      "meta": {
+        "external_id": "AN2046",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0903#AN2046"
+        ]
+      },
+      "uuid": "c556c91d-64a0-401c-9c41-18971eeca0f2",
+      "value": "Analytic 2046 - AN2046"
+    },
+    {
       "description": "Detects file reads across locations followed by writes to temp or staging directories, often compressed or encrypted, indicating local staging behavior.",
       "meta": {
         "external_id": "AN0724",
@@ -12257,6 +12521,21 @@
       },
       "uuid": "c94b2c2b-8885-4f5e-abec-e80ab0a24f21",
       "value": "Analytic 0472 - AN0472"
+    },
+    {
+      "description": "Monitor for firmware changes which may be observable via operational alarms from devices.\n\nMonitor device application logs for firmware changes, although not all devices will produce such logs.\n\nMonitor ICS management protocols / file transfer protocols for protocol functions related to firmware changes.\n\nMonitor firmware for unexpected changes. Asset management systems should be consulted to understand known-good firmware versions. Dump and inspect BIOS images on vulnerable systems and compare against known good images.(Citation: MITRE Copernicus) Analyze differences to determine if malicious changes have occurred. Log attempts to read/write to BIOS and compare against known patching behavior. Likewise, EFI modules can be collected and compared against a known-clean list of EFI executable binaries to detect potentially malicious modules. The CHIPSEC framework can be used for analysis to determine if firmware modifications have been performed.(Citation: McAfee CHIPSEC Blog)(Citation: Github CHIPSEC)(Citation: Intel HackingTeam UEFI Rootkit)\n",
+      "meta": {
+        "external_id": "AN2047",
+        "refs": [
+          "http://www.mitre.org/capabilities/cybersecurity/overview/cybersecurity-blog/copernicus-question-your-assumptions-about",
+          "https://attack.mitre.org/detectionstrategies/DET0904#AN2047",
+          "https://github.com/chipsec/chipsec",
+          "https://securingtomorrow.mcafee.com/business/chipsec-support-vault-7-disclosure-scanning/",
+          "https://web.archive.org/web/20170313124421/http://www.intelsecurity.com/advanced-threat-research/content/data/HT-UEFI-rootkit.html"
+        ]
+      },
+      "uuid": "fc6641ac-5748-4498-89e9-d4ada2b6f88a",
+      "value": "Analytic 2047 - AN2047"
     },
     {
       "description": "Monitors for TCC-bypassing or unauthorized access to input services like IOHIDSystem or Quartz Event Services used in keylogging or screen monitoring.",
@@ -12343,6 +12622,17 @@
       "value": "Analytic 0482 - AN0482"
     },
     {
+      "description": "Monitor network traffic for insecure credential use in protocols that allow unencrypted authentication.\n\nMonitor logon sessions for insecure credential use, when feasible.\n",
+      "meta": {
+        "external_id": "AN2048",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0905#AN2048"
+        ]
+      },
+      "uuid": "1017530e-423d-4857-80b6-99891bf82d28",
+      "value": "Analytic 2048 - AN2048"
+    },
+    {
       "description": "Unsigned or scripting-based processes invoking password cracking binaries or accessing hashed credential artifacts post-login",
       "meta": {
         "external_id": "AN0294",
@@ -12427,6 +12717,17 @@
       "value": "Analytic 0924 - AN0924"
     },
     {
+      "description": "Monitor for unexpected changes to project files, although if the malicious modification occurs in tandem with legitimate changes it will be difficult to isolate the unintended changes by analyzing only file systems modifications.",
+      "meta": {
+        "external_id": "AN2049",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0906#AN2049"
+        ]
+      },
+      "uuid": "6a510bf0-0289-4eb0-8645-89f0f4d32cf3",
+      "value": "Analytic 2049 - AN2049"
+    },
+    {
       "description": "Adversary runs commands like `whoami`, `id`, `w`, or `cat /etc/passwd` from non-interactive or scripting contexts to enumerate system user details.",
       "meta": {
         "external_id": "AN0255",
@@ -12467,6 +12768,17 @@
       },
       "uuid": "c15d6b5e-bbb7-4dc7-8b59-8ce2c0663c05",
       "value": "Analytic 0525 - AN0525"
+    },
+    {
+      "description": "Monitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist, alarms may still be visible even if Wi-Fi messages are blocked.\n\nMonitor for a loss of network communications, which may indicate this technique is being used.\n\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\n\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\n\nMonitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.\n",
+      "meta": {
+        "external_id": "AN2055",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0912#AN2055"
+        ]
+      },
+      "uuid": "0b4e7cfa-9f9d-49b0-b5bf-afdf62058c5a",
+      "value": "Analytic 2055 - AN2055"
     },
     {
       "description": "Adversary uses `dscl`, `who`, or environment variables like `$USER` to identify accounts or sessions via Terminal or malicious LaunchAgents.",
@@ -12567,6 +12879,17 @@
       "value": "Analytic 2065 - AN2065"
     },
     {
+      "description": "Monitor device alarms for program downloads, although not all devices produce such alarms.\n\nMonitor for protocol functions related to program download or modification. Program downloads may be observable in ICS automation protocols and remote management protocols.\n\nConsult asset management systems to understand expected program versions.\n\nMonitor devices configuration logs which may contain alerts that indicate whether a program download has occurred. Devices may maintain application logs that indicate whether a full program download, online edit, or program append function has occurred.\n",
+      "meta": {
+        "external_id": "AN2056",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0913#AN2056"
+        ]
+      },
+      "uuid": "e379be82-39d7-4ae4-8557-f846ba19cd4b",
+      "value": "Analytic 2056 - AN2056"
+    },
+    {
       "description": "Monitor for execution of hypervisor management commands such as `esxcli vm process list` or `vim-cmd vmsvc/getallvms` that enumerate virtual machines. Defenders observe unexpected users issuing VM listing commands outside normal administrative workflows.",
       "meta": {
         "external_id": "AN0572",
@@ -12651,6 +12974,17 @@
       "value": "Analytic 0752 - AN0752"
     },
     {
+      "description": "Monitor device alarms for program downloads, although not all devices produce such alarms.\n\nMonitor for protocol functions related to program download or modification. Program downloads may be observable in ICS automation protocols and remote management protocols.\n\nConsult asset management systems to understand expected program versions.\n\nMonitor devices configuration logs which may contain alerts that indicate whether a program download has occurred. Devices may maintain application logs that indicate whether a full program download, online edit, or program append function has occurred.\n",
+      "meta": {
+        "external_id": "AN2057",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0914#AN2057"
+        ]
+      },
+      "uuid": "3c6aa6f7-29e9-41d9-8500-30b6d0533d64",
+      "value": "Analytic 2057 - AN2057"
+    },
+    {
       "description": "Detects web-based credential phishing by analyzing traffic to suspicious URLs that mimic login portals and POST credential content.",
       "meta": {
         "external_id": "AN0285",
@@ -12733,6 +13067,17 @@
       },
       "uuid": "f2c03ef0-cd36-42b8-9c2d-e25a3b1b8b1c",
       "value": "Analytic 0582 - AN0582"
+    },
+    {
+      "description": "Monitor device alarms for program downloads, although not all devices produce such alarms.\n\nMonitor for protocol functions related to program download or modification. Program downloads may be observable in ICS automation protocols and remote management protocols.\n\nConsult asset management systems to understand expected program versions.\n\nMonitor devices configuration logs which may contain alerts that indicate whether a program download has occurred. Devices may maintain application logs that indicate whether a full program download, online edit, or program append function has occurred.\n",
+      "meta": {
+        "external_id": "AN2058",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0915#AN2058"
+        ]
+      },
+      "uuid": "22b202f2-d4dd-44dd-b5e1-791ff2aef8ed",
+      "value": "Analytic 2058 - AN2058"
     },
     {
       "description": "Sudden valid logins from accounts that previously had credentials dumped but had not authenticated successfully in the past; correlated with timeline of suspected hash cracking",
@@ -12873,6 +13218,17 @@
       },
       "uuid": "d02dbf1d-b6e9-4c3c-84a2-f70fec797504",
       "value": "Analytic 0662 - AN0662"
+    },
+    {
+      "description": "Monitor for newly constructed drive letters or mount points to removable media. Monitor for newly executed processes that execute from removable media after it is mounted or when initiated by a user.",
+      "meta": {
+        "external_id": "AN2066",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0748#AN2066"
+        ]
+      },
+      "uuid": "2b751a3d-c680-46c9-b92b-55a9d24bd4f9",
+      "value": "Analytic 2066 - AN2066"
     },
     {
       "description": "Detects staged data aggregated in /Users/Shared, /private/tmp with compression tools like ditto or zip, initiated via Terminal or AppleScript.",
@@ -18643,6 +18999,17 @@
       "value": "Analytic 1191 - AN1191"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1911",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0779#AN1911"
+        ]
+      },
+      "uuid": "8c77f31f-c6f4-491c-965a-e25c506b0c68",
+      "value": "Analytic 1911 - AN1911"
+    },
+    {
       "description": "Detects the creation, modification, or deletion of scheduled tasks through Task Scheduler, WMI, PowerShell, or API-based methods followed by execution from svchost.exe or taskeng.exe. Includes detection of hidden or anomalous scheduled tasks, especially those created under SYSTEM or suspicious user contexts.",
       "meta": {
         "external_id": "AN1221",
@@ -19245,6 +19612,28 @@
       "value": "Analytic 1192 - AN1192"
     },
     {
+      "description": "Monitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist alarms may still be visible even if reporting messages are blocked.  \nMonitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\nMonitor for a loss of network communications, which may indicate this technique is being used.\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.",
+      "meta": {
+        "external_id": "AN1921",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0789#AN1921"
+        ]
+      },
+      "uuid": "393d7e7b-0790-49e7-9bcd-87ab4662b05e",
+      "value": "Analytic 1921 - AN1921"
+    },
+    {
+      "description": "Monitor for changes made to firmware for unexpected modifications to settings and/or data that may be used by rootkits to hide the presence of programs, files, network connections, services, drivers, and other system components. Asset management systems should be consulted to understand known-good firmware versions and configurations.",
+      "meta": {
+        "external_id": "AN1912",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0780#AN1912"
+        ]
+      },
+      "uuid": "ec695157-8c3c-439b-9925-459c9d4172f0",
+      "value": "Analytic 1912 - AN1912"
+    },
+    {
       "description": "Identify repeated DNS resolutions where the same domain name returns multiple IPs in short succession, combined with low TTL values and high query volume from unusual processes. Correlate with process lineage (e.g., Office apps spawning abnormal DNS lookups).",
       "meta": {
         "external_id": "AN1331",
@@ -19763,6 +20152,31 @@
       "value": "Analytic 1139 - AN1139"
     },
     {
+      "description": "Monitor for suspicious descendant process spawning from Microsoft Office and other productivity software.(Citation: Elastic - Koadiac Detection with EQL) For added context on adversary procedures and background see [Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001).\nMonitor for newly constructed files from a spearphishing emails with a malicious attachment in an attempt to gain access to victim systems.\nMonitor network traffic for suspicious email attachments. Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments associated to traffic patterns (e.g., monitor anomalies in use of files that do not normally initiate connections for respective protocol(s)). Use web proxies to review content of emails including sender information, headers, and attachments for potentially malicious content.\nMonitor mail server and proxy logs for evidence of messages originating from spoofed addresses, including records indicating failed DKIM+SPF validation or mismatched message headers.(Citation: Microsoft Anti Spoofing)(Citation: ACSC Email Spoofing) Anti-virus can potentially detect malicious documents and attachments as they're scanned to be stored on the email server or on the user's computer.",
+      "meta": {
+        "external_id": "AN1913",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0781#AN1913",
+          "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-spoofing-protection?view=o365-worldwide",
+          "https://web.archive.org/web/20210708014107/https://www.cyber.gov.au/sites/default/files/2019-03/spoof_email_sender_policy_framework.pdf",
+          "https://www.elastic.co/security-labs/embracing-offensive-tooling-building-detections-against-koadic-using-eql"
+        ]
+      },
+      "uuid": "5610211c-1458-4333-8640-384189d9318e",
+      "value": "Analytic 1913 - AN1913"
+    },
+    {
+      "description": "Monitor and analyze traffic flows that do not follow the expected protocol standards and traffic flows (e.g., extraneous packets that do not belong to established flows    , or gratuitous or anomalous traffic patterns). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments associated to traffic patterns (e.g., monitor anomalies in use of files that do not normally initiate connections for respective protocol(s)).\nMonitor and analyze traffic patterns and packet inspection associated to protocol(s), leveraging SSL/TLS inspection for encrypted traffic, that do not follow the expected protocol standards and traffic flows (e.g., extraneous packets that do not belong to established flows, gratuitous or anomalous traffic patterns, anomalous syntax, or structure). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments associated to traffic patterns  (e.g., monitor anomalies in use of files that do not normally initiate connections for respective protocol(s)).",
+      "meta": {
+        "external_id": "AN1931",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0799#AN1931"
+        ]
+      },
+      "uuid": "d271c7fc-d76a-4fb0-a645-5db2c1223a32",
+      "value": "Analytic 1931 - AN1931"
+    },
+    {
       "description": "Detects staged file access (e.g., archive or obfuscation), followed by an encrypted outbound connection (TLS/HTTPS) from unusual processes such as curl/wget, Python scripts, or custom binaries.",
       "meta": {
         "external_id": "AN1414",
@@ -20211,6 +20625,17 @@
       "value": "Analytic 1149 - AN1149"
     },
     {
+      "description": "Monitor for unusual network traffic that may indicate additional tools transferred to the system. Use network intrusion detection systems, sometimes with SSL/TLS inspection, to look for known malicious scripts (recon, heap spray, and browser identification scripts have been frequently reused), common script obfuscation, and exploit code.\nFirewalls and proxies can inspect URLs for potentially known-bad domains or parameters. They can also do reputation-based analytics on websites and their requested resources such as how old a domain is, who it's registered to, if it's on a known bad list, or how many other users have connected to it before.\nMonitor for behaviors on the endpoint system that might indicate successful compromise, such as abnormal behaviors of browser processes. This could include suspicious files written to disk.\nMonitor for newly constructed files written to disk through a user visiting a website over the normal course of browsing.\nMonitor for newly constructed network connections to untrusted hosts that are used to send or receive data.",
+      "meta": {
+        "external_id": "AN1914",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0782#AN1914"
+        ]
+      },
+      "uuid": "32db74f9-d46d-4728-891a-113a8b8e2b07",
+      "value": "Analytic 1914 - AN1914"
+    },
+    {
       "description": "Unusual access to ~/Library/Keychains, ~/.bash_history, or Terminal command history by unauthorized processes or users.",
       "meta": {
         "external_id": "AN1155",
@@ -20575,6 +21000,17 @@
       "value": "Analytic 1159 - AN1159"
     },
     {
+      "description": "Monitor device management protocols for functions that modify programs such as online edit and program append events.\nMonitor device alarms that indicate the program has changed, although not all devices produce such alarms.\nEngineering and asset management software will often maintain a copy of the expected program loaded on a controller and may also record any changes made to controller programs. Data from these platforms can be used to identify modified controller programs.\nMonitor device application logs that indicate the program has changed, although not all devices produce such logs.",
+      "meta": {
+        "external_id": "AN1915",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0783#AN1915"
+        ]
+      },
+      "uuid": "882f2365-4c14-4c48-8eef-2a7c293c8569",
+      "value": "Analytic 1915 - AN1915"
+    },
+    {
       "description": "Automated scripts or repeated CLI/API requests that trigger application backends to consume high CPU or memory (e.g., Apache/PHP, MySQL, mail servers), resulting in syslog errors and excessive process spawning.",
       "meta": {
         "external_id": "AN1166",
@@ -20771,6 +21207,17 @@
       "value": "Analytic 1681 - AN1681"
     },
     {
+      "description": "Monitor for loss of network traffic which could indicate alarms are being suppressed. A loss of expected communications associated with network protocols used to communicate alarm events or process data could indicate this technique is being used. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor for loss of operational process data which could indicate alarms are being suppressed. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor for loss of expected device alarms which could indicate alarms are being suppressed. As noted in the technique description, there may be multiple sources of alarms in an ICS environment. Discrepancies between alarms may indicate the adversary is suppressing some but not all the alarms in the environment. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor for loss of expected operational process alarms which could indicate alarms are being suppressed. As noted in the technique description, there may be multiple sources of alarms in an ICS environment. Discrepancies between alarms may indicate the adversary is suppressing some but not all the alarms in the environment.  This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.",
+      "meta": {
+        "external_id": "AN1861",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0728#AN1861"
+        ]
+      },
+      "uuid": "edd8297d-ec63-4b54-8d28-106f228dd535",
+      "value": "Analytic 1861 - AN1861"
+    },
+    {
       "description": "Account discovery via VBA macros, COM objects, or embedded scripting.",
       "meta": {
         "external_id": "AN1619",
@@ -20840,6 +21287,17 @@
       },
       "uuid": "66adf2b9-42aa-401f-8bc3-3830854017ee",
       "value": "Analytic 1691 - AN1691"
+    },
+    {
+      "description": "Monitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\nMonitor for a loss of network communications, which may indicate this technique is being used.\nMonitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist alarms may still be visible even if command messages are blocked.",
+      "meta": {
+        "external_id": "AN1916",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0784#AN1916"
+        ]
+      },
+      "uuid": "11a350cf-1ea0-4065-877b-c3bb410bf3a0",
+      "value": "Analytic 1916 - AN1916"
     },
     {
       "description": "Multi-stage Windows DACL manipulation behavioral chain: (1) Process creation of permission-modifying utilities (icacls.exe, takeown.exe, attrib.exe, cacls.exe) or PowerShell ACL cmdlets, (2) Command-line analysis revealing privilege escalation intent through suspicious parameters (/grant, /takeown, /T, Set-Acl), (3) DACL modification events (4670) correlating with process execution, (4) Subsequent file access attempts (4663) indicating successful permission bypass, (5) Potential follow-on persistence or lateral movement activities",
@@ -20954,6 +21412,17 @@
       "value": "Analytic 1781 - AN1781"
     },
     {
+      "description": "Detecting software exploitation may be difficult depending on the tools available. Software exploits may not always succeed or may cause the exploited process to become unstable or crash.",
+      "meta": {
+        "external_id": "AN1871",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0738#AN1871"
+        ]
+      },
+      "uuid": "b6fb91d0-28f6-447d-ba25-e7b26116ebfe",
+      "value": "Analytic 1871 - AN1871"
+    },
+    {
       "description": "Identify processes issuing repeated DNS queries to random-looking domains with abnormal entropy or word concatenations. Correlate resolver logs with high NXDOMAIN rates and auditd socket connections.",
       "meta": {
         "external_id": "AN1179",
@@ -21024,6 +21493,17 @@
       "value": "Analytic 1791 - AN1791"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1917",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0785#AN1917"
+        ]
+      },
+      "uuid": "d71e98fa-64d1-4ddb-acb1-bba1e4af6a73",
+      "value": "Analytic 1917 - AN1917"
+    },
+    {
       "description": "Creation, deletion, or modification of security groups and firewall rules in cloud control plane logs that expand access to cloud resources beyond expected baselines. Defender view: unexpected ingress/egress rules permitting 0.0.0.0/0 or opening atypical ports, often correlated with privileged role or API key activity.",
       "meta": {
         "external_id": "AN1188",
@@ -21050,6 +21530,17 @@
       },
       "uuid": "ece5746f-194b-4564-9f5f-7ebf3b23542e",
       "value": "Analytic 1818 - AN1818"
+    },
+    {
+      "description": "Monitor for unexpected/abnormal access to files that may be malicious collection of local data, such as user files (e.g., .pdf, .docx, .jpg, .dwg   ) or local databases.\nMonitor for newly executed processes that may search local system sources, such as file systems or local databases, to find files of interest and sensitive data.\nMonitor for any suspicious attempts to enable scripts running on a system. If scripts are not commonly used on a system, but enabled, scripts running out of cycle from patching or other administrator functions are suspicious. Scripts should be captured from the file system when possible to determine their actions and intent. Data may also be acquired through Windows system management tools such as [Windows Management Instrumentation](https://attack.mitre.org/techniques/T1047) and [PowerShell](https://attack.mitre.org/techniques/T1059/001).\nMonitor for API calls that may search local system sources, such as file systems or local databases, to find files of interest and sensitive data. \nMonitor executed commands and arguments that may search and collect local system sources, such as file systems or local databases, to find files of interest and sensitive data. Remote access tools with built-in features may interact directly with the Windows API to gather data. Data may also be acquired through Windows system management tools such as [Windows Management Instrumentation](https://attack.mitre.org/techniques/T1047) and [PowerShell](https://attack.mitre.org/techniques/T1059/001).",
+      "meta": {
+        "external_id": "AN1881",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0749#AN1881"
+        ]
+      },
+      "uuid": "0099659c-6a20-4331-9d47-b1c0c380fd6b",
+      "value": "Analytic 1881 - AN1881"
     },
     {
       "description": "Detects unusual outbound connections to web services from uncommon processes using SSL/TLS, particularly those exhibiting high outbound data volume or persistence.",
@@ -21108,6 +21599,28 @@
       "value": "Analytic 1819 - AN1819"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1918",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0786#AN1918"
+        ]
+      },
+      "uuid": "7ec4b791-7054-442f-8967-6d6fa5e8678b",
+      "value": "Analytic 1918 - AN1918"
+    },
+    {
+      "description": "Monitor and analyze traffic patterns and packet inspection associated to protocol(s) that do not follow the expected protocol standards and traffic flows (e.g., extraneous packets that do not belong to established flows, gratuitous or anomalous traffic patterns, anomalous syntax, or structure). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments associated to traffic patterns (e.g., monitor anomalies in use of files that do not normally initiate connections for respective protocol(s)).\nMonitor for known proxy protocols (e.g., SOCKS, Tor, peer-to-peer protocols) and tool usage (e.g., Squid,  peer-to-peer software) on the network that are not part of normal operations. Also monitor network data for uncommon data flows. Processes utilizing the network that do not normally have network communication or have never been seen before are suspicious.",
+      "meta": {
+        "external_id": "AN1891",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0759#AN1891"
+        ]
+      },
+      "uuid": "ece52da2-ac60-4b0e-863f-ebbc95118a8c",
+      "value": "Analytic 1891 - AN1891"
+    },
+    {
       "description": "Once adversaries leverage compromised network devices as infrastructure (ex: for command and control), it may be possible to look for unique characteristics associated with adversary software, if known.(Citation: ThreatConnect Infrastructure Dec 2020) Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle. ",
       "meta": {
         "external_id": "AN1991",
@@ -21135,6 +21648,18 @@
       },
       "uuid": "571b10ce-fb7d-492e-b05a-23649ae14148",
       "value": "Analytic 1199 - AN1199"
+    },
+    {
+      "description": "Monitor for new ICS protocol connections to existing assets or for device scanning (i.e., a host connecting to many devices) over ICS and enterprise protocols (e.g., ICMP, DCOM, WinRM).\nMonitor for anomalies related to discovery related ICS functions, including devices that have not previously used these functions or for functions being sent to many outstations. Note that some ICS protocols use broadcast or multicast functionality, which may produce false positives. Also monitor for hosts enumerating network connected resources using non-ICS enterprise protocols.\nMonitor for files (such as /etc/hosts) being accessed that may attempt to get a listing of other systems by IP address, hostname, or other logical identifier on a network that may be used for Lateral Movement from the current system.\nMonitor for newly executed processes that can be used to discover remote systems, such as ping.exe and tracert.exe, especially when executed in quick succession.(Citation: Elastic - Koadiac Detection with EQL) Consider monitoring for new processes engaging in scanning activity or connecting to multiple systems by correlating process creation network data.",
+      "meta": {
+        "external_id": "AN1919",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0787#AN1919",
+          "https://www.elastic.co/security-labs/embracing-offensive-tooling-building-detections-against-koadic-using-eql"
+        ]
+      },
+      "uuid": "f123f13f-b6f4-4e86-96cd-14df0e855e0f",
+      "value": "Analytic 1919 - AN1919"
     },
     {
       "description": "Detection of anomalous registry modifications to Subject Interface Packages (SIPs) or trust provider DLL mappings, unexpected loading of non-Microsoft cryptographic modules, or attempts to redirect WinVerifyTrust validation logic. Defender view focuses on registry tampering, suspicious DLL loads into trusted processes, and abnormal trust validation failures correlated across event streams.",
@@ -21429,6 +21954,21 @@
       },
       "uuid": "4f2bc468-a57d-44e9-b9cd-d491df6b0daf",
       "value": "Analytic 1292 - AN1292"
+    },
+    {
+      "description": "Monitor for firmware changes which may be observable via operational alarms from devices.\nMonitor device application logs for firmware changes, although not all devices will produce such logs.\nMonitor ICS management protocols / file transfer protocols for protocol functions related to firmware changes.\nMonitor firmware for unexpected changes. Asset management systems should be consulted to understand known-good firmware versions. Dump and inspect BIOS images on vulnerable systems and compare against known good images.(Citation: MITRE Copernicus) Analyze differences to determine if malicious changes have occurred. Log attempts to read/write to BIOS and compare against known patching behavior. Likewise, EFI modules can be collected and compared against a known-clean list of EFI executable binaries to detect potentially malicious modules. The CHIPSEC framework can be used for analysis to determine if firmware modifications have been performed.(Citation: McAfee CHIPSEC Blog)(Citation: Github CHIPSEC)(Citation: Intel HackingTeam UEFI Rootkit)",
+      "meta": {
+        "external_id": "AN1922",
+        "refs": [
+          "http://www.mitre.org/capabilities/cybersecurity/overview/cybersecurity-blog/copernicus-question-your-assumptions-about",
+          "https://attack.mitre.org/detectionstrategies/DET0790#AN1922",
+          "https://github.com/chipsec/chipsec",
+          "https://securingtomorrow.mcafee.com/business/chipsec-support-vault-7-disclosure-scanning/",
+          "https://web.archive.org/web/20170313124421/http://www.intelsecurity.com/advanced-threat-research/content/data/HT-UEFI-rootkit.html"
+        ]
+      },
+      "uuid": "880a1133-6639-42f0-96a8-3e914426d38b",
+      "value": "Analytic 1922 - AN1922"
     },
     {
       "description": "Monitor resolver logs and auditd events for domains resolving to a rotating set of IPs within very short TTL intervals. Correlate high query rates from non-browser applications (e.g., python, curl).",
@@ -21949,6 +22489,28 @@
       "value": "Analytic 1392 - AN1392"
     },
     {
+      "description": "Monitor for newly executed processes that can aid in sniffing network traffic to capture information about an environment.\nMonitor executed commands and arguments for actions that aid in sniffing network traffic to capture information about an environment.",
+      "meta": {
+        "external_id": "AN1932",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0800#AN1932"
+        ]
+      },
+      "uuid": "28eb77c1-1834-4b7a-a06f-afebb7f2e756",
+      "value": "Analytic 1932 - AN1932"
+    },
+    {
+      "description": "Monitor for newly executed processes that depend on user interaction, especially for applications that can embed programmatic capabilities (e.g., Microsoft Office products with scripts, installers, zip files). This includes compression applications, such as those for zip files, that can be used to [Deobfuscate/Decode Files or Information](https://attack.mitre.org/techniques/T1140) in payloads. For added context on adversary procedures and background see [User Execution](https://attack.mitre.org/techniques/T1204) and applicable sub-techniques.\nMonitor for application logging, messaging, and/or other artifacts that may rely upon specific actions by a user in order to gain execution.\nMonitor for newly constructed web-based network connections that are sent to malicious or suspicious destinations (e.g., destinations attributed to phishing campaigns). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments (e.g., monitor anomalies in use of files that do not normally initiate network connections or unusual connections initiated by regsvr32.exe, rundll.exe, SCF, HTA, MSI, DLLs, or msiexec.exe). \nAnti-virus can potentially detect malicious documents and files that are downloaded and executed on the user's computer. Endpoint sensing or network sensing can potentially detect malicious events once the file is opened (such as a Microsoft Word document or PDF reaching out to the internet or spawning PowerShell).\nMonitor for newly executed processes that depend on user interaction, especially for applications that can embed programmatic capabilities (e.g., Microsoft Office products with scripts, installers, zip files). This includes compression applications, such as those for zip files, that can be used to [Deobfuscate/Decode Files or Information](https://attack.mitre.org/techniques/T1140) in payloads.\nMonitor and analyze traffic patterns and packet inspection associated with web-based network connections that are sent to malicious or suspicious destinations (e.g., destinations attributed to phishing campaigns). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments (e.g., monitor anomalies in use of files that do not normally initiate network connections or unusual connections initiated by regsvr32.exe, rundll.exe, SCF, HTA, MSI, DLLs, or msiexec.exe).",
+      "meta": {
+        "external_id": "AN1923",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0791#AN1923"
+        ]
+      },
+      "uuid": "d937e4b8-20f2-44c1-9940-48c74318c715",
+      "value": "Analytic 1923 - AN1923"
+    },
+    {
       "description": "Detect user-initiated kextload commands or modifications to /Library/Extensions. Correlate with changes to KextPolicy database or unauthorized developer signing identities. Alert on attempts to disable SIP or load legacy extensions from unsigned sources.",
       "meta": {
         "external_id": "AN1244",
@@ -22397,6 +22959,17 @@
       "value": "Analytic 1294 - AN1294"
     },
     {
+      "description": "Consult asset management systems which may help with the detection of computer systems or network devices that should not exist on a network.\nMonitor for network traffic originating from unknown/unexpected devices or addresses.  Local network traffic metadata could be used to identify unexpected connections, including unknown/unexpected source MAC addresses connecting to ports associated with operational protocols. Also, network management protocols such as DHCP and ARP may be helpful in identifying unexpected devices. \nMonitor for new master devices communicating with outstations, which may be visible in alarms within the ICS environment.\nMonitor for unexpected ICS protocol functions from new and existing devices. Monitoring known devices requires ICS function level insight to determine if an unauthorized device is issuing commands (e.g., a historian).\nMonitor for new master devices communicating with outstation assets, which may be visible in asset application logs.",
+      "meta": {
+        "external_id": "AN1924",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0792#AN1924"
+        ]
+      },
+      "uuid": "37d989e6-14cd-49a4-adec-3d8b72c8dc22",
+      "value": "Analytic 1924 - AN1924"
+    },
+    {
       "description": "Login attempt failures over SNMP, Telnet, or SSH interface, often reflected in logs or syslog events",
       "meta": {
         "external_id": "AN1525",
@@ -22763,6 +23336,17 @@
       "value": "Analytic 1295 - AN1295"
     },
     {
+      "description": "Monitor for any suspicious attempts to enable script execution on a system. If scripts are not commonly used on a system, but enabled, scripts running out of cycle from patching or other administrator functions are suspicious. Scripts should be captured from the file system when possible to determine their actions and intent.\nMonitor executed commands and associated arguments for application programs which support executing custom code, scripts, commands, or executables. \nMonitor for unusual processes execution, especially for processes that allow the proxy execution of malicious files.",
+      "meta": {
+        "external_id": "AN1925",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0793#AN1925"
+        ]
+      },
+      "uuid": "23ce0ac3-6afe-4647-be72-e1e9bcd1490e",
+      "value": "Analytic 1925 - AN1925"
+    },
+    {
       "description": "Detects attempts to modify file timestamps via API usage (e.g., `SetFileTime`), CLI tools (e.g., `w32tm`, PowerShell), or double-timestomp behavior where $SI and $FN timestamps are mismatched or reverted.",
       "meta": {
         "external_id": "AN1626",
@@ -22959,6 +23543,17 @@
       "value": "Analytic 1682 - AN1682"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1862",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0729#AN1862"
+        ]
+      },
+      "uuid": "8428e0cd-009e-41c1-8292-88651d4486c9",
+      "value": "Analytic 1862 - AN1862"
+    },
+    {
       "description": "Use of leaked credential pairs against Outlook Web Access (OWA), Microsoft 365, or Exchange from a single client IP with multiple failures",
       "meta": {
         "external_id": "AN1269",
@@ -23027,6 +23622,17 @@
       },
       "uuid": "c956f269-d282-4c68-afc6-ca68d8532ab6",
       "value": "Analytic 1692 - AN1692"
+    },
+    {
+      "description": "Monitor industrial process history data for events that correspond with command message functions, such as setpoint modification or changes to system status for key devices. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor for anomalous or unexpected commands that may result in changes to the process operation (e.g., discrete write, logic and device configuration, mode changes) observable via asset application logs.\nMonitor for new or unexpected connections to controllers, which could indicate an Unauthorized Command Message being sent via [Rogue Master](https://attack.mitre.org/techniques/T0848).\nMonitor for anomalous or unexpected commands that may result in changes to the process operation (e.g., discrete write, logic and device configuration, mode changes) observable via asset application logs.\nMonitor for unexpected ICS protocol command functions to controllers from existing master devices (including from new processes) or from new devices. The latter is like detection for [Rogue Master](https://attack.mitre.org/techniques/T0848) but requires ICS function level insight to determine if an unauthorized device is issuing commands (e.g., a historian).\n\nMonitoring for unexpected or problematic values below the function level will provide better insights into potentially malicious activity but at the cost of additional false positives depending on the underlying operational process.",
+      "meta": {
+        "external_id": "AN1926",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0794#AN1926"
+        ]
+      },
+      "uuid": "23eb2bc3-735d-4425-96e1-f9d3a1453bfa",
+      "value": "Analytic 1926 - AN1926"
     },
     {
       "description": "Password spraying or brute force attempts across user pool within short time intervals",
@@ -23141,6 +23747,18 @@
       "value": "Analytic 1782 - AN1782"
     },
     {
+      "description": "Monitor for files (such as /etc/hosts) being accessed that may attempt to get a listing of other systems by IP address, hostname, or other logical identifier on a network that may be used for Lateral Movement from the current system.\nMonitor for newly executed processes that can be used to discover remote systems, such as ping.exe and tracert.exe  , especially when executed in quick succession.(Citation: Elastic - Koadiac Detection with EQL) Consider monitoring for new processes engaging in scanning activity or connecting to multiple systems by correlating process creation network data.\nMonitor for anomalies related to discovery related ICS functions, including devices that have not previously used these functions or for functions being sent to many outstations. Note that some ICS protocols use broadcast or multicast functionality, which may produce false positives. Also monitor for hosts enumerating network connected resources using non-ICS enterprise protocols.\nMonitor for new ICS protocol connections to existing assets or for device scanning (i.e., a host connecting to many devices) over ICS and enterprise protocols (e.g., ICMP, DCOM, WinRM). For added context on adversary enterprise procedures and background see [Remote System Discovery](https://attack.mitre.org/techniques/T1018).",
+      "meta": {
+        "external_id": "AN1872",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0739#AN1872",
+          "https://www.elastic.co/security-labs/embracing-offensive-tooling-building-detections-against-koadic-using-eql"
+        ]
+      },
+      "uuid": "322ac45b-d540-4d2a-84a1-cde200238b95",
+      "value": "Analytic 1872 - AN1872"
+    },
+    {
       "description": "ESXi hosts initiating connections from non-standard daemons mimicking HTTP/HTTPS or SNMP traffic, but with irregular payload formats or expired/unsigned TLS certificates.",
       "meta": {
         "external_id": "AN1297",
@@ -23212,6 +23830,17 @@
       "value": "Analytic 1729 - AN1729"
     },
     {
+      "description": "Detecting software exploitation may be difficult depending on the tools available. Software exploits may not always succeed or may cause the exploited process to become unstable or crash.",
+      "meta": {
+        "external_id": "AN1927",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0795#AN1927"
+        ]
+      },
+      "uuid": "fbd4686e-f637-459b-ad48-c6fd7840acfa",
+      "value": "Analytic 1927 - AN1927"
+    },
+    {
       "description": "Execution of Microsoft-signed scripts (e.g., pubprn.vbs, installutil.exe, wscript.exe, cscript.exe) used to proxy execution of untrusted or external binaries. Behavior is detected through command-line process lineage, child process spawning, and unsigned payload execution from signed parent.",
       "meta": {
         "external_id": "AN1288",
@@ -23238,6 +23867,17 @@
       },
       "uuid": "7c96d701-391d-4904-b6ba-941344aaf059",
       "value": "Analytic 1828 - AN1828"
+    },
+    {
+      "description": "Monitor executed commands and arguments that may delete or alter generated artifacts on a host system, including logs or captured files such as quarantined malware.\nMonitor for API calls that may delete or alter generated artifacts on a host system, including logs or captured files such as quarantined malware.\nMonitor for changes made to Windows Registry keys or values that may delete or alter generated artifacts on a host system, including logs or captured files such as quarantined malware. For added context on adversary procedures and background see [Indicator Removal](https://attack.mitre.org/techniques/T1070) and applicable sub-techniques.\nMonitor for contextual file data that may show signs of deletion or alter generated artifacts on a host system, including logs or captured files such as quarantined malware.\nMonitor Windows registry keys that may be deleted or alter generated artifacts on a host system, including logs or captured files such as quarantined malware. For added context on adversary procedures and background see [Indicator Removal](https://attack.mitre.org/techniques/T1070) and applicable sub-techniques.\nMonitor for a file that may delete or alter generated artifacts on a host system, including logs or captured files such as quarantined malware.\nMonitor for changes made to a file may delete or alter generated artifacts on a host system, including logs or captured files such as quarantined malware.\nMonitor for newly executed processes that may delete or alter generated artifacts on a host system, including logs or captured files such as quarantined malware.",
+      "meta": {
+        "external_id": "AN1882",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0750#AN1882"
+        ]
+      },
+      "uuid": "55544bb8-440f-4b67-aa35-7e7af5952aca",
+      "value": "Analytic 1882 - AN1882"
     },
     {
       "description": "Detects thread local storage (TLS) callback injection by monitoring memory modifications to PE headers and TLS directory structures during or after process hollowing events, followed by anomalous thread behavior prior to main entry point execution.",
@@ -23300,6 +23940,28 @@
       "value": "Analytic 1829 - AN1829"
     },
     {
+      "description": "On Windows and Unix systems monitor executed commands and arguments that may use shell commands for execution. Shells may be common on administrator, developer, or power user systems depending on job function.\n\nOn network device and embedded system CLIs consider reviewing command history if unauthorized or suspicious commands were used to modify device configuration.\nMonitor logs from installed applications (e.g., historian logs) for unexpected commands or abuse of system features.\nMonitor for processes spawning from known command shell applications (e.g., PowerShell, Bash). Benign activity will need to be allow-listed. This information can be useful in gaining additional insight to adversaries' actions through how they use native processes or custom tools.",
+      "meta": {
+        "external_id": "AN1892",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0760#AN1892"
+        ]
+      },
+      "uuid": "7107739b-92d2-41fa-9fc8-ebe72f6086ee",
+      "value": "Analytic 1892 - AN1892"
+    },
+    {
+      "description": "Monitor logon activity for unexpected or unusual access to devices from the Internet.\nMonitor for unexpected protocols to/from the Internet. While network traffic content and logon session metadata may directly identify a login event, new Internet-based network flows may also be a reliable indicator of this technique.\nMonitor for unusual logins to Internet connected devices or unexpected protocols to/from the Internet. Network traffic content will provide valuable context and details about the content of network flows.",
+      "meta": {
+        "external_id": "AN1928",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0796#AN1928"
+        ]
+      },
+      "uuid": "87f5d864-d79b-474a-a3b4-43673dcb9f90",
+      "value": "Analytic 1928 - AN1928"
+    },
+    {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
       "meta": {
         "external_id": "AN1992",
@@ -23326,6 +23988,17 @@
       },
       "uuid": "7518f788-43dd-440a-955c-870cdb7dea26",
       "value": "Analytic 1299 - AN1299"
+    },
+    {
+      "description": "Monitor asset alarms which may help identify a loss of communications. Consider correlating alarms with other data sources that indicate traffic has been blocked, such as network traffic. In cases where alternative methods of communicating with outstations exist alarms may still be visible even if messages over serial COM ports are blocked.\nMonitor for a loss of network communications, which may indicate this technique is being used.\nMonitor for lack of operational process data which may help identify a loss of communications. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nMonitor application logs for changes to settings and other events associated with network protocols that may be used to block communications.\nMonitor for the termination of processes or services associated with ICS automation protocols and application software which could help detect blocked communications.",
+      "meta": {
+        "external_id": "AN1929",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0797#AN1929"
+        ]
+      },
+      "uuid": "354b93da-06e9-4634-a5fd-7f9b7b3a9d5a",
+      "value": "Analytic 1929 - AN1929"
     },
     {
       "description": "Use unified logs to identify processes issuing repeated DNS queries where the resolved IP addresses change frequently within very short TTL values. Correlate with outbound network traffic to validate C2-like patterns.",
@@ -23578,6 +24251,17 @@
       },
       "uuid": "d9383849-c91c-4eef-88a0-97c2454ca1af",
       "value": "Analytic 1393 - AN1393"
+    },
+    {
+      "description": "Monitor for a loss of network communications, which may indicate a device has been shutdown or restarted. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.\nDevice restarts and shutdowns may be observable in device application logs. Monitor for unexpected device restarts or shutdowns.\nDevices may produce alarms about restarts or shutdowns. Monitor for unexpected device restarts or shutdowns.\nMonitor ICS automation protocols for functions that restart or shutdown a device. Commands to restart or shutdown devices may also be observable in traditional IT management protocols.",
+      "meta": {
+        "external_id": "AN1933",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0801#AN1933"
+        ]
+      },
+      "uuid": "fcfe9c48-3a5a-49c8-96c3-be79414a8419",
+      "value": "Analytic 1933 - AN1933"
     },
     {
       "description": "Executable or script generating large outbound network traffic targeting remote hosts or known amplification ports",
@@ -24028,6 +24712,17 @@
       "value": "Analytic 1394 - AN1394"
     },
     {
+      "description": "Monitor ICS automation network protocols for information that an asset has been placed into Firmware Update Mode.\nMonitor device alarms that indicate the devices has been placed into Firmware Update Mode, although not all devices produce such alarms.\nMonitor asset log which may provide information that an asset has been placed into Firmware Update Mode. Some assets may log firmware updates themselves without logging that the device has been placed into update mode.",
+      "meta": {
+        "external_id": "AN1934",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0802#AN1934"
+        ]
+      },
+      "uuid": "96e7b86f-b960-489c-882b-9dcdb1c44aa9",
+      "value": "Analytic 1934 - AN1934"
+    },
+    {
       "description": "Execution of system utilities like 'system_profiler' and 'ioreg' to enumerate hardware components or USB devices, particularly if followed by clipboard, file, or network activity.",
       "meta": {
         "external_id": "AN1355",
@@ -24393,6 +25088,17 @@
       "value": "Analytic 1539 - AN1539"
     },
     {
+      "description": "Monitor for network traffic originating from unknown/unexpected systems.\nMonitor authentication logs and analyze for unusual access patterns, windows of activity, and access outside of normal business hours, including use of [Valid Accounts](https://attack.mitre.org/techniques/T0859).\nWhen authentication is not required to access an exposed remote service, monitor for follow-on activities such as anomalous external use of the exposed API or application.",
+      "meta": {
+        "external_id": "AN1935",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0803#AN1935"
+        ]
+      },
+      "uuid": "908fe88b-d8e2-47d1-b6a4-7a42b3bbe09b",
+      "value": "Analytic 1935 - AN1935"
+    },
+    {
       "description": "Detects exploitation of IaaS cloud security boundaries to evade defense controls. Defender perspective includes anomalous API calls that bypass audit logging, disable monitoring, or manipulate guardrails (e.g., CloudTrail tampering). Correlation highlights when exploitation attempts precede sudden absence of expected telemetry.",
       "meta": {
         "external_id": "AN1636",
@@ -24589,6 +25295,17 @@
       "value": "Analytic 1683 - AN1683"
     },
     {
+      "description": "Use verification of distributed binaries through hash checking or other integrity checking mechanisms. Scan downloads for malicious signatures.",
+      "meta": {
+        "external_id": "AN1863",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0730#AN1863"
+        ]
+      },
+      "uuid": "899d0dce-64f7-4924-93a1-8e3c83dd510f",
+      "value": "Analytic 1863 - AN1863"
+    },
+    {
       "description": "Detection of obfuscated commands via shell, osascript, or AppleScript interpreters using unusual tokens, encoding, variable substitution, or runtime string reconstruction.",
       "meta": {
         "external_id": "AN1396",
@@ -24660,6 +25377,17 @@
       },
       "uuid": "5e90ac48-345b-445a-877f-596737ad7efb",
       "value": "Analytic 1693 - AN1693"
+    },
+    {
+      "description": "Monitor network data for uncommon  data flows (e.g., time of day, unusual source/destination address) that may be related to abuse of [Valid Accounts](https://attack.mitre.org/techniques/T0859) to log into a service specifically designed to accept remote connections, such as RDP, Telnet, SSH, and VNC.\nMonitor DLL file events, specifically creation of these files as well as the loading of DLLs into processes specifically designed to accept remote connections, such as RDP, Telnet, SSH, and VNC.\nMonitor for user accounts logged into systems they would not normally access or abnormal access patterns, such as multiple systems over a relatively short period of time. Correlate use of login activity related to remote services with unusual behavior or other malicious or suspicious activity. Adversaries will likely need to learn about an environment and the relationships between systems through Discovery techniques prior to attempting Lateral Movement. For added context on adversary procedures and background see [Remote Services](https://attack.mitre.org/techniques/T1021) and applicable sub-techniques.\nMonitor for newly executed processes related to services specifically designed to accept remote connections, such as RDP, Telnet, SSH, and VNC. The adversary may use [Valid Accounts](https://attack.mitre.org/techniques/T0859) to login and may perform follow-on actions that spawn additional processes as the user.\nMonitor executed commands and arguments to services specifically designed to accept remote connections, such as RDP, Telnet, SSH, and VNC. The adversary may then perform these actions using [Valid Accounts](https://attack.mitre.org/techniques/T0859).\nMonitor for newly constructed network connections into a service specifically designed to accept remote connections, such as RDP, Telnet, SSH, and VNC. Monitor network connections involving common remote management protocols, such as ports tcp:3283 and tcp:5900, as well as ports tcp:3389 and tcp:22 for remote logins. The adversary may use [Valid Accounts](https://attack.mitre.org/techniques/T0859) to enable remote logins.\nMonitor interactions with network shares, such as reads or file transfers, using remote services such as Server Message Block (SMB). For added context on adversary procedures and background see [Remote Services](https://attack.mitre.org/techniques/T1021) and applicable sub-techniques.",
+      "meta": {
+        "external_id": "AN1936",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0804#AN1936"
+        ]
+      },
+      "uuid": "058d856a-6356-402f-b3ff-a7c1b6186921",
+      "value": "Analytic 1936 - AN1936"
     },
     {
       "description": "Creation of outbound connections on alternate ports or using covert transport (e.g., ICMP, DNS) from non-network-intensive processes, following known disruption or blocked traffic.",
@@ -24772,6 +25500,17 @@
       },
       "uuid": "fbc0a210-8942-4fcb-81f1-a120551013d4",
       "value": "Analytic 1837 - AN1837"
+    },
+    {
+      "description": "Detecting software exploitation may be difficult depending on the tools available. Software exploits may not always succeed or may cause the exploited process to become unstable or crash. Web Application Firewalls may detect improper inputs attempting exploitation.\nUse deep packet inspection to look for artifacts of common exploit traffic, such as known payloads.",
+      "meta": {
+        "external_id": "AN1873",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0740#AN1873"
+        ]
+      },
+      "uuid": "dd25b818-ceb0-4518-9384-dcf895d4956b",
+      "value": "Analytic 1873 - AN1873"
     },
     {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders. \n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
@@ -24887,6 +25626,19 @@
       "value": "Analytic 1838 - AN1838"
     },
     {
+      "description": "Monitor executed commands and arguments that may attempt to take screen captures of the desktop to gather information over the course of an operation.\nMonitoring for screen capture behavior will depend on the method used to obtain data from the operating system and write output files. Detection methods could include collecting information from unusual processes using API calls used to obtain image data, and monitoring for image files written to disk, such as CopyFromScreen, xwd, or screencapture.(Citation: CopyFromScreen .NET)(Citation: Antiquated Mac Malware) The data may need to be correlated with other events to identify malicious activity, depending on the legitimacy of this behavior within a given network environment.",
+      "meta": {
+        "external_id": "AN1883",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0751#AN1883",
+          "https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/",
+          "https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen?view=netframework-4.8"
+        ]
+      },
+      "uuid": "66070162-d51e-46e7-8d32-2140fd5e7086",
+      "value": "Analytic 1883 - AN1883"
+    },
+    {
       "description": "Detects the execution of non-browser processes establishing outbound encrypted network connections using uncommon symmetric encryption protocols (e.g., AES via PowerShell or custom scripts) to alternate external destinations.",
       "meta": {
         "external_id": "AN1389",
@@ -24956,6 +25708,17 @@
       },
       "uuid": "98b0a8a6-881d-4f00-84c3-3f70d368067e",
       "value": "Analytic 1839 - AN1839"
+    },
+    {
+      "description": "Program uploads may be observable in ICS management protocols or file transfer protocols. Note when protocol functions related to program uploads occur. In cases where the ICS protocols is not well understood, one option is to examine network traffic for the program files themselves using signature-based tools.\nMonitor device communication patterns to identify irregular bulk transfers of data between the embedded ICS asset and other nodes within the network. Note these indicators are dependent on the profile of normal operations and the capabilities of the industrial automation protocols involved (e.g., partial program uploads).\nMonitor for device alarms produced when program uploads occur, although not all devices will produce such alarms.",
+      "meta": {
+        "external_id": "AN1893",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0761#AN1893"
+        ]
+      },
+      "uuid": "3c6a21cb-8643-41bc-94a1-e860b02a1cad",
+      "value": "Analytic 1893 - AN1893"
     },
     {
       "description": "Detects process injection by correlating memory manipulation API calls (e.g., VirtualAllocEx, WriteProcessMemory), suspicious thread creation (e.g., CreateRemoteThread), and unusual DLL loads within another process's context.",
@@ -25801,6 +26564,21 @@
       "value": "Analytic 1684 - AN1684"
     },
     {
+      "description": "Monitor for firmware changes which may be observable via operational alarms from devices.\nMonitor device application logs for firmware changes, although not all devices will produce such logs.\nMonitor firmware for unexpected changes. Asset management systems should be consulted to understand known-good firmware versions. Dump and inspect BIOS images on vulnerable systems and compare against known good images.(Citation: MITRE Copernicus) Analyze differences to determine if malicious changes have occurred. Log attempts to read/write to BIOS and compare against known patching behavior. Likewise, EFI modules can be collected and compared against a known-clean list of EFI executable binaries to detect potentially malicious modules. The CHIPSEC framework can be used for analysis to determine if firmware modifications have been performed.(Citation: McAfee CHIPSEC Blog)(Citation: Github CHIPSEC)(Citation: Intel HackingTeam UEFI Rootkit)\nMonitor ICS management protocols / file transfer protocols for protocol functions related to firmware changes.",
+      "meta": {
+        "external_id": "AN1864",
+        "refs": [
+          "http://www.mitre.org/capabilities/cybersecurity/overview/cybersecurity-blog/copernicus-question-your-assumptions-about",
+          "https://attack.mitre.org/detectionstrategies/DET0731#AN1864",
+          "https://github.com/chipsec/chipsec",
+          "https://securingtomorrow.mcafee.com/business/chipsec-support-vault-7-disclosure-scanning/",
+          "https://web.archive.org/web/20170313124421/http://www.intelsecurity.com/advanced-threat-research/content/data/HT-UEFI-rootkit.html"
+        ]
+      },
+      "uuid": "3f10ffe9-fa73-4aeb-bf98-322831bf757f",
+      "value": "Analytic 1864 - AN1864"
+    },
+    {
       "description": "Processes not typically associated with encryption loading asymmetric crypto libraries (e.g., rsaenh.dll, crypt32.dll) and subsequently initiating outbound TLS/SSL connections with abnormal certificate chains or handshakes. Defender correlates process creation, module load, and unusual encrypted sessions.",
       "meta": {
         "external_id": "AN1496",
@@ -25999,6 +26777,17 @@
       "value": "Analytic 1784 - AN1784"
     },
     {
+      "description": "Monitor asset application logs for information that indicate task parameters have changed.\nMonitor device alarms that indicate controller task parameters have changed, although not all devices produce such alarms.\n \n[Program Download](https://attack.mitre.org/techniques/T0843) may be used to enable this technique. Monitor for program downloads which may be noticeable via operational alarms. Asset management systems should be consulted to understand expected program versions.\nEngineering and asset management software will often maintain a copy of the expected program loaded on a controller and may also record any changes made to controller programs and tasks. Data from these platforms can be used to identify modified controller tasking.",
+      "meta": {
+        "external_id": "AN1874",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0741#AN1874"
+        ]
+      },
+      "uuid": "2195ec67-7cea-4b0d-a678-18384089bf2c",
+      "value": "Analytic 1874 - AN1874"
+    },
+    {
       "description": "Processes (e.g., bash, python, custom binaries) dynamically linking libcrypto/libssl for RSA key exchange, then creating external connections with abnormal certificate validation or handshake anomalies. Defender observes syscall traces and outbound asymmetric key exchanges from non-SSL-native processes.",
       "meta": {
         "external_id": "AN1497",
@@ -26111,6 +26900,17 @@
       "value": "Analytic 1848 - AN1848"
     },
     {
+      "description": "Monitor device alarms for program downloads, although not all devices produce such alarms.\nMonitor for protocol functions related to program download or modification. Program downloads may be observable in ICS automation protocols and remote management protocols.\nConsult asset management systems to understand expected program versions.\nMonitor devices configuration logs which may contain alerts that indicate whether a program download has occurred. Devices may maintain application logs that indicate whether a full program download, online edit, or program append function has occurred.",
+      "meta": {
+        "external_id": "AN1884",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0752#AN1884"
+        ]
+      },
+      "uuid": "b74100d1-0085-468a-834a-2bf10924a3b7",
+      "value": "Analytic 1884 - AN1884"
+    },
+    {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
       "meta": {
         "external_id": "AN1948",
@@ -26180,6 +26980,17 @@
       },
       "uuid": "d7e3296a-9f95-4061-b3f5-0f02910745ab",
       "value": "Analytic 1849 - AN1849"
+    },
+    {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1894",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0762#AN1894"
+        ]
+      },
+      "uuid": "636e612f-0b63-44e8-bf2c-31b62d20508b",
+      "value": "Analytic 1894 - AN1894"
     },
     {
       "description": "VMware services (hostd, vpxa) unexpectedly negotiating asymmetric crypto sessions to external endpoints outside vCenter or update servers. Defender sees encrypted handshakes in logs inconsistent with baseline ESXi communication patterns.",
@@ -26348,6 +27159,23 @@
       },
       "uuid": "8ed1a27f-3a60-441d-b92d-dc7b086db459",
       "value": "Analytic 1558 - AN1558"
+    },
+    {
+      "description": "Monitor for API calls that can be used to install a hook procedure, such as the SetWindowsHookEx and SetWinEventHook functions.(Citation: Microsoft Hook Overview)(Citation: Volatility Detecting Hooks Sept 2012) Also consider analyzing hook chains (which hold pointers to hook procedures for each type of hook) using tools(Citation: Volatility Detecting Hooks Sept 2012)(Citation: PreKageo Winhook Jul 2011)(Citation: Jay GetHooks Sept 2011) or by programmatically examining internal kernel structures.(Citation: Zairon Hooking Dec 2006)(Citation: EyeofRa Detecting Hooking June 2017)\nVerify integrity of live processes by comparing code in memory to that of corresponding static binaries, specifically checking for jumps and other instructions that redirect code flow.",
+      "meta": {
+        "external_id": "AN1855",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0722#AN1855",
+          "https://eyeofrablog.wordpress.com/2017/06/27/windows-keylogger-part-2-defense-against-user-land/",
+          "https://github.com/jay/gethooks",
+          "https://github.com/prekageo/winhook",
+          "https://msdn.microsoft.com/library/windows/desktop/ms644959.aspx",
+          "https://volatility-labs.blogspot.com/2012/09/movp-31-detecting-malware-hooks-in.html",
+          "https://zairon.wordpress.com/2006/12/06/any-application-defined-hook-procedure-on-my-machine/"
+        ]
+      },
+      "uuid": "05ca4f07-df4f-4e88-b216-f40ca6ce39b8",
+      "value": "Analytic 1855 - AN1855"
     },
     {
       "description": "Monitor for suspicious usage of driver enumeration utilities (driverquery.exe) or API calls such as EnumDeviceDrivers(). Registry queries against HKLM\\SYSTEM\\CurrentControlSet\\Services and HardwareProfiles that are abnormal may also indicate attempts to discover installed drivers and services. Correlate command execution, process creation, and registry access to build a behavioral chain of driver discovery.",
@@ -26578,6 +27406,28 @@
       "value": "Analytic 1658 - AN1658"
     },
     {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1865",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0732#AN1865"
+        ]
+      },
+      "uuid": "cd4c92f9-3107-45c7-9d95-19a44d7dc92c",
+      "value": "Analytic 1865 - AN1865"
+    },
+    {
+      "description": "Monitor and analyze traffic patterns and packet inspection associated to protocol(s) that do not follow the expected protocol standards and traffic flows (e.g., extraneous packets that do not belong to established flows, gratuitous or anomalous traffic patterns, anomalous syntax, or structure). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments associated to traffic patterns (e.g., monitor anomalies in use of files that do not normally initiate connections for respective protocol(s)).\nMonitor network data for uncommon data flows. Processes utilizing the network that do not normally have network communication or have never been seen before are suspicious.\nMonitor for application logging, messaging, and/or other artifacts that may result from  Denial of Service (DoS) attacks which degrade or block the availability of services to users. In addition to network level detections, endpoint logging and instrumentation can be useful for detection.\nMonitor operational data for indicators of temporary data loss which may indicate a Denial of Service. This will not directly detect the technique’s execution, but instead may provide additional evidence that the technique has been used and may complement other detections.",
+      "meta": {
+        "external_id": "AN1856",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0723#AN1856"
+        ]
+      },
+      "uuid": "cff25f71-859e-48bf-88d6-852d05e22b33",
+      "value": "Analytic 1856 - AN1856"
+    },
+    {
       "description": "Consider analyzing self-signed code signing certificates for features that may be associated with the adversary and/or their developers, such as the thumbprint, algorithm used, validity period, and common name. Malware repositories can also be used to identify additional samples associated with the adversary and identify patterns an adversary has used in crafting self-signed code signing certificates.\nMuch of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related follow-on behavior, such as [Code Signing](https://attack.mitre.org/techniques/T1553/002) or [Install Root Certificate](https://attack.mitre.org/techniques/T1553/004).",
       "meta": {
         "external_id": "AN1965",
@@ -26760,6 +27610,28 @@
       "value": "Analytic 1758 - AN1758"
     },
     {
+      "description": "Monitor for an authentication attempt by a user that may obtain and abuse credentials of existing accounts as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion.\nMonitor for logon behavior that may abuse credentials of existing accounts as a means of gaining Lateral Movement or Persistence. Correlate other security systems with login information (e.g., a user has an active login session but has not entered the building or does not have VPN access). \nMonitor for suspicious account behavior across systems that share accounts, either user, admin, or service accounts. Examples: one account logged into multiple systems simultaneously; multiple accounts logged into the same machine simultaneously; accounts logged in at odd times or outside of business hours. Activity may be from interactive login sessions or process ownership from accounts being used to execute binaries on a remote system as a particular account.",
+      "meta": {
+        "external_id": "AN1857",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0724#AN1857"
+        ]
+      },
+      "uuid": "ddfcd948-3526-4241-a12f-d7bf63468e40",
+      "value": "Analytic 1857 - AN1857"
+    },
+    {
+      "description": "Devices that provide user access to the underlying operating system may allow the installation of custom software to monitor OS API execution. Monitoring API calls may generate a significant amount of data and may not be useful for defense unless collected under specific circumstances, since benign use of API functions are common and may be difficult to distinguish from malicious behavior. Correlation of other events with behavior surrounding API function calls using API monitoring will provide additional context to an event that may assist in determining if it is due to malicious behavior.",
+      "meta": {
+        "external_id": "AN1875",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0742#AN1875"
+        ]
+      },
+      "uuid": "e8f51c53-fc55-441b-a45f-ba7709ccbce2",
+      "value": "Analytic 1875 - AN1875"
+    },
+    {
       "description": "Detects assignment of high-privilege roles to user or service accounts via Kubernetes RoleBinding or ClusterRoleBinding objects, especially outside of CI/CD automation or from unknown IPs.",
       "meta": {
         "external_id": "AN1579",
@@ -26858,6 +27730,29 @@
       "value": "Analytic 1588 - AN1588"
     },
     {
+      "description": "Monitor for newly constructed services/daemons that may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools.\nMonitor for changes made to files outside of an update or patch that may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools.\nMonitor for file names that are mismatched between the file name on disk and that of the binary's metadata. This is a likely indicator that a binary was renamed after it was compiled. For added context on adversary procedures and background see [Masquerading](https://attack.mitre.org/techniques/T1036) and applicable sub-techniques.\nMonitor executed commands and arguments that may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools.(Citation: Twitter ItsReallyNick Masquerading Update)\nMonitor for changes made to scheduled jobs that may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools.\nMonitor for changes made to services that may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools.\nCollect file hashes. Monitor for file names that do not match their expected hash. Perform file monitoring. Files with known names but in unusual locations are suspect.  Look for indications of common characters that may indicate an attempt to trick users into misidentifying the file type, such as a space as the last character of a file name or the right-to-left override characters\"\\u202E\", \"[U+202E]\", and \"%E2%80%AE\". For added context on adversary procedures and background see [Masquerading](https://attack.mitre.org/techniques/T1036) and applicable sub-techniques.\nMonitor for newly constructed scheduled jobs that may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools.",
+      "meta": {
+        "external_id": "AN1858",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0725#AN1858",
+          "https://x.com/ItsReallyNick/status/1055321652777619457"
+        ]
+      },
+      "uuid": "791310ad-7db5-41df-9fa5-fa4097d8a51d",
+      "value": "Analytic 1858 - AN1858"
+    },
+    {
+      "description": "Devices that provide user access to the underlying operating system may allow the installation of custom software to monitor OS API execution. Monitoring API calls may generate a significant amount of data and may not be useful for defense unless collected under specific circumstances, since benign use of API functions are common and may be difficult to distinguish from malicious behavior. Correlation of other events with behavior surrounding API function calls using API monitoring will provide additional context to an event that may assist in determining if it is due to malicious behavior.",
+      "meta": {
+        "external_id": "AN1885",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0753#AN1885"
+        ]
+      },
+      "uuid": "aebd2848-98db-46f1-8e22-627e2ec3c280",
+      "value": "Analytic 1885 - AN1885"
+    },
+    {
       "description": "Consider analyzing malware for features that may be associated with the adversary and/or their developers, such as compiler used, debugging artifacts, or code similarities. Malware repositories can also be used to identify additional samples associated with the adversary and identify development patterns over time. Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Defense Evasion or Command and Control.\nMonitor for contextual data about a malicious payload, such as compilation times, file hashes, as well as watermarks or other identifiable configuration information. Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Defense Evasion or Command and Control.\nConsider use of services that may aid in the tracking of capabilities, such as certificates, in use on sites across the Internet. In some cases it may be possible to pivot on known pieces of information to uncover other adversary infrastructure.(Citation: Splunk Kovar Certificates 2017) Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Defense Evasion or Command and Control.",
       "meta": {
         "external_id": "AN1985",
@@ -26915,6 +27810,30 @@
       },
       "uuid": "fe489775-b01e-4da2-a0e2-962d1572ba09",
       "value": "Analytic 1589 - AN1589"
+    },
+    {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1895",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0763#AN1895"
+        ]
+      },
+      "uuid": "1e9c5d46-14e2-4efc-8861-e6dc942b3b9c",
+      "value": "Analytic 1895 - AN1895"
+    },
+    {
+      "description": "Monitor login sessions for new or unexpected devices or sessions on wireless networks.\nMonitor application logs for new or unexpected devices or sessions on wireless networks.\nNew or irregular network traffic flows may indicate potentially unwanted devices or sessions on wireless networks. In Wi-Fi networks monitor for changes such as rogue access points or low signal strength, indicating a device is further away from the access point then expected and changes in the physical layer signal.(Citation: Nzyme Alerts Intro) (Citation: Wireless Intrusion Detection) Network traffic content will provide important context, such as hardware (e.g., MAC) addresses, user accounts, and types of messages sent.",
+      "meta": {
+        "external_id": "AN1859",
+        "refs": [
+          "https://apps.dtic.mil/sti/pdfs/ADA466332.pdf",
+          "https://attack.mitre.org/detectionstrategies/DET0726#AN1859",
+          "https://docs.nzyme.org/wifi/monitoring/network-monitoring/"
+        ]
+      },
+      "uuid": "2388dc31-ba9a-4c12-b4b9-28bbc981c73e",
+      "value": "Analytic 1859 - AN1859"
     },
     {
       "description": "Monitor for logged domain name system (DNS) registry data that may hijack domains and/or subdomains that can be used during targeting.  In some cases, abnormal subdomain IP addresses (such as those originating in a different country from the root domain) may indicate a malicious subdomain.(Citation: Palo Alto Unit 42 Domain Shadowing 2022) Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Command and Control.\nConsider monitoring for anomalous changes to domain registrant information and/or domain resolution information that may indicate the compromise of a domain. Efforts may need to be tailored to specific domains of interest as benign registration and resolution changes are a common occurrence on the internet.\nMonitor for queried domain name system (DNS) registry data that may hijack domains and/or subdomains that can be used during targeting. In some cases, abnormal subdomain IP addresses (such as those originating in a different country from the root domain) may indicate a malicious subdomain.(Citation: Palo Alto Unit 42 Domain Shadowing 2022) Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Command and Control.",
@@ -27048,6 +27967,17 @@
       },
       "uuid": "c56cfd62-b8cb-49be-820b-e447a1605106",
       "value": "Analytic 1668 - AN1668"
+    },
+    {
+      "description": "Monitor for newly executed processes that execute from removable media after it is mounted or when initiated by a user. If a remote access tool is used in this manner to move laterally, then additional actions are likely to occur after execution, such as opening network connections for Command and Control and system and network information Discovery. \nMonitor for newly constructed files copied to or from removable media.\nMonitor for newly constructed drive letters or mount points to removable media.\nMonitor for files accessed on removable media, particularly those with executable content.",
+      "meta": {
+        "external_id": "AN1866",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0733#AN1866"
+        ]
+      },
+      "uuid": "9ad83be0-5c88-4fb6-b59d-19db21176923",
+      "value": "Analytic 1866 - AN1866"
     },
     {
       "description": "If infrastructure or patterns in tooling have been previously identified, internet scanning may uncover when an adversary has staged tools to make them accessible for targeting.\nMuch of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on post-compromise phases of the adversary lifecycle, such as [Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105).",
@@ -27190,6 +28120,30 @@
       "value": "Analytic 1678 - AN1678"
     },
     {
+      "description": "Purely passive network sniffing cannot be detected effectively. In cases where the adversary interacts with the wireless network (e.g., joining a Wi-Fi network) detection may be possible. Monitor for new or irregular network traffic flows which may indicate potentially unwanted devices or sessions on wireless networks.  In Wi-Fi networks monitor for changes such as rogue access points or low signal strength, indicating a device is further away from the access point then expected and changes in the physical layer signal.(Citation: Nzyme Alerts Intro) (Citation: Wireless Intrusion Detection)  Network traffic content will provide important context, such as hardware (e.g., MAC) addresses, user accounts, and types of messages sent.",
+      "meta": {
+        "external_id": "AN1876",
+        "refs": [
+          "https://apps.dtic.mil/sti/pdfs/ADA466332.pdf",
+          "https://attack.mitre.org/detectionstrategies/DET0743#AN1876",
+          "https://docs.nzyme.org/wifi/monitoring/network-monitoring/"
+        ]
+      },
+      "uuid": "c14544a4-5ca1-4523-97eb-4a9840d74c6d",
+      "value": "Analytic 1876 - AN1876"
+    },
+    {
+      "description": "Monitor for any suspicious attempts to enable script execution on a system. If scripts are not commonly used on a system, but enabled, scripts running out of cycle from patching or other administrator functions are suspicious. Scripts should be captured from the file system when possible, to determine their actions and intent.\nMonitor executed commands and arguments for actions that could be taken to collect internal data.\nMonitor for unexpected files (e.g., .pdf, .docx, .jpg) viewed for collecting internal data.\nMonitor for information collection on assets that may indicate deviations from standard operational tools. Examples include unexpected industrial automation protocol functions, new high volume communication sessions, or broad collection across many hosts within the network. ",
+      "meta": {
+        "external_id": "AN1867",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0734#AN1867"
+        ]
+      },
+      "uuid": "e25ef816-bbfd-4656-8ecb-c7eebcba31d4",
+      "value": "Analytic 1867 - AN1867"
+    },
+    {
       "description": "Consider use of services that may aid in the tracking of certificates in use on sites across the Internet. In some cases it may be possible to pivot on known pieces of certificate information to uncover other adversary infrastructure.(Citation: Splunk Kovar Certificates 2017)\nDetection efforts may be focused on related behaviors, such as [Web Protocols](https://attack.mitre.org/techniques/T1071/001) , [Asymmetric Cryptography](https://attack.mitre.org/techniques/T1573/002) , and/or [Install Root Certificate](https://attack.mitre.org/techniques/T1553/004) .",
       "meta": {
         "external_id": "AN1976",
@@ -27289,6 +28243,31 @@
       "value": "Analytic 1688 - AN1688"
     },
     {
+      "description": "Monitor for newly constructed logon behavior within Microsoft's SharePoint can be configured to report access to certain pages and documents.(Citation: Microsoft SharePoint Logging) Sharepoint audit logging can also be configured to report when a user shares a resource.(Citation: Sharepoint Sharing Events) The user access logging within Atlassian's Confluence can also be configured to report access to certain pages and documents through AccessLogFilter.(Citation: Atlassian Confluence Logging) Additional log storage and analysis infrastructure will likely be required for more robust detection capabilities. \nIn the case of detecting collection from shared network drives monitor for unexpected and abnormal accesses to network shares. \nMonitor for third-party application logging, messaging, and/or other artifacts that may leverage information repositories to mine valuable information. Information repositories generally have a considerably large user base, detection of malicious use can be non-trivial. At minimum, access to information repositories performed by privileged users (for example, Active Directory Domain, Enterprise, or Schema Administrators) should be closely monitored and alerted upon, as these types of accounts should generally not be used to access information repositories. If the capability exists, it may be of value to monitor and alert on users that are retrieving and viewing a large number of documents and pages; this behavior may be indicative of programmatic means being used to retrieve all data within the repository. In environments with high-maturity, it may be possible to leverage User-Behavioral Analytics (UBA) platforms to detect and alert on user-based anomalies.",
+      "meta": {
+        "external_id": "AN1886",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0754#AN1886",
+          "https://confluence.atlassian.com/confkb/how-to-enable-user-access-logging-182943.html",
+          "https://docs.microsoft.com/en-us/microsoft-365/compliance/use-sharing-auditing?view=o365-worldwide#sharepoint-sharing-events",
+          "https://support.office.com/en-us/article/configure-audit-settings-for-a-site-collection-a9920c97-38c0-44f2-8bcb-4cf1e2ae22d2"
+        ]
+      },
+      "uuid": "1672d2e3-8756-4380-b22c-517aa9f1cce0",
+      "value": "Analytic 1886 - AN1886"
+    },
+    {
+      "description": "Monitor command-line arguments for script execution and subsequent behavior. Actions may be related to network and system information Discovery, Collection, or other scriptable post-compromise behaviors and could be used as indicators of detection leading back to the source script. Scripts are likely to perform actions with various effects on a system that may generate events, depending on the types of monitoring used. \nMonitor log files for process execution through command-line and scripting activities. This information can be useful in gaining additional insight to adversaries' actions through how they use native processes or custom tools. Also monitor for loading of modules associated with specific languages.\nMonitor contextual data about a running process, which may include information such as environment variables, image name, user/owner, or other information that may reveal abuse of system features. \nMonitor for events associated with scripting execution, such as the loading of modules associated with scripting languages (e.g., JScript.dll, vbscript.dll).\nMonitor for any attempts to enable scripts running on a system would be considered suspicious. If scripts are not commonly used on a system, but enabled, scripts running out of cycle from patching or other administrator functions are suspicious. Scripts should be captured from the file system when possible to determine their actions and intent.",
+      "meta": {
+        "external_id": "AN1868",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0735#AN1868"
+        ]
+      },
+      "uuid": "302a5327-70cf-44b5-b592-ce9a62014dcc",
+      "value": "Analytic 1868 - AN1868"
+    },
+    {
       "description": "Once adversaries have provisioned software on a compromised VPS (ex: for use as a command and control server), internet scans may reveal VPSs that adversaries have compromised. Consider looking for identifiable patterns such as services listening, certificates in use, SSL/TLS negotiation features, or other response artifacts associated with adversary C2 software.(Citation: ThreatConnect Infrastructure Dec 2020)(Citation: Mandiant SCANdalous Jul 2020)(Citation: Koczwara Beacon Hunting Sep 2021)\n\nMuch of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during Command and Control.",
       "meta": {
         "external_id": "AN1986",
@@ -27346,6 +28325,29 @@
       },
       "uuid": "9aa716a2-0301-49cd-89c0-a441e5da0551",
       "value": "Analytic 1698 - AN1698"
+    },
+    {
+      "description": "Analyze network data for uncommon data flows (e.g., new protocols in use between hosts, unexpected ports in use). Processes utilizing the network that do not normally have network communication or have never been seen before are suspicious. \nMonitor for mismatches between protocols and their expected ports (e.g., non-HTTP traffic on tcp:80). Analyze packet contents to detect communications that do not follow the expected protocol behavior for the port that is being used.(Citation: University of Birmingham C2)",
+      "meta": {
+        "external_id": "AN1869",
+        "refs": [
+          "https://arxiv.org/ftp/arxiv/papers/1408/1408.1136.pdf",
+          "https://attack.mitre.org/detectionstrategies/DET0736#AN1869"
+        ]
+      },
+      "uuid": "981b659b-992a-4d71-9404-0e1b2b598e50",
+      "value": "Analytic 1869 - AN1869"
+    },
+    {
+      "description": "Monitor HKLM\\Software\\Policies\\Microsoft\\Windows NT\\DNSClient for changes to the \"EnableMulticast\" DWORD value. A value of \"0\" indicates LLMNR is disabled.\nHost-based implementations of this technique may utilize networking-based system calls or network utility commands (e.g., iptables) to locally intercept traffic. Monitor for relevant process creation events.\nMonitor for network traffic originating from unknown/unexpected hosts. Local network traffic metadata (such as source MAC addressing) as well as usage of network management protocols such as DHCP may be helpful in identifying hardware. For added context on adversary procedures and background see [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T1557) and applicable sub-techniques.\nMonitor for newly constructed services/daemons through Windows event logs for event IDs 4697 and 7045.\nMonitor network traffic for anomalies associated with known AiTM behavior. For Collection activity where transmitted data is not manipulated, anomalies may be present in network management protocols (e.g., ARP, DHCP).\nMonitor application logs for changes to settings and other events associated with network protocols and other services commonly abused for AiTM.",
+      "meta": {
+        "external_id": "AN1896",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0764#AN1896"
+        ]
+      },
+      "uuid": "afc9e394-147e-49db-81df-953d2d3ea93e",
+      "value": "Analytic 1896 - AN1896"
     },
     {
       "description": "Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on related stages of the adversary lifecycle, such as during [Phishing](https://attack.mitre.org/techniques/T1566), [Endpoint Denial of Service](https://attack.mitre.org/techniques/T1499), or [Network Denial of Service](https://attack.mitre.org/techniques/T1498).",
@@ -27433,6 +28435,17 @@
       "value": "Analytic 1787 - AN1787"
     },
     {
+      "description": "Monitor for network traffic originating from unknown/unexpected hardware devices. Local network traffic metadata (such as source MAC addressing) may be helpful in identifying transient assets.\nNetworking devices such as switches may log when new client devices connect (e.g., SNMP notifications). Monitor for any logs documenting changes to network connection status to determine when a new connection has occurred, including the resulting addresses (e.g., IP, MAC) of devices on that network.",
+      "meta": {
+        "external_id": "AN1877",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0744#AN1877"
+        ]
+      },
+      "uuid": "9127dd4e-0994-442f-8d73-b6b2dfb1f9ac",
+      "value": "Analytic 1877 - AN1877"
+    },
+    {
       "description": "Monitor for contextual data about a malicious payload, such as compilation times, file hashes, as well as watermarks or other identifiable configuration information. Much of this activity will take place outside the visibility of the target organization, making detection of this behavior difficult. Detection efforts may be focused on post-compromise phases of the adversary lifecycle.\nConsider analyzing malware for features that may be associated with malware providers, such as compiler used, debugging artifacts, code similarities, or even group identifiers associated with specific MaaS offerings. Malware repositories can also be used to identify additional samples associated with the developers and the adversary utilizing their services. Identifying overlaps in malware use by different adversaries may indicate malware was obtained by the adversary rather than developed by them. In some cases, identifying overlapping characteristics in malware used by different adversaries may point to a shared quartermaster.(Citation: FireEyeSupplyChain)",
       "meta": {
         "external_id": "AN1977",
@@ -27488,6 +28501,28 @@
       },
       "uuid": "36cb5f92-996c-42f4-be7e-43c5e21eee2e",
       "value": "Analytic 1788 - AN1788"
+    },
+    {
+      "description": "Monitor ICS management protocols for functions that change an asset’s operating mode.\nMonitor device application logs which may contain information related to operating mode changes, although not all devices produce such logs.\nMonitor alarms for information about when an operating mode is changed, although not all devices produce such logs.",
+      "meta": {
+        "external_id": "AN1887",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0755#AN1887"
+        ]
+      },
+      "uuid": "78615cd7-6a14-4921-aaa9-2aae0774f0f1",
+      "value": "Analytic 1887 - AN1887"
+    },
+    {
+      "description": "Monitor for unexpected network share access, such as files transferred between shares within a network using protocols such as Server Message Block (SMB).\nMonitor for alike file hashes or characteristics (ex: filename) that are created on multiple hosts. \nMonitor for file creation in conjunction with other techniques (e.g., file transfers using [Remote Services](https://attack.mitre.org/techniques/T0886)).\nMonitor for unusual processes with internal network connections creating files on-system which may be suspicious. \nMonitor executed commands and arguments for abnormal usage of utilities and command-line arguments that may be used in support of remote transfer of files.\nMonitor newly constructed processes that assist in lateral tool transfers, such as file transfer programs.\nMonitor for network traffic originating from unknown/unexpected hosts. Local network traffic metadata (such as source MAC addressing) as well as usage of network management protocols such as DHCP may be helpful in identifying hardware.",
+      "meta": {
+        "external_id": "AN1878",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0745#AN1878"
+        ]
+      },
+      "uuid": "930aae7c-e8f0-4594-8e3f-f0e71d7e1640",
+      "value": "Analytic 1878 - AN1878"
     },
     {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
@@ -27546,6 +28581,28 @@
       "value": "Analytic 1798 - AN1798"
     },
     {
+      "description": "Various techniques enable spoofing a reporting message. Consider monitoring for [Rogue Master](https://attack.mitre.org/techniques/T0848) and [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) activity which may precede this technique.\nMonitor asset logs for alarms or other information the adversary is unable to directly suppress. Relevant alarms include those from a loss of communications due to [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) activity.\nVarious techniques enable spoofing a reporting message. Monitor for LLMNR/NBT-NS poisoning via new services/daemons which may be used to enable this technique. For added context on adversary procedures and background see [Name Resolution Poisoning and SMB Relay](https://attack.mitre.org/techniques/T1557/001).\nSpoofed reporting messages may be detected by reviewing the content of automation protocols, either through detecting based on expected values or comparing to other out of band process data sources. Spoofed messages may not precisely match legitimate messages which may lead to malformed traffic, although traffic may be malformed for many benign reasons. Monitor reporting messages for changes in how they are constructed.\n\nVarious techniques enable spoofing a reporting message. Consider monitoring for [Rogue Master](https://attack.mitre.org/techniques/T0848) and [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) activity.",
+      "meta": {
+        "external_id": "AN1879",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0746#AN1879"
+        ]
+      },
+      "uuid": "32bfb2ab-2ad1-4c00-8428-96bc626c34f3",
+      "value": "Analytic 1879 - AN1879"
+    },
+    {
+      "description": "Monitor for changes made to files that may stop or disable services on a system to render those services unavailable to legitimate users.\nMonitor executed commands and arguments that may stop or disable services on a system to render those services unavailable to legitimate users.\nRemote access tools with built-in features may interact directly with the Windows API to perform these functions outside of typical system utilities. For example, ChangeServiceConfigW may be used by an adversary to prevent services from starting. For added context on adversary procedures and background see [Service Stop](https://attack.mitre.org/techniques/T1489).\nMonitor processes and command-line arguments to see if critical processes are terminated or stop running. For added context on adversary procedures and background see [Service Stop](https://attack.mitre.org/techniques/T1489).\nAlterations to the service binary path or the service startup type changed to disabled may be suspicious.\nMonitor for changes made to Windows registry keys and/or values that may stop or disable services on a system to render those services unavailable to legitimate users.\nMonitor for newly executed processes that may stop or disable services on a system to render those services unavailable to legitimate users.",
+      "meta": {
+        "external_id": "AN1897",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0765#AN1897"
+        ]
+      },
+      "uuid": "6b3b3e92-bef7-4977-9895-29036bab29f1",
+      "value": "Analytic 1897 - AN1897"
+    },
+    {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
       "meta": {
         "external_id": "AN1979",
@@ -27590,6 +28647,17 @@
       "value": "Analytic 1799 - AN1799"
     },
     {
+      "description": "Monitor network traffic for default credential use in protocols that allow unencrypted authentication.\nMonitor logon sessions for default credential use.",
+      "meta": {
+        "external_id": "AN1888",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0756#AN1888"
+        ]
+      },
+      "uuid": "f12aa823-91cc-40e1-93b7-eaa5f5fa9c4d",
+      "value": "Analytic 1888 - AN1888"
+    },
+    {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
       "meta": {
         "external_id": "AN1988",
@@ -27602,6 +28670,28 @@
       },
       "uuid": "c752faa1-9cc2-421a-b646-0efe4da990c9",
       "value": "Analytic 1988 - AN1988"
+    },
+    {
+      "description": "Monitor for unexpected changes to project files, although if the malicious modification occurs in tandem with legitimate changes it will be difficult to isolate the unintended changes by analyzing only file systems modifications.",
+      "meta": {
+        "external_id": "AN1898",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0766#AN1898"
+        ]
+      },
+      "uuid": "6e046c4c-6c93-4fdf-a69e-5d81b52d1e9c",
+      "value": "Analytic 1898 - AN1898"
+    },
+    {
+      "description": "No standard detection method currently exists for this technique.",
+      "meta": {
+        "external_id": "AN1889",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0757#AN1889"
+        ]
+      },
+      "uuid": "89ca8617-20fd-404b-9afb-dcfd2684a791",
+      "value": "Analytic 1889 - AN1889"
     },
     {
       "description": "Much of this activity may have a very high occurrence and associated false positive rate, as well as potentially taking place outside the visibility of the target organization, making detection difficult for defenders.\n\nDetection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.",
@@ -27632,6 +28722,17 @@
       "value": "Analytic 1998 - AN1998"
     },
     {
+      "description": "Detecting software exploitation may be difficult depending on the tools available. Software exploits may not always succeed or may cause the exploited process to become unstable or crash, which may be recorded in the application log.\nUse deep packet inspection to look for artifacts of common exploit traffic, such as known payloads.",
+      "meta": {
+        "external_id": "AN1899",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0767#AN1899"
+        ]
+      },
+      "uuid": "3e456d4d-397d-4e04-9261-9399960c9633",
+      "value": "Analytic 1899 - AN1899"
+    },
+    {
       "description": "Monitor and analyze traffic patterns and packet inspection associated to protocol(s) that do not follow the expected protocol standards and traffic flows (e.g extraneous packets that do not belong to established flows, gratuitous or anomalous traffic patterns, anomalous syntax, or structure). Consider correlation with process monitoring and command line to detect anomalous processes execution and command line arguments associated to traffic patterns (e.g. monitor anomalies in use of files that do not normally initiate connections for respective protocol(s)).\nMonitor network data for uncommon data flows. Processes utilizing the network that do not normally have network communication or have never been seen before are suspicious.",
       "meta": {
         "external_id": "AN1999",
@@ -27646,5 +28747,5 @@
       "value": "Analytic 1999 - AN1999"
     }
   ],
-  "version": 5
+  "version": 6
 }

--- a/clusters/mitre-asset.json
+++ b/clusters/mitre-asset.json
@@ -1,0 +1,297 @@
+{
+  "authors": [
+    "MITRE"
+  ],
+  "category": "asset",
+  "description": "Assets from MITRE ATT&CK, representing the devices and systems that adversaries target.",
+  "name": "MITRE ATT&CK Assets",
+  "source": "https://github.com/mitre/cti",
+  "type": "mitre-asset",
+  "uuid": "f527feac-8bbb-4752-9500-c16806de049d",
+  "values": [
+    {
+      "description": "A VPN server is a device that is used to establish a secure network tunnel between itself and other remote VPN devices, including field VPNs. VPN servers can be used to establish a secure connection with a single remote device, or to securely bridge all traffic between two separate networks together by encapsulating all data between those networks. VPN servers typically support remote network services that are used by field VPNs to initiate the establishment of the secure VPN tunnel between the field device and server.",
+      "meta": {
+        "external_id": "A0011",
+        "mitre_platforms": [
+          "Embedded",
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0011",
+          "https://webstore.iec.ch/publication/34421"
+        ]
+      },
+      "uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+      "value": "Virtual Private Network (VPN) Server - A0011"
+    },
+    {
+      "description": "A Distributed Control System (DCS) Controller is a microprocessor unit that is used to manage automation processes. DCS Controllers are often found in plants (chemical, manufacturing, oil and gas, etc.) where large scale continuous automation processes are required. A DCS Controller typically operates as part of a larger networked system with other DCS Controllers where each DCS Controller manages an individual part of a continuous process. In addition to these other controllers, DCS Controllers operate along side multiple other system components including system software, operator stations, and other embedded field controllers. The distributed nature of DCS Controllers provides scalability, redundancy, and improved process reliability. DCS Controllers are programmed using traditional process automation programming languages (IEC-61131). ",
+      "meta": {
+        "external_id": "A0017",
+        "mitre_platforms": [
+          "Embedded"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0017"
+        ]
+      },
+      "uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+      "value": "Distributed Control System (DCS) Controller - A0017"
+    },
+    {
+      "description": "A Programmable Logic Controller (PLC) is an embedded programmable control device. PLCs typically utilize a modular architecture with separate modules used to support its processing capabilities, communication mediums, and I/O interfaces. PLCs allow for the deployment of customized programs/logic to control or monitor an operational process. This logic is defined using industry specific programming languages, such as IEC 61131 (Citation: IEC February 2013), which define the set of tasks and program organizational units (POUs) included in the device’s programs.  PLCs also typically have distinct operating modes (e.g., Remote, Run, Program, Stop) which are used to determine when the device can be programmed or whether it should execute the custom logic.",
+      "meta": {
+        "external_id": "A0003",
+        "mitre_platforms": [
+          "Embedded"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0003",
+          "https://webstore.iec.ch/publication/4552"
+        ]
+      },
+      "uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+      "value": "Programmable Logic Controller (PLC) - A0003"
+    },
+    {
+      "description": "A Remote Terminal Unit (RTU) is a device that typically resides between field devices (e.g., PLCs, IEDs) and control/SCADA servers and supports various communication interfacing and data aggregation functions. RTUs are typically responsible for forwarding commands from the control server and the collection of telemetry, events, and alerts from the field devices. An RTU can be implemented as a dedicated embedded device, as software platform that runs on a hardened/ruggedized computer, or using a custom application program on a PLC.",
+      "meta": {
+        "external_id": "A0004",
+        "mitre_platforms": [
+          "Embedded",
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0004"
+        ]
+      },
+      "uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+      "value": "Remote Terminal Unit (RTU) - A0004"
+    },
+    {
+      "description": "An Intelligent Electronic Device (IED) is a type of specialized field device that is designed to perform specific operational functions, frequently for protection, monitoring, or control within the electric sector. IEDs are typically used to both acquire telemetry and execute tailored control algorithms/actions based on customizable parameters/settings. An IED is usually implemented as a dedicated embedded device and supports various network automation protocols to communicate with RTUs and Control Servers.",
+      "meta": {
+        "external_id": "A0005",
+        "mitre_platforms": [
+          "Embedded"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0005"
+        ]
+      },
+      "uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+      "value": "Intelligent Electronic Device (IED) - A0005"
+    },
+    {
+      "description": "A Programmable Automation Controller (PAC) is an embedded programmable control device. PACs are designed to enable automation applications across integrated software applications, peer controllers (e.g., PLC), Human Machine Interfaces, and other systems. PACs often include advanced features for process control, motion control, drive control, and vision applications. PACs are programmed using traditional process automation programming languages (IEC-61131) and sometimes languages such as C and C++ to support more advanced controls.",
+      "meta": {
+        "external_id": "A0018",
+        "mitre_platforms": [
+          "Embedded"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0018"
+        ]
+      },
+      "uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+      "value": "Programmable Automation Controller (PAC) - A0018"
+    },
+    {
+      "description": "Human-Machine Interfaces (HMIs) are systems used by an operator to monitor the real-time status of an operational process and to perform necessary control functions, including the adjustment of device parameters. An HMI can take various forms, including a dedicated screen or control panel integrated with a specific device/controller, or a customizable software GUI application running on a standard operating system (e.g., MS Windows) that interfaces with a control/SCADA server. The HMI is critical to ensuring operators have sufficient visibility and control over the operational process.",
+      "meta": {
+        "external_id": "A0002",
+        "mitre_platforms": [
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0002",
+          "https://webstore.iec.ch/publication/34421"
+        ]
+      },
+      "uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+      "value": "Human-Machine Interface (HMI) - A0002"
+    },
+    {
+      "description": "Field I/O are devices that communicate with a controller or data aggregator to either send input data or receive output data. Input data may include readings about a given environment/device state from sensors, while output data may include data sent back to actuators for them to either undertake actions or change parameter values.(Citation: Guidance - NIST SP800-82) These devices are frequently embedded devices running on lightweight embedded operating systems or RTOSes. ",
+      "meta": {
+        "external_id": "A0013",
+        "mitre_platforms": [
+          "Embedded"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0013",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
+        ]
+      },
+      "uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+      "value": "Field I/O - A0013"
+    },
+    {
+      "description": "Safety controllers are typically a type of field device used to perform the safety critical function. Safety controllers often support the deployment of custom programs/logic, similar to a PLC, but can also be tailored for sector specific functions/applications. The safety controllers typically utilize redundant hardware and processors to ensure they operate reliably if a component fails.",
+      "meta": {
+        "external_id": "A0010",
+        "mitre_platforms": [
+          "Embedded"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0010",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf",
+          "https://sigtto.org/media/3457/sigtto-2021-esd-systems.pdf"
+        ]
+      },
+      "uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+      "value": "Safety Controller - A0010"
+    },
+    {
+      "description": "Data historians, or historian, are systems used to collect and store data, including telemetry, events, alerts, and alarms about the operational process and supporting devices. The historian typically utilizes a database to store this data, and commonly provide tools and interfaces to support the analysis of the data. Data historians are often used to support various engineering or business analysis functions and therefore commonly needs access from the corporate network. Data historians often work in a hierarchical paradigm where lower/site level historians collect and store data which is then aggregated into a site/plant level historian. Therefore, data historians often have remote services that can be accessed externally from the ICS network. Many data historian vendors have designed their software to securely transfer data between the ICS and business networks instead of requiring business systems to access the data historian in the ICS network directly.",
+      "meta": {
+        "external_id": "A0006",
+        "mitre_platforms": [
+          "Embedded",
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0006"
+        ]
+      },
+      "uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+      "value": "Data Historian - A0006"
+    },
+    {
+      "description": "Control servers are typically a software platform that runs on a modern server operating system (e.g., MS Windows Server). The server typically uses one or more automation protocols (e.g., Modbus, DNP3) to communicate with the various low-level control devices such as Remote Terminal Units (RTUs) and Programmable Logic Controllers (PLCs). The control server also usually provides an interface/network service to connect with an HMI.",
+      "meta": {
+        "external_id": "A0007",
+        "mitre_platforms": [
+          "Embedded",
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0007",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
+        ]
+      },
+      "uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+      "value": "Control Server - A0007"
+    },
+    {
+      "description": "Application servers are used across many different sectors to host various diverse software applications necessary to supporting the ICS. Example functions can include data analytics and reporting, alarm management, and the management/coordination of different control servers.  The application server typically runs on a modern server operating system (e.g., MS Windows Server).",
+      "meta": {
+        "external_id": "A0008",
+        "mitre_platforms": [
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0008"
+        ]
+      },
+      "uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+      "value": "Application Server - A0008"
+    },
+    {
+      "description": "Data Gateway is a device that supports the communication and exchange of data between different systems, networks, or protocols within the ICS. Different types of data gateways are used to perform various functions, including:\n\n *  <u>Protocol Translation:</u> Enable communication to devices that support different or incompatible protocols by translating information from one protocol to another. \n *  <u>Media Converter:</u> Convert data across different Layer 1 and 2 network protocols / mediums, for example, converting from Serial to Ethernet. \n *  <u>Data Aggregation:</u> Collect and combine data from different devices into one consistent format and protocol interface. \n*  <u>Data Mirroring:</u> Create a real-time, exact copy of data streams from devices to a separate destination for redundancy, monitoring, or backup purposes.\n\nData gateways are often critical to the forwarding/transmission of critical control or monitoring data within the ICS. Further, these devices often have remote various network services that are used to communicate across different zones or networks.  \n\nThese assets may focus on a single function listed below or combinations of these functions to best fit the industry use-case. \n",
+      "meta": {
+        "external_id": "A0009",
+        "mitre_platforms": [
+          "Windows",
+          "Linux",
+          "Embedded",
+          "Network"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0009"
+        ]
+      },
+      "uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+      "value": "Data Gateway - A0009"
+    },
+    {
+      "description": "Jump hosts are devices used to support remote management sessions into ICS networks or devices. The system is used to access the ICS environment securely from external networks, such as the corporate network. The user must first remote into the jump host before they can access ICS devices. The jump host may be a customized Windows server using common remote access protocols (e.g., RDP) or a dedicated access management device. The jump host typically performs various security functions to ensure the authenticity of remote sessions, including authentication, enforcing access controls/permissions, and auditing all access attempts.  ",
+      "meta": {
+        "external_id": "A0012",
+        "mitre_platforms": [
+          "Embedded",
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0012",
+          "https://www.nerc.com/pa/Stand/Glossary%20of%20Terms/Glossary_of_Terms.pdf"
+        ]
+      },
+      "uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+      "value": "Jump Host - A0012"
+    },
+    {
+      "description": "Workstations are devices used by human operators or engineers to perform various configuration, programming, maintenance, diagnostic, or operational tasks. Workstations typically utilize standard desktop or laptop hardware and operating systems (e.g., MS Windows), but run dedicated control system applications or diagnostic/management software     to support interfacing with the control servers or field devices. Some workstations have a fixed location within the network architecture, while others are transient devices that are directly connected to various field devices to support local management activities.",
+      "meta": {
+        "external_id": "A0001",
+        "mitre_platforms": [
+          "Linux",
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0001",
+          "https://www.nerc.com/pa/Stand/Glossary%20of%20Terms/Glossary_of_Terms.pdf"
+        ]
+      },
+      "uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+      "value": "Workstation - A0001"
+    },
+    {
+      "description": "A computer that is a gateway between two networks at OSI layer 3 and that relays and directs data packets through that inter-network. The most common form of router operates on IP packets.(Citation: IETF RFC4949 2007)",
+      "meta": {
+        "external_id": "A0014",
+        "mitre_platforms": [
+          "Embedded",
+          "Network"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0014",
+          "https://www.ietf.org/rfc/rfc4949.txt"
+        ]
+      },
+      "uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+      "value": "Routers - A0014"
+    },
+    {
+      "description": "A switch is a network device that connects endpoints (e.g., workstations, servers, HMIs, PLCs, etc.) so that they can communicate and share data and resources. Switches may operate at either Layer 2 or Layer 3 of the OSI Model and intelligently forward packets across the network based on the specified address (Media Access Control (MAC) address for Layer 2 and Internet Protocol (IP) address for Layer 3). Switches are typically used to define network segments and connect the devices within a particular level of the Purdue Model.  ",
+      "meta": {
+        "external_id": "A0015",
+        "mitre_platforms": [
+          "Embedded",
+          "Network"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0015"
+        ]
+      },
+      "uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+      "value": "Switch - A0015"
+    },
+    {
+      "description": "A gateway that limits access between networks in accordance with local security policy.\n\nIn ICS networks, firewalls can exist in multiple locations in the network architecture and  serve a variety of purposes. The first, and often the most important, is the firewall segmenting the ICS network from the business network. This firewall acts as the primary network boundary point that controls the ingress/egress of network traffic between the ICS and business networks. This firewall may also be a single device connected to multiple network segments, where the firewall defines individual zones for the different network segments and can control access to the zones and between the zones. This can limit the ability of an adversary to traverse a network.\n",
+      "meta": {
+        "external_id": "A0016",
+        "mitre_platforms": [
+          "Embedded",
+          "Windows",
+          "Linux",
+          "Network"
+        ],
+        "refs": [
+          "https://attack.mitre.org/assets/A0016"
+        ]
+      },
+      "uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+      "value": "Firewall - A0016"
+    }
+  ],
+  "version": 2
+}

--- a/clusters/mitre-attack-pattern.json
+++ b/clusters/mitre-attack-pattern.json
@@ -3,7 +3,7 @@
     "MITRE"
   ],
   "category": "attack-pattern",
-  "description": "Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise and Mobile).",
+  "description": "Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise, Mobile, PRE and ICS).",
   "name": "MITRE ATT&CK Techniques",
   "source": "https://github.com/mitre/cti",
   "type": "mitre-attack-pattern",
@@ -2518,6 +2518,23 @@
       "value": "Custom Command and Control Protocol - T1094"
     },
     {
+      "description": "Adversaries may cause loss of productivity and revenue through disruption and even damage to the availability and integrity of control system operations, devices, and related processes. This technique may manifest as a direct effect of an ICS-targeting attack or tangentially, due to an IT-targeting attack against non-segregated environments. \n\nIn cases where these operations or services are brought to a halt, the loss of productivity may eventually present an impact for the end-users or consumers of products and services. The disrupted supply-chain may result in supply shortages and increased prices, among other consequences. \n\nA ransomware attack on an Australian beverage company resulted in the shutdown of some manufacturing sites, including precautionary halts to protect key systems. (Citation: Paganini, Pierluigi June 2020) The company announced the potential for temporary shortages of their products following the attack. (Citation: Paganini, Pierluigi June 2020) (Citation: Lion Corporation June 2020) \n\nIn the 2021 Colonial Pipeline ransomware incident, the pipeline was unable to transport approximately 2.5 million barrels of fuel per day to the East Coast.  (Citation: Colonial Pipeline Company May 2021)",
+      "meta": {
+        "external_id": "T0828",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0828",
+          "https://lionco.com/2020/06/26/lion-update-re-cyber-issue/",
+          "https://securityaffairs.co/wordpress/104749/cyber-crime/ransomware-attack-hit-lion.html",
+          "https://www.colpipe.com/news/press-releases/media-statement-colonial-pipeline-system-disruption"
+        ]
+      },
+      "uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+      "value": "Loss of Productivity and Revenue - T0828"
+    },
+    {
       "description": "Adversaries may take advantage of trusted developer utilities to proxy execution of malicious payloads. There are many utilities used for software development related tasks that can be used to execute code in various forms to assist in development, debugging, and reverse engineering.(Citation: engima0x3 DNX Bypass)(Citation: engima0x3 RCSI Bypass)(Citation: Exploit Monday WinDbg)(Citation: LOLBAS Tracker) These utilities may often be signed with legitimate certificates that allow them to execute on a system and proxy execution of malicious code through a trusted process that effectively bypasses application control solutions.\n\nSmart App Control is a feature of Windows that blocks applications it considers potentially malicious from running by verifying unsigned applications against a known safe list from a Microsoft cloud service before executing them.(Citation: Microsoft Smart App Control) However, adversaries may leverage \"reputation hijacking\" to abuse an operating system’s trust of safe, signed applications that support the execution of arbitrary code. By leveraging [Trusted Developer Utilities Proxy Execution](https://attack.mitre.org/techniques/T1127) to run their malicious code, adversaries may bypass Smart App Control protections.(Citation: Elastic Security Labs)",
       "meta": {
         "external_id": "T1127",
@@ -3461,6 +3478,63 @@
       "value": "Establish & Maintain Infrastructure - TA0022"
     },
     {
+      "description": "Adversaries may collect point and tag values to gain a more comprehensive understanding of the process environment. Points may be values such as inputs, memory locations, outputs or other process specific variables. (Citation: Dennis L. Sloatman September 2016) Tags are the identifiers given to points for operator convenience. \n\nCollecting such tags provides valuable context to environmental points and enables an adversary to map inputs, outputs, and other values to their control processes. Understanding the points being collected may inform an adversary on which processes and values to keep track of over the course of an operation.",
+      "meta": {
+        "external_id": "T0861",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0861",
+          "https://www.radioworld.com/industry/understanding-plc-programming-methods-and-the-tag-database-system"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+      "value": "Point & Tag Identification - T0861"
+    },
+    {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/techniques/T1275).\n\nIn addition to a target's social media presence may exist a larger digital footprint, such as accounts and credentials on e-commerce sites or usernames and logins for email.  An adversary familiar with a target's username can mine to determine the target's larger digital footprint via publicly available sources. (Citation: DigitalFootprint) (Citation: trendmicro-vtech)",
       "meta": {
         "external_id": "T1275",
@@ -4023,6 +4097,31 @@
       ],
       "uuid": "143c0cbb-a297-4142-9624-87ffc778980b",
       "value": "Archive via Custom Method - T1560.003"
+    },
+    {
+      "description": "Adversaries may infect Siemens PLC project files (i.e., Step 7, WinCC, etc.) to achieve [Execution](https://attack.mitre.org/tactics/TA0104), [Persistence](https://attack.mitre.org/tactics/TA0110), and [Lateral Movement](https://attack.mitre.org/tactics/TA0109) objectives. Adversaries may modify an existing project file or bring their own project files into the environment.(Citation: Nicolas Falliere, Liam O Murchu, Eric Chien February 2011)\n\nThe ability for an adversary to deploy an infected project file relies on access to a workstation with Siemens PLC programming software installed on it from which a program download can be performed.\n",
+      "meta": {
+        "external_id": "T0873.001",
+        "kill_chain": [
+          "ics-attack:persistence"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0873/001",
+          "https://docs.broadcom.com/doc/security-response-w32-stuxnet-dossier-11-en"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+      "value": "Siemens Project File Format - T0873.001"
     },
     {
       "description": "An adversary may add additional roles or permissions to an adversary-controlled user or service account to maintain persistent access to a container orchestration system. For example, an adversary with sufficient permissions may create a RoleBinding or a ClusterRoleBinding to bind a Role or ClusterRole to a Kubernetes account.(Citation: Kubernetes RBAC)(Citation: Aquasec Kubernetes Attack 2023) Where attribute-based access control (ABAC) is in use, an adversary with sufficient permissions may modify a Kubernetes ABAC policy to give the target account additional permissions.(Citation: Kuberentes ABAC)\n \nThis account modification may immediately follow [Create Account](https://attack.mitre.org/techniques/T1136) or other malicious account activity. Adversaries may also modify existing [Valid Accounts](https://attack.mitre.org/techniques/T1078) that they have compromised.  \n\nNote that where container orchestration systems are deployed in cloud environments, as with Google Kubernetes Engine, Amazon Elastic Kubernetes Service, and Azure Kubernetes Service, cloud-based  role-based access control (RBAC) assignments or ABAC policies can often be used in place of or in addition to local permission assignments.(Citation: Google Cloud Kubernetes IAM)(Citation: AWS EKS IAM Roles for Service Accounts)(Citation: Microsoft Azure Kubernetes Service Service Accounts) In these cases, this technique may be used in conjunction with [Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003).",
@@ -5403,6 +5502,58 @@
       "value": "Receive operator KITs/KIQs tasking - T1235"
     },
     {
+      "description": "Adversaries may activate firmware update mode on devices to prevent expected response functions from engaging in reaction to an emergency or process malfunction. For example, devices such as protection relays may have an operation mode designed for firmware installation. This mode may halt process monitoring and related functions to allow new firmware to be loaded. A device left in update mode may be placed in an inactive holding state if no firmware is provided to it. By entering and leaving a device in this mode, the adversary may deny its usual functionalities.",
+      "meta": {
+        "external_id": "T0800",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0800"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+      "value": "Activate Firmware Update Mode - T0800"
+    },
+    {
       "description": "An adversary may exfiltrate data in fixed size chunks instead of whole files or limit packet sizes below certain thresholds. This approach may be used to avoid triggering network data transfer threshold alerts.",
       "meta": {
         "external_id": "T1030",
@@ -5464,6 +5615,87 @@
       },
       "uuid": "3c4a2599-71ee-4405-ba1e-0e28414b4bc5",
       "value": "Data from Local System - T1005"
+    },
+    {
+      "description": "Adversaries may exploit software vulnerabilities in an attempt to elevate privileges. Exploitation of a software vulnerability occurs when an adversary takes advantage of a programming error in a program, service, or within the operating system software or kernel itself to execute adversary-controlled code. Security constructs such as permission levels will often hinder access to information and use of certain techniques, so adversaries will likely need to perform privilege escalation to include use of software exploitation to circumvent those restrictions. (Citation: The MITRE Corporation) \n\nWhen initially gaining access to a system, an adversary may be operating within a lower privileged process which will prevent them from accessing certain resources on the system. Vulnerabilities may exist, usually in operating system components and software commonly running at higher permissions, that can be exploited to gain higher levels of access on the system. This could enable someone to move from unprivileged or user level permissions to SYSTEM or root permissions depending on the component that is vulnerable. This may be a necessary step for an adversary compromising an endpoint system that has been properly configured and limits other privilege escalation methods. (Citation: The MITRE Corporation)",
+      "meta": {
+        "external_id": "T0890",
+        "kill_chain": [
+          "ics-attack:privilege-escalation"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0890",
+          "https://attack.mitre.org/techniques/T1068/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+      "value": "Exploitation for Privilege Escalation - T0890"
     },
     {
       "description": "Adversaries may steal data by exfiltrating it over an existing command and control channel. Stolen data is encoded into the normal communications channel using the same protocol as command and control communications.",
@@ -5562,6 +5794,32 @@
       },
       "uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
       "value": "System Network Configuration Discovery - T1016"
+    },
+    {
+      "description": "Adversaries may target and collect data from information repositories. This can include sensitive data such as specifications, schematics, or diagrams of control system layouts, devices, and processes. Examples of information repositories include reference databases in the process environment, as well as databases in the corporate network that might contain information about the ICS.(Citation: Cybersecurity & Infrastructure Security Agency March 2018)\n\nInformation collected from these systems may provide the adversary with a better understanding of the operational environment, vendors used, processes, or procedures of the ICS.\n\nIn a campaign between 2011 and 2013 against ONG organizations, Chinese state-sponsored actors searched document repositories for specific information such as, system manuals, remote terminal unit (RTU) sites, personnel lists, documents that included the string SCAD*, user credentials, and remote dial-up access information. (Citation: CISA AA21-201A Pipeline Intrusion July 2021)",
+      "meta": {
+        "external_id": "T0811",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0811",
+          "https://us-cert.cisa.gov/ncas/alerts/TA18-074A",
+          "https://us-cert.cisa.gov/sites/default/files/publications/AA21-201A_Chinese_Gas_Pipeline_Intrusion_Campaign_2011_to_2013%20(1).pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+      "value": "Data from Information Repositories - T0811"
     },
     {
       "description": "Adversaries may move onto systems, possibly those on disconnected or air-gapped networks, by copying malware to removable media and taking advantage of Autorun features when the media is inserted into a system and executes. In the case of Lateral Movement, this may occur through modification of executable files stored on removable media or by copying malware and renaming it to look like a legitimate file to trick users into executing it on a separate system. In the case of Initial Access, this may occur through manual manipulation of the media, modification of systems used to initially format the media, or modification to the media's firmware itself.\n\nMobile devices may also be used to infect PCs with malware if connected via USB.(Citation: Exploiting Smartphone USB ) This infection may be achieved using devices (Android, iOS, etc.) and, in some instances, USB charging cables.(Citation: Windows Malware Infecting Android)(Citation: iPhone Charging Cable Hack) For example, when a smartphone is connected to a system, it may appear to be mounted similar to a USB-connected disk drive. If malware that is compatible with the connected system is on the mobile device, the malware could infect the machine (especially if Autorun features are enabled).",
@@ -6444,6 +6702,530 @@
       "value": "Bypass User Account Control - T1088"
     },
     {
+      "description": "Adversaries may attempt to remove indicators of their presence on a system in an effort to cover their tracks. In cases where an adversary may feel detection is imminent, they may try to overwrite, delete, or cover up changes they have made to the device.",
+      "meta": {
+        "external_id": "T0872",
+        "kill_chain": [
+          "ics-attack:evasion"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0872"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
+      "value": "Indicator Removal on Host - T0872"
+    },
+    {
+      "description": "Adversaries may steal operational information on a production environment as a direct mission outcome for personal gain or to inform future operations. This information may include design documents, schedules, rotational data, or similar artifacts that provide insight on operations.    In the Bowman Dam incident, adversaries probed systems for operational data. (Citation: Mark Thompson March 2016) (Citation: Danny Yadron December 2015)",
+      "meta": {
+        "external_id": "T0882",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0882",
+          "https://time.com/4270728/iran-cyber-attack-dam-fbi/",
+          "https://www.wsj.com/articles/iranian-hackers-infiltrated-new-york-dam-in-2013-1450662559"
+        ]
+      },
+      "uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+      "value": "Theft of Operational Information - T0882"
+    },
+    {
+      "description": "Adversaries may target and collect data from local system sources, such as file systems, configuration files, or local databases. This can include sensitive data such as specifications, schematics, or diagrams of control system layouts, devices, and processes.\n\nAdversaries may do this using [Command-Line Interface](https://attack.mitre.org/techniques/T0807) or [Scripting](https://attack.mitre.org/techniques/T0853) techniques to interact with the file system to gather information. Adversaries may also use [Automated Collection](https://attack.mitre.org/techniques/T0802) on the local system. ",
+      "meta": {
+        "external_id": "T0893",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0893"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+      "value": "Data from Local System - T0893"
+    },
+    {
+      "description": "Adversaries may move onto systems, such as those separated from the enterprise network, by copying malware to removable media which is inserted into the control systems environment. The adversary may rely on unknowing trusted third parties, such as suppliers or contractors with access privileges, to introduce the removable media. This technique enables initial access to target devices that never connect to untrusted networks, but are physically accessible.     \n\nOperators of the German nuclear power plant, Gundremmingen, discovered malware on a facility computer not connected to the internet. (Citation: Kernkraftwerk Gundremmingen April 2016) (Citation: Trend Micro April 2016) The malware included Conficker and W32.Ramnit, which were also found on eighteen removable disk drives in the facility. (Citation: Christoph Steitz, Eric Auchard April 2016) (Citation: Catalin Cimpanu April 2016) (Citation: Peter Dockrill April 2016) (Citation: Lee Mathews April 2016) (Citation: Sean Gallagher April 2016) (Citation: Dark Reading Staff April 2016) The plant has since checked for infection and cleaned up more than 1,000 computers. (Citation: BBC April 2016) An ESET researcher commented that internet disconnection does not guarantee system safety from infection or payload execution. (Citation: ESET April 2016)",
+      "meta": {
+        "external_id": "T0847",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://arstechnica.com/information-technology/2016/04/german-nuclear-plants-fuel-rod-system-swarming-with-old-malware/",
+          "https://attack.mitre.org/techniques/T0847",
+          "https://news.softpedia.com/news/on-chernobyl-s-30th-anniversary-malware-shuts-down-german-nuclear-power-plant-503429.shtml",
+          "https://web.archive.org/web/20160430041256/https://www.geek.com/apps/german-nuclear-plant-found-riddled-with-conficker-other-viruses-1653415/",
+          "https://www.bbc.com/news/technology-36158606",
+          "https://www.darkreading.com/endpoint/german-nuclear-power-plant-infected-with-malware/d/d-id/1325298",
+          "https://www.kkw-gundremmingen.de/presse.php?id=571",
+          "https://www.reuters.com/article/us-nuclearpower-cyber-germany/german-nuclear-plant-infected-with-computer-viruses-operator-says-idUSKCN0XN2OS",
+          "https://www.sciencealert.com/multiple-computer-viruses-have-been-discovered-in-this-german-nuclear-plant",
+          "https://www.trendmicro.com/vinfo/us/security/news/cyber-attacks/malware-discovered-in-german-nuclear-power-plant",
+          "https://www.welivesecurity.com/2016/04/28/malware-found-german-nuclear-power-plant/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
+      "value": "Replication Through Removable Media - T0847"
+    },
+    {
+      "description": "Adversaries may bypass process and/or signature-based defenses by proxying execution of malicious content with signed, or otherwise trusted, binaries. Binaries used in this technique are often Microsoft-signed files, indicating that they have been either downloaded from Microsoft or are already native in the operating system. (Citation: LOLBAS Project) Binaries signed with trusted digital certificates can typically execute on Windows systems protected by digital signature validation. Several Microsoft signed binaries that are default on Windows installations can be used to proxy execution of other files or commands. Similarly, on Linux systems adversaries may abuse trusted binaries such as split to proxy execution of malicious commands. (Citation: split man page)(Citation: GTFO split)\n\nAdversaries may abuse application binaries installed on a system for proxy execution of malicious code or domain-specific commands. These commands could be used to target local resources on the device or networked devices within the environment through defined APIs ([Execution through API](https://attack.mitre.org/techniques/T0871)) or application-specific programming languages (e.g., MicroSCADA SCIL). Application binaries may be signed by the developer or generally trusted by the operators, analysts, and monitoring tools accustomed to the environment. These applications may be developed and/or directly provided by the device vendor to enable configuration, management, and operation of their devices without many alternatives. \n\nAdversaries may seek to target these trusted application binaries to execute or send commands without the development of custom malware. For example, adversaries may target a SCADA server binary which has the existing ability to send commands to substation devices, such as through IEC 104 command messages. Proxy execution may still require the development of custom tools to hook into the application binary’s execution.\n\n",
+      "meta": {
+        "external_id": "T0894",
+        "kill_chain": [
+          "ics-attack:evasion"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0894",
+          "https://github.com/LOLBAS-Project/LOLBAS#criteria",
+          "https://gtfobins.github.io/gtfobins/split/",
+          "https://man7.org/linux/man-pages/man1/split.1.html"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "1c5cf58c-a34a-40d7-82f4-f987cdfc2b91",
+      "value": "System Binary Proxy Execution - T0894"
+    },
+    {
+      "description": "Adversaries may exploit a software vulnerability to take advantage of a programming error in a program, service, or within the operating system software or kernel itself to enable remote service abuse. A common goal for post-compromise exploitation of remote services is for initial access into and lateral movement throughout the ICS environment to enable access to targeted systems. (Citation: Enterprise ATT&CK)\n\nICS asset owners and operators have been affected by ransomware (or disruptive malware masquerading as ransomware) migrating from enterprise IT to ICS environments: WannaCry, NotPetya, and BadRabbit. In each of these cases, self-propagating (wormable) malware initially infected IT networks, but through exploit (particularly the SMBv1-targeting MS17-010 vulnerability) spread to industrial networks, producing significant impacts. (Citation: Joe Slowik April 2019)",
+      "meta": {
+        "external_id": "T0866",
+        "kill_chain": [
+          "ics-attack:initial-access",
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0866",
+          "https://attack.mitre.org/techniques/T1210/",
+          "https://dragos.com/blog/industry-news/implications-of-it-ransomware-for-ics-environments/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+      "value": "Exploitation of Remote Services - T0866"
+    },
+    {
+      "description": "Adversaries may establish command and control capabilities over commonly used application layer protocols such as HTTP(S), OPC, RDP, telnet, DNP3, and modbus. These protocols may be used to disguise adversary actions as benign network traffic. Standard protocols may be seen on their associated port or in some cases over a non-standard port.  Adversaries may use these protocols to reach out of the network for command and control, or in some cases to other infected devices within the network.",
+      "meta": {
+        "external_id": "T0869",
+        "kill_chain": [
+          "ics-attack:command-and-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0869"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+      "value": "Standard Application Layer Protocol - T0869"
+    },
+    {
+      "description": "An adversary may attempt to get detailed information about remote systems and their peripherals, such as make/model, role, and configuration. Adversaries may use information from Remote System Information Discovery to aid in targeting and shaping follow-on behaviors. For example, the system's operational role and model information can dictate whether it is a relevant target for the adversary's operational objectives. In addition, the system's configuration may be used to scope subsequent technique usage. \n\nRequests for system information are typically implemented using automation and management protocols and are often automatically requested by vendor software during normal operation. This information may be used to tailor management actions, such as program download and system or module firmware. An adversary may leverage this same information by issuing calls directly to the system's API.",
+      "meta": {
+        "external_id": "T0888",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0888"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
+      "value": "Remote System Information Discovery - T0888"
+    },
+    {
       "description": "Before creating a window, graphical Windows-based processes must prescribe to or register a windows class, which stipulate appearance and behavior (via windows procedures, which are functions that handle input/output of data). (Citation: Microsoft Window Classes) Registration of new windows classes can include a request for up to 40 bytes of extra window memory (EWM) to be appended to the allocated memory of each instance of that class. This EWM is intended to store data specific to that window and has specific application programming interface (API) functions to set and get its value. (Citation: Microsoft GetWindowLong function) (Citation: Microsoft SetWindowLong function)\n\nAlthough small, the EWM is large enough to store a 32-bit pointer and is often used to point to a windows procedure. Malware may possibly utilize this memory location in part of an attack chain that includes writing code to shared sections of the process’s memory, placing a pointer to the code in EWM, then invoking execution by returning execution control to the address in the process’s EWM.\n\nExecution granted through EWM injection may take place in the address space of a separate live process. Similar to [Process Injection](https://attack.mitre.org/techniques/T1055), this may allow access to both the target process's memory and possibly elevated privileges. Writing payloads to shared sections also avoids the use of highly monitored API calls such as WriteProcessMemory and CreateRemoteThread. (Citation: Elastic Process Injection July 2017) More sophisticated malware samples may also potentially bypass protection mechanisms such as data execution prevention (DEP) by triggering a combination of windows procedures and other system functions that will rewrite the malicious payload inside an executable portion of the target process. (Citation: MalwareTech Power Loader Aug 2013) (Citation: WeLiveSecurity Gapz and Redyms Mar 2013)",
       "meta": {
         "external_id": "T1181",
@@ -6936,6 +7718,60 @@
       },
       "uuid": "63b24abc-5702-4745-b1e4-ac70b20a43f2",
       "value": "Search Threat Vendor Data - T1681"
+    },
+    {
+      "description": "Adversaries may block messages between systems and devices in an OT/ICS environment to disrupt processes. Messages typically fall into two categories: (1) reporting messages that contain telemetry data about the current state of systems, devices, and processes and (2) command messages that contain instructions to control systems, devices, and processes. Both types of messages are critical for the proper functioning of industrial control processes and failure of the messages to reach their intended destinations could inhibit response functions or create an unsafe condition that could have physical impacts.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)(Citation: Electricity Information Sharing and Analysis Center; SANS Industrial Control Systems March 2016)\n\nAdversaries may block communications by either making modifications to software ([System Firmware](https://attack.mitre.org/techniques/T0857), [Module Firmware](https://attack.mitre.org/techniques/T0839), [Hooking](https://attack.mitre.org/techniques/T0874), and [Rootkit](https://attack.mitre.org/techniques/T0851)) and services ([Service Stop](https://attack.mitre.org/techniques/T0881), [Denial of Service](https://attack.mitre.org/techniques/T0814)) on systems and devices or by positioning themselves between systems and devices and intercepting and blocking the communications such as the case with an [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) attack.\n",
+      "meta": {
+        "external_id": "T1691",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://assets.contentstack.io/v3/assets/blt36c2e63521272fdc/blt6a77276749b76a40/607f235992f0063e5c070fff/E-ISAC_SANS_Ukraine_DUC_5%5b73%5d.pdf",
+          "https://attack.mitre.org/techniques/T1691"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "338f4364-2269-4f70-9079-b20384b16628",
+      "value": "Block Operational Technology Message - T1691"
     },
     {
       "description": "Adversaries may enumerate objects in cloud storage infrastructure. Adversaries may use this information during automated discovery to shape follow-on behaviors, including requesting all or specific objects from cloud storage.  Similar to [File and Directory Discovery](https://attack.mitre.org/techniques/T1083) on a local host, after identifying available storage services (i.e. [Cloud Infrastructure Discovery](https://attack.mitre.org/techniques/T1580)) adversaries may access the contents/objects stored in cloud infrastructure.\n\nCloud service providers offer APIs allowing users to enumerate objects stored within cloud storage. Examples include ListObjectsV2 in AWS (Citation: ListObjectsV2) and List Blobs in Azure(Citation: List Blobs) .",
@@ -8505,6 +9341,38 @@
       },
       "uuid": "c21d5a77-d422-4a69-acd7-2c53c1faa34b",
       "value": "Non-Application Layer Protocol - T1095"
+    },
+    {
+      "description": "Adversaries may leverage weaknesses to exploit internet-facing software for initial access into an industrial network. Internet-facing software may be user applications, underlying networking implementations, an assets operating system, weak defenses, etc. Targets of this technique may be intentionally exposed for the purpose of remote management and visibility.\n\nAn adversary may seek to target public-facing applications as they may provide direct access into an ICS environment or the ability to move into the ICS network. Publicly exposed applications may be found through online tools that scan the internet for open ports and services. Version numbers for the exposed application may provide adversaries an ability to target specific known vulnerabilities. Exposed control protocol or remote access ports found in Commonly Used Port may be of interest by adversaries.",
+      "meta": {
+        "external_id": "T0819",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0819"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+      "value": "Exploit Public-Facing Application - T0819"
     },
     {
       "description": "Adversaries may target multi-factor authentication (MFA) mechanisms, (i.e., smart cards, token generators, etc.) to gain access to credentials that can be used to access systems, services, and network resources. Use of MFA is recommended and provides a higher level of security than usernames and passwords alone, but organizations should be aware of techniques that could be used to intercept and bypass these security mechanisms. \n\nIf a smart card is used for multi-factor authentication, then a keylogger will need to be used to obtain the password associated with a smart card during normal use. With both an inserted card and access to the smart card password, an adversary can connect to a network resource using the infected system to proxy the authentication with the inserted hardware token. (Citation: Mandiant M Trends 2011)\n\nAdversaries may also employ a keylogger to similarly target other hardware tokens, such as RSA SecurID. Capturing token input (including a user's personal identification code) may provide temporary access (i.e. replay the one-time passcode until the next value rollover) as well as possibly enabling adversaries to reliably predict future authentication values (given access to both the algorithm and any seed values used to generate appended temporary codes). (Citation: GCN RSA June 2011)\n\nOther methods of MFA may be intercepted and used by an adversary to authenticate. It is common for one-time codes to be sent via out-of-band communications (email, SMS). If the device and/or service is not secured, then it may be vulnerable to interception. Service providers can also be targeted: for example, an adversary may compromise an SMS messaging service in order to steal MFA codes sent to users’ phones.(Citation: Okta Scatter Swine 2022)",
@@ -13431,6 +14299,54 @@
       "value": "Python Startup Hooks - T1546.018"
     },
     {
+      "description": "Adversaries may repetitively or successively change I/O point values to perform an action. Brute Force I/O may be achieved by changing either a range of I/O point values or a single point value repeatedly to manipulate a process function. The adversary's goal and the information they have about the target environment will influence which of the options they choose. In the case of brute forcing a range of point values, the adversary may be able to achieve an impact without targeting a specific point. In the case where a single point is targeted, the adversary may be able to generate instability on the process function associated with that particular point. \n\nAdversaries may use Brute Force I/O to cause failures within various industrial processes. These failures could be the result of wear on equipment or damage to downstream equipment.",
+      "meta": {
+        "external_id": "T0806",
+        "kill_chain": [
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0806"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+      "value": "Brute Force I/O - T0806"
+    },
+    {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/techniques/T1280).\n\nUnderstanding an organizations business processes and tempo may allow an adversary to more effectively craft social engineering attempts or to better hide technical actions, such as those that generate network traffic. (Citation: Scasny2015) (Citation: Infosec-osint)",
       "meta": {
         "external_id": "T1280",
@@ -13509,6 +14425,59 @@
       "revoked": true,
       "uuid": "b332a960-3c04-495a-827f-f17a5daed3a6",
       "value": "Disguise Root/Jailbreak Indicators - T1408"
+    },
+    {
+      "description": "Adversaries may use input/output (I/O) module discovery to gather key information about a control system device. An I/O module is a device that allows the control system device to either receive or send signals to other devices. These signals can be analog or digital, and may support a number of different protocols. Devices are often able to use attachable I/O modules to increase the number of inputs and outputs that it can utilize. An adversary with access to a device can use native device functions to enumerate I/O modules that are connected to the device. Information regarding the I/O modules can aid the adversary in understanding related control processes.",
+      "meta": {
+        "external_id": "T0824",
+        "kill_chain": [
+          "ics-attack-Windows:discovery",
+          "ics-attack-Field-Controller/RTU/PLC/IED:discovery"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0824"
+        ]
+      },
+      "uuid": "e2994b6a-122b-4043-b654-7411c5198ec0",
+      "value": "I/O Module Discovery - T0824"
+    },
+    {
+      "description": "Adversaries may manipulate the I/O image of PLCs through various means to prevent them from functioning as expected. Methods of I/O image manipulation may include overriding the I/O table via direct memory manipulation or using the override function used for testing PLC programs. (Citation: Dr. Kelvin T. Erickson December 2010) During the scan cycle, a PLC reads the status of all inputs and stores them in an image table. (Citation: Nanjundaiah, Vaidyanath) The image table is the PLCs internal storage location where values of inputs/outputs for one scan are stored while it executes the user program. After the PLC has solved the entire logic program, it updates the output image table. The contents of this output image table are written to the corresponding output points in I/O Modules. \n\nOne of the unique characteristics of PLCs is their ability to override the status of a physical discrete input or to override the logic driving a physical output coil and force the output to a desired status.",
+      "meta": {
+        "external_id": "T0835",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0835",
+          "https://www.ezautomation.net/industry-articles/plc-ladder-logic-basics.htm",
+          "https://www.scribd.com/document/458637574/Programmable-Logic-Controllers"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "36e9f5bc-ac13-4da4-a2f4-01f4877d9004",
+      "value": "Manipulate I/O Image - T0835"
     },
     {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/techniques/T1281).\n\nTemplates and branding materials may be used by an adversary to add authenticity to social engineering message. (Citation: Scasny2015)",
@@ -13675,6 +14644,17 @@
       },
       "uuid": "f72804c5-f15a-449e-a5da-2eecd181f813",
       "value": "Command and Control - TA0011"
+    },
+    {
+      "description": "The adversary is trying to communicate with and control compromised systems, controllers, and platforms with access to your ICS environment.\n\nCommand and Control consists of techniques that adversaries use to communicate with and send commands to compromised systems, devices, controllers, and platforms with specialized applications used in ICS environments. Examples of these specialized communication devices include human machine interfaces (HMIs), data historians, SCADA servers, and engineering workstations (EWS). Adversaries often seek to use commonly available resources and mimic expected network traffic to avoid detection and suspicion. For instance, commonly used ports and protocols in ICS environments, and even expected IT resources, depending on the target network. Command and Control may be established to varying degrees of stealth, often depending on the victim’s network structure and defenses.",
+      "meta": {
+        "external_id": "TA0101",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0101"
+        ]
+      },
+      "uuid": "97c8ff73-bd14-4b6c-ac32-3d91d2c41e3f",
+      "value": "Command and Control - TA0101"
     },
     {
       "description": "Adversaries may attempt to get a listing of open application windows. Window listings could convey information about how the system is used.(Citation: Prevailion DarkWatchman 2021) For example, information about application windows could be used identify potential data to collect as well as identifying security tooling ([Security Software Discovery](https://attack.mitre.org/techniques/T1518/001)) to evade.(Citation: ESET Grandoreiro April 2020)\n\nAdversaries typically abuse system features for this type of enumeration. For example, they may gather information through native system features such as [Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059) commands and [Native API](https://attack.mitre.org/techniques/T1106) functions.",
@@ -13871,6 +14851,17 @@
       "value": "Technical Information Gathering - TA0015"
     },
     {
+      "description": "The adversary is trying to manipulate, disable, or damage physical control processes.\n\nImpair Process Control consists of techniques that adversaries use to disrupt control logic and cause determinantal effects to processes being controlled in the target environment. Targets of interest may include active procedures or parameters that manipulate the physical environment. These techniques can also include prevention or manipulation of reporting elements and control logic. If an adversary has modified process functionality, then they may also obfuscate the results, which are often self-revealing in their impact on the outcome of a product or the environment. The direct physical control these techniques exert may also threaten the safety of operators and downstream users, which can prompt response mechanisms. Adversaries may follow up with or use [Inhibit Response Function](https://attack.mitre.org/tactics/TA0107) techniques in tandem, to assist with the successful abuse of control processes to result in [Impact](https://attack.mitre.org/tactics/TA0105).",
+      "meta": {
+        "external_id": "TA0106",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0106"
+        ]
+      },
+      "uuid": "ff048b6c-b872-4218-b68c-3735ebd1f024",
+      "value": "Impair Process Control - TA0106"
+    },
+    {
       "description": "Adversaries may directly access a volume to bypass file access controls and file system monitoring. Windows allows programs to have direct access to logical volumes. Programs with direct access may read and write files directly from the drive by analyzing file system data structures. This technique may bypass Windows file access controls as well as file system monitoring tools.(Citation: Hakobyan 2009)\n\nUtilities, such as `NinjaCopy`, exist to perform these actions in PowerShell.(Citation: Github PowerSploit Ninjacopy) Adversaries may also use built-in or third-party utilities (such as `vssadmin`, `wbadmin`, and [esentutl](https://attack.mitre.org/software/S0404)) to create shadow copies or backups of data from system volumes.(Citation: LOLBAS Esentutl)",
       "meta": {
         "external_id": "T1006",
@@ -13907,6 +14898,17 @@
       },
       "uuid": "d90bd741-2edb-4e74-8a6f-435143ad7bbb",
       "value": "People Information Gathering - TA0016"
+    },
+    {
+      "description": "The adversary is trying to prevent your safety, protection, quality assurance, and operator intervention functions from responding to a failure, hazard, or unsafe state.\n\nInhibit Response Function consists of techniques that adversaries use to hinder the safeguards put in place for processes and products. This may involve the inhibition of safety, protection, quality assurance, or operator intervention functions to disrupt safeguards that aim to prevent the loss of life, destruction of equipment, and disruption of production. These techniques aim to actively deter and prevent expected alarms and responses that arise due to statuses in the ICS environment. Adversaries may modify or update system logic, or even outright prevent responses with a denial-of-service. They may result in the prevention, destruction, manipulation, or modification of programs, logic, devices, and communications. As prevention functions are generally dormant, reporting and processing functions can appear fine, but may have been altered to prevent failure responses in dangerous scenarios. Unlike [Evasion](https://attack.mitre.org/tactics/TA0103), Inhibit Response Function techniques may be more intrusive, such as actively preventing responses to a known dangerous scenario. Adversaries may use these techniques to follow through with or provide cover for [Impact](https://attack.mitre.org/tactics/TA0105) techniques.",
+      "meta": {
+        "external_id": "TA0107",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0107"
+        ]
+      },
+      "uuid": "298fe907-7931-4fd2-8131-2814dd493134",
+      "value": "Inhibit Response Function - TA0107"
     },
     {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/tactics/TA0017/).\n\nOrganizational information gathering consists of the process of identifying critical organizational elements of intelligence an adversary will need about a target in order to best attack.  Similar to competitive intelligence, organizational intelligence gathering focuses on understanding the operational tempo of an organization and gathering a deep understanding of the organization and how it operates, in order to best develop a strategy to target it.",
@@ -13961,6 +14963,24 @@
       "value": "Technical Weakness Identification - TA0018"
     },
     {
+      "description": "Adversaries may compromise and gain control of a data historian to gain a foothold into the control system environment. Access to a data historian may be used to learn stored database archival and analysis information on the control system. A dual-homed data historian may provide adversaries an interface from the IT environment to the OT environment. \n\nDragos has released an updated analysis on CrashOverride that outlines the attack from the ICS network breach to payload delivery and execution.  (Citation: Industroyer - Dragos - 201810) The report summarized that CrashOverride represents a new application of malware, but relied on standard intrusion techniques. In particular, new artifacts include references to a Microsoft Windows Server 2003 host, with a SQL Server. Within the ICS environment, such a database server can act as a data historian. Dragos noted a device with this role should be \"expected to have extensive connections\" within the ICS environment. Adversary activity leveraged database capabilities to perform reconnaissance, including directory queries and network connectivity checks.\n\nPermissions Required: Administrator\n\nContributors: Joe Slowik - Dragos",
+      "meta": {
+        "external_id": "T0810",
+        "kill_chain": [
+          "ics-attack-Windows:initial-access"
+        ],
+        "mitre_platforms": [
+          "Windows"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0810",
+          "https://dragos.com/wp-content/uploads/CRASHOVERRIDE2018.pdf"
+        ]
+      },
+      "uuid": "50d3222f-7550-4a3c-94e1-78cb6c81d064",
+      "value": "Data Historian Compromise - T0810"
+    },
+    {
       "description": "\nAdversaries may deliver payloads to remote systems by adding content to shared storage locations, such as network drives or internal code repositories. Content stored on network drives or in other shared locations may be tainted by adding malicious programs, scripts, or exploit code to otherwise valid files. Once a user opens the shared tainted content, the malicious portion can be executed to run the adversary's code on a remote system. Adversaries may use tainted shared content to move laterally.\n\nA directory share pivot is a variation on this technique that uses several other techniques to propagate malware when users access a shared network directory. It uses [Shortcut Modification](https://attack.mitre.org/techniques/T1547/009) of directory .LNK files that use [Masquerading](https://attack.mitre.org/techniques/T1036) to look like the real directories, which are hidden through [Hidden Files and Directories](https://attack.mitre.org/techniques/T1564/001). The malicious .LNK-based directories have an embedded command that executes the hidden malware file in the directory and then opens the real intended directory so that the user's expected action still occurs. When used with frequently used network directories, the technique may result in frequent reinfections and broad access to systems and potentially to new and higher privileged accounts. (Citation: Retwin Directory Share Pivot)\n\nAdversaries may also compromise shared network directories through binary infections by appending or prepending its code to the healthy binary on the shared network directory. The malware may modify the original entry point (OEP) of the healthy binary to ensure that it is executed before the legitimate code. The infection could continue to spread via the newly infected file when it is executed by a remote system. These infections may target both binary and non-binary formats that end with extensions including, but not limited to, .EXE, .DLL, .SCR, .BAT, and/or .VBS.",
       "meta": {
         "external_id": "T1080",
@@ -13993,6 +15013,66 @@
       "value": "Taint Shared Content - T1080"
     },
     {
+      "description": "Adversaries may gather information about the physical process state. This information may be used to gain more information about the process itself or used as a trigger for malicious actions. The sources of process state information may vary such as, OPC tags, historian data, specific PLC block information, or network traffic.",
+      "meta": {
+        "external_id": "T0801",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0801"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+      "value": "Monitor Process State - T0801"
+    },
+    {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/tactics/TA0019/).\n\nPeople weakness identification consists of identifying and analyzing weaknesses and vulnerabilities from the intelligence gathering phases which can be leveraged to gain access to target or intermediate target persons of interest or social trust relationships.",
       "meta": {
         "external_id": "TA0019",
@@ -14002,6 +15082,86 @@
       },
       "uuid": "f30c2753-e6b2-4186-818d-99b8b1a0322b",
       "value": "People Weakness Identification - TA0019"
+    },
+    {
+      "description": "Adversaries may exploit a software vulnerability to take advantage of a programming error in a program, service, or within the operating system software or kernel itself to evade detection. Vulnerabilities may exist in software that can be used to disable or circumvent security features.  \n\nAdversaries may have prior knowledge through [Remote System Information Discovery](https://attack.mitre.org/techniques/T0888) about security features implemented on control devices. These device security features will likely be targeted directly for exploitation. There are examples of firmware RAM/ROM consistency checks on control devices being targeted by adversaries to enable the installation of malicious [System Firmware](https://attack.mitre.org/techniques/T0857).",
+      "meta": {
+        "external_id": "T0820",
+        "kill_chain": [
+          "ics-attack:evasion"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0820"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+      "value": "Exploitation for Evasion - T0820"
     },
     {
       "description": "The adversary is trying to communicate with compromised devices to control them.\n\nThe command and control tactic represents how adversaries communicate with systems under their control within a target network. There are many ways an adversary can establish command and control with various levels of covertness, depending on system configuration and network topology. Due to the wide degree of variation available to the adversary at the network level, only the most common factors were used to describe the differences in command and control. There are still a great many specific techniques within the documented methods, largely due to how easy it is to define new protocols and use existing, legitimate protocols and network services for communication. \n\nThe resulting breakdown should help convey the concept that detecting intrusion through command and control protocols without prior knowledge is a difficult proposition over the long term. Adversaries' main constraints in network-level defense avoidance are testing and deployment of tools to rapidly change their protocols, awareness of existing defensive technologies, and access to legitimate Web services that, when used appropriately, make their tools difficult to distinguish from benign traffic.\n\nAdditionally, in the mobile environment, mobile devices are frequently connected to networks outside enterprise control such as cellular networks or public Wi-Fi networks. Adversaries could attempt to evade detection by communicating on these networks, and potentially even by using non-Internet Protocol mechanisms such as Short Message Service (SMS). However, cellular networks often have data caps and/or extra data charges that could increase the potential for adversarial communication to be detected.",
@@ -14015,6 +15175,29 @@
       "value": "Command and Control - TA0037"
     },
     {
+      "description": "Adversaries may block a command message from reaching its intended target to prevent command execution. In OT networks, command messages are sent to provide instructions to control system devices. A blocked command message can inhibit response functions from correcting a disruption or unsafe condition. (Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)  (Citation: Electricity Information Sharing and Analysis Center; SANS Industrial Control Systems March 2016)",
+      "meta": {
+        "external_id": "T0803",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://assets.contentstack.io/v3/assets/blt36c2e63521272fdc/blt6a77276749b76a40/607f235992f0063e5c070fff/E-ISAC_SANS_Ukraine_DUC_5%5b73%5d.pdf",
+          "https://attack.mitre.org/techniques/T0803"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "008b8f56-6107-48be-aa9f-746f927dbb61",
+      "value": "Block Command Message - T0803"
+    },
+    {
       "description": "The adversary is trying to control or monitor the device using remote services.\n\nThis category refers to techniques involving remote services, such as vendor-provided cloud services (e.g. Google Drive, Google Find My Device, or Apple iCloud), or enterprise mobility management (EMM)/mobile device management (MDM) services that an adversary may be able to use to fulfill his or her objectives without access to the mobile device itself.",
       "meta": {
         "external_id": "TA0039",
@@ -14024,6 +15207,184 @@
       },
       "uuid": "e78d7d60-41b5-49b7-b0a9-5c5d4cbabe17",
       "value": "Remote Service Effects - TA0039"
+    },
+    {
+      "description": "Adversaries may block or prevent a reporting message from reaching its intended target. In control systems, reporting messages contain telemetry data (e.g., I/O values) pertaining to the current state of equipment and the industrial process. By blocking these reporting messages, an adversary can potentially hide their actions from an operator.\n\nBlocking reporting messages in control systems that manage physical processes may contribute to system impact, causing inhibition of a response function. A control system may not be able to respond in a proper or timely manner to an event, such as a dangerous fault, if its corresponding reporting message is blocked. (Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)  (Citation: Electricity Information Sharing and Analysis Center; SANS Industrial Control Systems March 2016)",
+      "meta": {
+        "external_id": "T0804",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://assets.contentstack.io/v3/assets/blt36c2e63521272fdc/blt6a77276749b76a40/607f235992f0063e5c070fff/E-ISAC_SANS_Ukraine_DUC_5%5b73%5d.pdf",
+          "https://attack.mitre.org/techniques/T0804"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "3f1f4ccb-9be2-4ff8-8f69-dd972221169b",
+      "value": "Block Reporting Message - T0804"
+    },
+    {
+      "description": "Adversaries may perform network connection enumeration to discover information about device communication patterns. If an adversary can inspect the state of a network connection with tools, such as Netstat(Citation: Netstat), in conjunction with [System Firmware](https://attack.mitre.org/techniques/T0857), then they can determine the role of certain devices on the network  (Citation: MITRE). The adversary can also use [Network Sniffing](https://attack.mitre.org/techniques/T0842) to watch network traffic for details about the source, destination, protocol, and content.",
+      "meta": {
+        "external_id": "T0840",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0840",
+          "https://attack.mitre.org/wiki/Technique/T1049",
+          "https://en.wikipedia.org/wiki/Netstat"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
+      "value": "Network Connection Enumeration - T0840"
+    },
+    {
+      "description": "Adversaries may block access to serial COM to prevent instructions or configurations from reaching target devices. Serial Communication ports (COM) allow communication with control system devices. Devices can receive command and configuration messages over such serial COM. Devices also use serial COM to send command and reporting messages. Blocking device serial COM may also block command messages and block reporting messages. \n\nA serial to Ethernet converter is often connected to a serial COM to facilitate communication between serial and Ethernet devices. One approach to blocking a serial COM would be to create and hold open a TCP session with the Ethernet side of the converter. A serial to Ethernet converter may have a few ports open to facilitate multiple communications. For example, if there are three serial COM available -- 1, 2 and 3 --, the converter might be listening on the corresponding ports 20001, 20002, and 20003. If a TCP/IP connection is opened with one of these ports and held open, then the port will be unavailable for use by another party. One way the adversary could achieve this would be to initiate a TCP session with the serial to Ethernet converter at 10.0.0.1 via Telnet on serial port 1 with the following command: telnet 10.0.0.1 20001.",
+      "meta": {
+        "external_id": "T0805",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0805"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "1c478716-71d9-46a4-9a53-fa5d576adb60",
+      "value": "Block Serial COM - T0805"
+    },
+    {
+      "description": "Adversaries may seek to gather information about the current state of a program on a PLC. State information reveals information about the program, including whether it's running, halted, stopped, or has generated an exception. This information may be leveraged as a verification of malicious program execution or to determine if a PLC is ready to download a new program.",
+      "meta": {
+        "external_id": "T0870",
+        "kill_chain": [
+          "ics-attack-Windows:collection",
+          "ics-attack-Field-Controller/RTU/PLC/IED:collection"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0870"
+        ]
+      },
+      "uuid": "94f042ae-3033-4a8d-9ec3-26396533a541",
+      "value": "Detect Program State - T0870"
+    },
+    {
+      "description": "Adversaries may perform control device identification to determine the make and model of a target device. Management software and device APIs may be utilized by the adversary to gain this information. By identifying and obtaining device specifics, the adversary may be able to determine device vulnerabilities. This device information can also be used to understand device functionality and inform the decision to target the environment.",
+      "meta": {
+        "external_id": "T0808",
+        "kill_chain": [
+          "ics-attack-Windows:discovery",
+          "ics-attack-Field-Controller/RTU/PLC/IED:discovery"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0808"
+        ]
+      },
+      "uuid": "abb0a255-eb9c-48d0-8f5c-874bb84c0e45",
+      "value": "Control Device Identification - T0808"
+    },
+    {
+      "description": "Adversaries may compromise safety system functions designed to maintain safe operation of a process when unacceptable or dangerous conditions occur. Safety systems are often composed of the same elements as control systems but have the sole purpose of ensuring the process fails in a predetermined safe manner. \n\nMany unsafe conditions in process control happen too quickly for a human operator to react to. Speed is critical in correcting these conditions to limit serious impacts such as Loss of Control and Property Damage. \n\nAdversaries may target and disable safety system functions as a prerequisite to subsequent attack execution or to allow for future unsafe conditionals to go unchecked. Detection of a Loss of Safety by operators can result in the shutdown of a process due to strict policies regarding safety systems. This can cause a Loss of Productivity and Revenue and may meet the technical goals of adversaries seeking to cause process disruptions.",
+      "meta": {
+        "external_id": "T0880",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0880"
+        ]
+      },
+      "uuid": "5fa00fdd-4a55-4191-94a0-564181d7fec2",
+      "value": "Loss of Safety - T0880"
     },
     {
       "description": "Windows Security Support Provider (SSP) DLLs are loaded into the Local Security Authority (LSA) process at system start. Once loaded into the LSA, SSP DLLs have access to encrypted and plaintext passwords that are stored in Windows, such as any logged-on user's Domain password or smart card PINs. The SSP configuration is stored in two Registry keys: <code>HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Security Packages</code> and <code>HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\OSConfig\\Security Packages</code>. An adversary may modify these Registry keys to add new SSPs, which will be loaded the next time the system boots, or when the AddSecurityPackage Windows API function is called.\n (Citation: Graeber 2014)",
@@ -14719,6 +16080,39 @@
       "value": "Software Deployment Tools - T1072"
     },
     {
+      "description": "Adversaries may modify the tasking of a controller to allow for the execution of their own programs. This can allow an adversary to manipulate the execution flow and behavior of a controller. \n\nAccording to 61131-3, the association of a Task with a Program Organization Unit (POU) defines a task association. (Citation: IEC February 2013) An adversary may modify these associations or create new ones to manipulate the execution flow of a controller. Modification of controller tasking can be accomplished using a Program Download in addition to other types of program modification such as online edit and program append.\n\nTasks have properties, such as interval, frequency and priority to meet the requirements of program execution. Some controller vendors implement tasks with implicit, pre-defined properties whereas others allow for these properties to be formulated explicitly. An adversary may associate their program with tasks that have a higher priority or execute associated programs more frequently. For instance, to ensure cyclic execution of their program on a Siemens controller, an adversary may add their program to the task, Organization Block 1 (OB1).",
+      "meta": {
+        "external_id": "T0821",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0821",
+          "https://webstore.iec.ch/publication/4552"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+      "value": "Modify Controller Tasking - T0821"
+    },
+    {
       "description": "An adversary may attempt to get detailed information about the operating system and hardware, including version, patches, hotfixes, service packs, and architecture. Adversaries may use this information to shape follow-on behaviors, including whether or not the adversary fully infects the target and/or attempts specific actions. This behavior is distinct from [Local Storage Discovery](https://attack.mitre.org/techniques/T1680) which is an adversary's discovery of local drive, disks and/or volumes.\n\nTools such as [Systeminfo](https://attack.mitre.org/software/S0096) can be used to gather detailed system information. If running with privileged access, a breakdown of system data can be gathered through the <code>systemsetup</code> configuration tool on macOS. Adversaries may leverage a [Network Device CLI](https://attack.mitre.org/techniques/T1059/008) on network devices to gather detailed system information (e.g. <code>show version</code>).(Citation: US-CERT-TA18-106A) On ESXi servers, threat actors may gather system information from various esxcli utilities, such as `system hostname get` and `system version get`.(Citation: Crowdstrike Hypervisor Jackpotting Pt 2 2021)(Citation: Varonis)\n\nInfrastructure as a Service (IaaS) cloud providers such as AWS, GCP, and Azure allow access to instance and virtual machine information via APIs. Successful authenticated API calls can return data such as the operating system platform and status of a particular instance or the model view of a virtual machine.(Citation: Amazon Describe Instance)(Citation: Google Instances Resource)(Citation: Microsoft Virutal Machine API)\n\n[System Information Discovery](https://attack.mitre.org/techniques/T1082) combined with information gathered from other forms of discovery and reconnaissance can drive payload development and concealment.(Citation: OSX.FairyTale)(Citation: 20 macOS Common Tools and Techniques) ",
       "meta": {
         "external_id": "T1082",
@@ -14864,6 +16258,41 @@
       "value": "Test physical access - T1360"
     },
     {
+      "description": "Adversaries may cause a denial of control to temporarily prevent operators and engineers from interacting with process controls. An adversary may attempt to deny process control access to cause a temporary loss of communication with the control device or to prevent operator adjustment of process controls. An affected process may still be operating during the period of control loss, but not necessarily in a desired state. (Citation: Corero) (Citation: Michael J. Assante and Robert M. Lee) (Citation: Tyson Macaulay)\n\nIn the 2017 Dallas Siren incident operators were unable to disable the false alarms from the Office of Emergency Management headquarters. (Citation: Mark Loveless April 2017)",
+      "meta": {
+        "external_id": "T0813",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0813",
+          "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false",
+          "https://duo.com/decipher/the-dallas-county-siren-hack",
+          "https://icscsi.org/library/Documents/White_Papers/SANS%20-%20ICS%20Cyber%20Kill%20Chain.pdf",
+          "https://www.corero.com/resources/files/whitepapers/cns_whitepaper_ics.pdf"
+        ]
+      },
+      "uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+      "value": "Denial of Control - T0813"
+    },
+    {
+      "description": "Adversaries may manipulate physical process control within the industrial environment. Methods of manipulating control can include changes to set point values, tags, or other parameters. Adversaries may manipulate control systems devices or possibly leverage their own, to communicate with and command physical control processes. The duration of manipulation may be temporary or longer sustained, depending on operator detection.   \n\nMethods of Manipulation of Control include: \n\n* Man-in-the-middle  \n* Spoof command message \n* Changing setpoints  \n\nA Polish student used a remote controller device to interface with the Lodz city tram system in Poland. (Citation: John Bill May 2017) (Citation: Shelley Smith February 2008) (Citation: Bruce Schneier January 2008) Using this remote, the student was able to capture and replay legitimate tram signals. As a consequence, four trams were derailed and twelve people injured due to resulting emergency stops. (Citation: Shelley Smith February 2008) The track controlling commands issued may have also resulted in tram collisions, a further risk to those on board and nearby the areas of impact. (Citation: Bruce Schneier January 2008)",
+      "meta": {
+        "external_id": "T0831",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0831",
+          "https://inhomelandsecurity.com/teen_hacker_in_poland_plays_tr/",
+          "https://www.londonreconnections.com/2017/hacked-cyber-security-railways/",
+          "https://www.schneier.com/blog/archives/2008/01/hacking_the_pol.html"
+        ]
+      },
+      "uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+      "value": "Manipulation of Control - T0831"
+    },
+    {
       "description": "A malicious app or other attack vector could be used to exploit vulnerabilities in code running within the Trusted Execution Environment (TEE) (Citation: Thomas-TrustZone). The adversary could then obtain privileges held by the TEE potentially including the ability to access cryptographic keys or other sensitive data (Citation: QualcommKeyMaster). Escalated operating system privileges may be first required in order to have the ability to attack the TEE (Citation: EkbergTEE). If not, privileges within the TEE can potentially be used to exploit the operating system (Citation: laginimaineb-TEE).",
       "meta": {
         "external_id": "T1405",
@@ -14983,6 +16412,101 @@
       },
       "uuid": "01a5a209-b94c-450b-b7f9-946497d91055",
       "value": "Windows Management Instrumentation - T1047"
+    },
+    {
+      "description": "Adversaries may perform Denial-of-Service (DoS) attacks to disrupt expected device functionality. Examples of DoS attacks include overwhelming the target device with a high volume of requests in a short time period and sending the target device a request it does not know how to handle. Disrupting device state may temporarily render it unresponsive, possibly lasting until a reboot can occur. When placed in this state, devices may be unable to send and receive requests, and may not perform expected response functions in reaction to other events in the environment. \n\nSome ICS devices are particularly sensitive to DoS events, and may become unresponsive in reaction to even a simple ping sweep. Adversaries may also attempt to execute a Permanent Denial-of-Service (PDoS) against certain devices, such as in the case of the BrickerBot malware. (Citation: ICS-CERT April 2017) \n\nAdversaries may exploit a software vulnerability to cause a denial of service by taking advantage of a programming error in a program, service, or within the operating system software or kernel itself to execute adversary-controlled code. Vulnerabilities may exist in software that can be used to cause a denial of service condition. \n\nAdversaries may have prior knowledge about industrial protocols or control devices used in the environment through [Remote System Information Discovery](https://attack.mitre.org/techniques/T0888). There are examples of adversaries remotely causing a [Device Restart/Shutdown](https://attack.mitre.org/techniques/T0816) by exploiting a vulnerability that induces uncontrolled resource consumption. (Citation: ICS-CERT August 2018) (Citation: Common Weakness Enumeration January 2019) (Citation: MITRE March 2018) ",
+      "meta": {
+        "external_id": "T0814",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://cwe.mitre.org/data/definitions/400.html",
+          "https://attack.mitre.org/techniques/T0814",
+          "https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01",
+          "https://nvd.nist.gov/vuln/detail/CVE-2015-5374",
+          "https://www.us-cert.gov/ics/alerts/ICS-ALERT-17-102-01A"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+      "value": "Denial of Service - T0814"
+    },
+    {
+      "description": "Network Service Scanning is the process of discovering services on networked systems.  This can be achieved through a technique called port scanning or probing.  Port scanning interacts with the TCP/IP ports on a target system to determine whether ports are open, closed, or filtered by a firewall.  This does not reveal the service that is running behind the port, but since many common services are run on [https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml specific port numbers], the type of service can be assumed.  More in-depth testing includes interaction with the actual service to determine the service type and specific version.  One of the most-popular tools to use for Network Service Scanning is [https://nmap.org/ Nmap].\n\nAn adversary may attempt to gain information about a target device and its role on the network via Network Service Scanning techniques, such as port scanning.  Network Service Scanning is useful for determining potential vulnerabilities in services on target devices.  Network Service Scanning is closely tied to .\n\nScanning ports can be noisy on a network. In some attacks, adversaries probe for specific ports using custom tools. This was specifically seen in the Triton and PLC-Blaster attacks.",
+      "meta": {
+        "external_id": "T0841",
+        "kill_chain": [
+          "ics-attack-Windows:discovery",
+          "ics-attack-Field-Controller/RTU/PLC/IED:discovery"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0841"
+        ]
+      },
+      "uuid": "539d0484-fe95-485a-b654-86991c0d0d00",
+      "value": "Network Service Scanning - T0841"
     },
     {
       "description": "Adversaries may try to access and collect application data resident on the device. Adversaries often target popular applications, such as Facebook, WeChat, and Gmail.(Citation: SWB Exodus March 2019) \n\n \n\nDue to mobile OS sandboxing, this technique is only possible in three scenarios: \n\n \n\n* An application stores files in unprotected external storage \n* An application stores files in its internal storage directory with insecure permissions (e.g. 777) \n* The adversary gains root permissions on the device ",
@@ -15322,6 +16846,23 @@
       "value": "Cloud Infrastructure Discovery - T1580"
     },
     {
+      "description": "Adversaries may cause a denial of view in attempt to disrupt and prevent operator oversight on the status of an ICS environment. This may manifest itself as a temporary communication failure between a device and its control source, where the interface recovers and becomes available once the interference ceases. (Citation: Corero) (Citation: Michael J. Assante and Robert M. Lee) (Citation: Tyson Macaulay) \n\nAn adversary may attempt to deny operator visibility by preventing them from receiving status and reporting messages. Denying this view may temporarily block and prevent operators from noticing a change in state or anomalous behavior. The environment's data and processes may still be operational, but functioning in an unintended or adversarial manner. ",
+      "meta": {
+        "external_id": "T0815",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0815",
+          "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false",
+          "https://icscsi.org/library/Documents/White_Papers/SANS%20-%20ICS%20Cyber%20Kill%20Chain.pdf",
+          "https://www.corero.com/resources/files/whitepapers/cns_whitepaper_ics.pdf"
+        ]
+      },
+      "uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+      "value": "Denial of View - T0815"
+    },
+    {
       "description": "Adversaries may forge credential materials that can be used to gain access to web applications or Internet services. Web applications and services (hosted in cloud SaaS environments or on-premise servers) often use session cookies, tokens, or other materials to authenticate and authorize user access.\n\nAdversaries may generate these credential materials in order to gain access to web resources. This differs from [Steal Web Session Cookie](https://attack.mitre.org/techniques/T1539), [Steal Application Access Token](https://attack.mitre.org/techniques/T1528), and other similar behaviors in that the credentials are new and forged by the adversary, rather than stolen or intercepted from legitimate users.\n\nThe generation of web credentials often requires secret values, such as passwords, [Private Keys](https://attack.mitre.org/techniques/T1552/004), or other cryptographic seed values.(Citation: GitHub AWS-ADFS-Credential-Generator) Adversaries may also forge tokens by taking advantage of features such as the `AssumeRole` and `GetFederationToken` APIs in AWS, which allow users to request temporary security credentials (i.e., [Temporary Elevated Cloud Access](https://attack.mitre.org/techniques/T1548/005)), or the `zmprov gdpak` command in Zimbra, which generates a pre-authentication key that can be used to generate tokens for any user in the domain.(Citation: AWS Temporary Security Credentials)(Citation: Zimbra Preauth)\n\nOnce forged, adversaries may use these web credentials to access resources (ex: [Use Alternate Authentication Material](https://attack.mitre.org/techniques/T1550)), which may bypass multi-factor and other authentication protection mechanisms.(Citation: Pass The Cookie)(Citation: Unit 42 Mac Crypto Cookies January 2019)(Citation: Microsoft SolarWinds Customer Guidance)  ",
       "meta": {
         "external_id": "T1606",
@@ -15556,6 +17097,70 @@
       "value": "Windows Admin Shares - T1077"
     },
     {
+      "description": "Adversaries may attempt to leverage Application Program Interfaces (APIs) used for communication between control software and the hardware. Specific functionality is often coded into APIs which can be called by software to engage specific functions on a device or other software.",
+      "meta": {
+        "external_id": "T0871",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0871"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+      "value": "Execution through API - T0871"
+    },
+    {
       "description": "Pass the ticket (PtT) is a method of authenticating to a system using Kerberos tickets without having access to an account's password. Kerberos authentication can be used as the first step to lateral movement to a remote system.\n\nIn this technique, valid Kerberos tickets for [Valid Accounts](https://attack.mitre.org/techniques/T1078) are captured by [OS Credential Dumping](https://attack.mitre.org/techniques/T1003). A user's service tickets or ticket granting ticket (TGT) may be obtained, depending on the level of access. A service ticket allows for access to a particular resource, whereas a TGT can be used to request service tickets from the Ticket Granting Service (TGS) to access any resource the user has privileges to access. (Citation: ADSecurity AD Kerberos Attacks) (Citation: GentilKiwi Pass the Ticket)\n\nSilver Tickets can be obtained for services that use Kerberos as an authentication mechanism and are used to generate tickets to access that particular resource and the system that hosts the resource (e.g., SharePoint). (Citation: ADSecurity AD Kerberos Attacks)\n\nGolden Tickets can be obtained for the domain using the Key Distribution Service account KRBTGT account NTLM hash, which enables generation of TGTs for any account in Active Directory. (Citation: Campbell 2014)",
       "meta": {
         "external_id": "T1097",
@@ -15585,6 +17190,23 @@
       "value": "Pass the Ticket - T1097"
     },
     {
+      "description": "Adversaries will compromise and gain control of an engineering workstation for Initial Access into the control system environment. Access to an engineering workstation may occur through or physical means, such as a Valid Accounts with privileged access or infection by removable media. A dual-homed engineering workstation may allow the adversary access into multiple networks. For example, unsegregated process control, safety system, or information system networks. An Engineering Workstation is designed as a reliable computing platform that configures, maintains, and diagnoses control system equipment and applications. Compromise of an engineering workstation may provide access to, and control of, other control system applications and equipment. In the Maroochy attack, the adversary utilized a computer, possibly stolen, with proprietary engineering software to communicate with a wastewater system.",
+      "meta": {
+        "external_id": "T0818",
+        "kill_chain": [
+          "ics-attack-Engineering-Workstation:initial-access"
+        ],
+        "mitre_platforms": [
+          "Engineering Workstation"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0818"
+        ]
+      },
+      "uuid": "d614a9cf-18eb-4800-81e4-ab8ddf0baa73",
+      "value": "Engineering Workstation Compromise - T0818"
+    },
+    {
       "description": "Adversaries may disable security tools to avoid possible detection of their tools and activities. This can take the form of killing security software or event logging processes, deleting Registry keys so that tools do not start at run time, or other methods to interfere with security scanning or event reporting.",
       "meta": {
         "external_id": "T1089",
@@ -15612,6 +17234,852 @@
       "revoked": true,
       "uuid": "2e0dd10b-676d-4964-acd0-8a404c92b044",
       "value": "Disabling Security Tools - T1089"
+    },
+    {
+      "description": "Adversaries may leverage external remote services as a point of initial access into your network. These services allow users to connect to internal network resources from external locations. Examples are VPNs, Citrix, and other access mechanisms. Remote service gateways often manage connections and credential authentication for these services. (Citation: Daniel Oakley, Travis Smith, Tripwire)\n\nExternal remote services allow administration of a control system from outside the system. Often, vendors and internal engineering groups have access to external remote services to control system networks via the corporate network. In some cases, this access is enabled directly from the internet. While remote access enables ease of maintenance when a control system is in a remote area, compromise of remote access solutions is a liability. The adversary may use these services to gain access to and execute attacks against a control system network. Access to valid accounts is often a requirement. \n\nAs they look for an entry point into the control system network, adversaries may begin searching for existing point-to-point VPN implementations at trusted third party networks or through remote support employee connections where split tunneling is enabled. (Citation: Electricity Information Sharing and Analysis Center; SANS Industrial Control Systems March 2016)\n",
+      "meta": {
+        "external_id": "T0822",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://assets.contentstack.io/v3/assets/blt36c2e63521272fdc/blt6a77276749b76a40/607f235992f0063e5c070fff/E-ISAC_SANS_Ukraine_DUC_5%5b73%5d.pdf",
+          "https://attack.mitre.org/techniques/T0822",
+          "https://attack.mitre.org/wiki/Technique/T1133"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        }
+      ],
+      "uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+      "value": "External Remote Services - T0822"
+    },
+    {
+      "description": "Adversaries may attempt to gain access to a machine via a Graphical User Interface (GUI) to enhance execution capabilities. Access to a GUI allows a user to interact with a computer in a more visual manner than a CLI. A GUI allows users to move a cursor and click on interface objects, with a mouse and keyboard as the main input devices, as opposed to just using the keyboard.\n\nIf physical access is not an option, then access might be possible via protocols such as VNC on Linux-based and Unix-based operating systems, and RDP on Windows operating systems. An adversary can use this access to execute programs and applications on the target machine.",
+      "meta": {
+        "external_id": "T0823",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0823"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "b0628bfc-5376-4a38-9182-f324501cb4cf",
+      "value": "Graphical User Interface - T0823"
+    },
+    {
+      "description": "Adversaries may attempt to manipulate the information reported back to operators or controllers. This manipulation may be short term or sustained. During this time the process itself could be in a much different state than what is reported. (Citation: Corero) (Citation: Michael J. Assante and Robert M. Lee) (Citation: Tyson Macaulay) \n\nOperators may be fooled into doing something that is harmful to the system in a loss of view situation. With a manipulated view into the systems, operators may issue inappropriate control sequences that introduce faults or catastrophic failures into the system. Business analysis systems can also be provided with inaccurate data leading to bad management decisions.",
+      "meta": {
+        "external_id": "T0832",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0832",
+          "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false",
+          "https://icscsi.org/library/Documents/White_Papers/SANS%20-%20ICS%20Cyber%20Kill%20Chain.pdf",
+          "https://www.corero.com/resources/files/whitepapers/cns_whitepaper_ics.pdf"
+        ]
+      },
+      "uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+      "value": "Manipulation of View - T0832"
+    },
+    {
+      "description": "Adversaries may attempt to disrupt essential components or systems to prevent owner and operator from delivering products or services. (Citation: Corero) (Citation: Michael J. Assante and Robert M. Lee) (Citation: Tyson Macaulay) \n\nAdversaries may leverage malware to delete or encrypt critical data on HMIs, workstations, or databases.\n\nIn the 2021 Colonial Pipeline ransomware incident, pipeline operations were temporally halted on May 7th and were not fully restarted until May 12th. (Citation: Colonial Pipeline Company May 2021)",
+      "meta": {
+        "external_id": "T0826",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0826",
+          "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false",
+          "https://icscsi.org/library/Documents/White_Papers/SANS%20-%20ICS%20Cyber%20Kill%20Chain.pdf",
+          "https://www.colpipe.com/news/press-releases/media-statement-colonial-pipeline-system-disruption",
+          "https://www.corero.com/resources/files/whitepapers/cns_whitepaper_ics.pdf"
+        ]
+      },
+      "uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+      "value": "Loss of Availability - T0826"
+    },
+    {
+      "description": "Adversaries may perform supply chain compromise to gain control systems environment access by means of infected products, software, and workflows. Supply chain compromise is the manipulation of products, such as devices or software, or their delivery mechanisms before receipt by the end consumer. Adversary compromise of these products and mechanisms is done for the goal of data or system compromise, once infected products are introduced to the target environment. \n\nSupply chain compromise can occur at all stages of the supply chain, from manipulation of development tools and environments to manipulation of developed products and tools distribution mechanisms. This may involve the compromise and replacement of legitimate software and patches, such as on third party or vendor websites. Targeting of supply chain compromise can be done in attempts to infiltrate the environments of a specific audience. In control systems environments with assets in both the IT and OT networks, it is possible a supply chain compromise affecting the IT environment could enable further access to the OT environment.   \n\nCounterfeit devices may be introduced to the global supply chain posing safety and cyber risks to asset owners and operators. These devices may not meet the safety, engineering and manufacturing requirements of regulatory bodies but may feature tagging indicating conformance with industry standards. Due to the lack of adherence to standards and overall lesser quality, the counterfeit products may pose a serious safety and operational risk. (Citation: Control Global May 2019) \n\nYokogawa identified instances in which their customers received counterfeit differential pressure transmitters using the Yokogawa logo. The counterfeit transmitters were nearly indistinguishable with a semblance of functionality and interface that mimics the genuine product. (Citation: Control Global May 2019) \n\nF-Secure Labs analyzed the approach the adversary used to compromise victim systems with Havex. (Citation: Daavid Hentunen, Antti Tikkanen June 2014) The adversary planted trojanized software installers available on legitimate ICS/SCADA vendor websites. After being downloaded, this software infected the host computer with a Remote Access Trojan (RAT).",
+      "meta": {
+        "external_id": "T0862",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0862",
+          "https://www.controlglobal.com/industrynews/2019/yokogawa-announcement-warns-of-counterfeit-transmitters/",
+          "https://www.f-secure.com/weblog/archives/00002718.html"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+      "value": "Supply Chain Compromise - T0862"
+    },
+    {
+      "description": "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided. (Citation: Corero) (Citation: Michael J. Assante and Robert M. Lee) (Citation: Tyson Macaulay)\n\nThe German Federal Office for Information Security (BSI) reported a targeted attack on a steel mill in its 2014 IT Security Report.(Citation: BSI State of IT Security 2014) These targeted attacks affected industrial operations and resulted in breakdowns of control system components and even entire installations. As a result of these breakdowns, massive impact resulted in damage and unsafe conditions from the uncontrolled shutdown of a blast furnace.",
+      "meta": {
+        "external_id": "T0827",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0827",
+          "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false",
+          "https://icscsi.org/library/Documents/White_Papers/SANS%20-%20ICS%20Cyber%20Kill%20Chain.pdf",
+          "https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/Securitysituation/IT-Security-Situation-in-Germany-2014.pdf?__blob=publicationFile&v=3",
+          "https://www.corero.com/resources/files/whitepapers/cns_whitepaper_ics.pdf"
+        ]
+      },
+      "uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+      "value": "Loss of Control - T0827"
+    },
+    {
+      "description": "Adversaries may cause a sustained or permanent loss of view where the ICS equipment will require local, hands-on operator intervention; for instance, a restart or manual operation. By causing a sustained reporting or visibility loss, the adversary can effectively hide the present state of operations. This loss of view can occur without affecting the physical processes themselves. (Citation: Corero) (Citation: Michael J. Assante and Robert M. Lee) (Citation: Tyson Macaulay)",
+      "meta": {
+        "external_id": "T0829",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0829",
+          "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false",
+          "https://icscsi.org/library/Documents/White_Papers/SANS%20-%20ICS%20Cyber%20Kill%20Chain.pdf",
+          "https://www.corero.com/resources/files/whitepapers/cns_whitepaper_ics.pdf"
+        ]
+      },
+      "uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+      "value": "Loss of View - T0829"
+    },
+    {
+      "description": "Adversaries may place malicious code in a system, which can cause the system to malfunction by modifying its control logic. Control system devices use programming languages (e.g. relay ladder logic) to control physical processes by affecting actuators, which cause machines to operate, based on environment sensor readings. These devices often include the ability to perform remote control logic updates. \n\nProgram code is normally edited in a vendor-specific Integrated Development Environment (IDE) that relies on proprietary tools and features. These IDEs allow an engineer to perform host target development and may have the ability to run the code on the machine it is programmed for. The IDE will transmit the control logic to the testing device, and will perform the required device-specific functions to apply the changes and make them active.\n\nAn adversary may attempt to use this host target IDE to modify device control logic. Even though proprietary tools are often used to edit and update control logic, the process can usually be reverse-engineered and reproduced with open-source tools.\n\nAn adversary can de-calibrate a sensor by removing functions in control logic that account for sensor error. This can be used to change a control process without actually spoofing command messages to a controller or device. \n\nIt is believed this process happened in the lesser known over-pressurizer attacks build into Stuxnet. Pressure sensors are not perfect at translating pressure into an analog output signal, but their errors can be corrected by calibration. The pressure controller can be told what the “real” pressure is for given analog signals and then automatically linearize the measurement to what would be the “real” pressure. If the linearization is overwritten by malicious code on the S7-417 controller, analog pressure readings will be “corrected” during the attack by the pressure controller, which then interprets all analog pressure readings as perfectly normal pressure no matter how high or low their analog values are. The pressure controller then acts accordingly by never opening the stage exhaust valves. In the meantime, actual pressure keeps rising. (Citation: Stuxnet - Langner - 201311)\n\nIn the Maroochy Attack, Vitek Boden gained remote computer access to the control system and altered data so that whatever function should have occurred at affected pumping stations did not occur or occurred in a different way. The software program installed in the laptop was one developed by Hunter Watertech for its use in changing configurations in the PDS computers. This ultimately led to 800,000 liters of raw sewage being spilled out into the community. (Citation: Maroochy - MITRE - 200808)",
+      "meta": {
+        "external_id": "T0833",
+        "kill_chain": [
+          "ics-attack-Safety-Instrumented-System/Protection-Relay:impair-process-control",
+          "ics-attack-Field-Controller/RTU/PLC/IED:impair-process-control",
+          "ics-attack-Safety-Instrumented-System/Protection-Relay:inhibit-response-function",
+          "ics-attack-Field-Controller/RTU/PLC/IED:inhibit-response-function"
+        ],
+        "mitre_platforms": [
+          "Safety Instrumented System/Protection Relay",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0833",
+          "https://www.langner.com/wp-content/uploads/2017/03/to-kill-a-centrifuge.pdf",
+          "https://www.mitre.org/sites/default/files/pdf/08%201145.pdf"
+        ]
+      },
+      "uuid": "e0d74479-86d2-465d-bf36-903ebecef43e",
+      "value": "Modify Control Logic - T0833"
+    },
+    {
+      "description": "Adversaries may attempt to infect project files with malicious code. These project files may consist of objects, program organization units, variables such as tags, documentation, and other configurations needed for PLC programs to function.(Citation: Beckhoff) Using built in functions of the engineering software, adversaries may be able to download an infected program to a PLC in the operating environment enabling further [Execution](https://attack.mitre.org/tactics/TA0104) and [Persistence](https://attack.mitre.org/tactics/TA0110) techniques.(Citation: PLCdev) \n\nAdversaries may export their own code into project files with conditions to execute at specific intervals.(Citation: Nicolas Falliere, Liam O Murchu, Eric Chien February 2011) Malicious programs allow adversaries control of all aspects of the process enabled by the PLC. Once the project file is downloaded to a PLC the workstation device may be disconnected with the infected project file still executing.(Citation: PLCdev)",
+      "meta": {
+        "external_id": "T0873",
+        "kill_chain": [
+          "ics-attack:persistence"
+        ],
+        "refs": [
+          "http://www.plcdev.com/book/export/html/373",
+          "https://attack.mitre.org/techniques/T0873",
+          "https://docs.broadcom.com/doc/security-response-w32-stuxnet-dossier-11-en",
+          "https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_sourcecontrol/18014398915785483.html&id="
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+      "value": "Project File Infection - T0873"
+    },
+    {
+      "description": "Adversaries may compromise protective system functions designed to prevent the effects of faults and abnormal conditions. This can result in equipment damage, prolonged process disruptions and hazards to personnel. \n\nMany faults and abnormal conditions in process control happen too quickly for a human operator to react to. Speed is critical in correcting these conditions to limit serious impacts such as Loss of Control and Property Damage. \n\nAdversaries may target and disable protective system functions as a prerequisite to subsequent attack execution or to allow for future faults and abnormal conditions to go unchecked. Detection of a Loss of Protection by operators can result in the shutdown of a process due to strict policies regarding protection systems. This can cause a Loss of Productivity and Revenue and may meet the technical goals of adversaries seeking to cause process disruptions.",
+      "meta": {
+        "external_id": "T0837",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0837"
+        ]
+      },
+      "uuid": "2bb4d762-bf4a-4bc3-9318-15cc6a354163",
+      "value": "Loss of Protection - T0837"
+    },
+    {
+      "description": "Adversaries may gain access into industrial environments through systems exposed directly to the internet for remote access rather than through [External Remote Services](https://attack.mitre.org/techniques/T0822). Internet Accessible Devices are exposed to the internet unintentionally or intentionally without adequate protections. This may allow for adversaries to move directly into the control system network. Access onto these devices is accomplished without the use of exploits, these would be represented within the [Exploit Public-Facing Application](https://attack.mitre.org/techniques/T0819) technique.\n\nAdversaries may leverage built in functions for remote access which may not be protected or utilize minimal legacy protections that may be targeted. (Citation: NCCIC January 2014) These services may be discoverable through the use of online scanning tools. \n\nIn the case of the Bowman dam incident, adversaries leveraged access to the dam control network through a cellular modem. Access to the device was protected by password authentication, although the application was vulnerable to brute forcing. (Citation: NCCIC January 2014) (Citation: Danny Yadron December 2015) (Citation: Mark Thompson March 2016)\n\nIn Trend Micros manufacturing deception operations adversaries were detected leveraging direct internet access to an ICS environment through the exposure of operational protocols such as Siemens S7, Omron FINS, and EtherNet/IP, in addition to misconfigured VNC access. (Citation: Stephen Hilt, Federico Maggi, Charles Perine, Lord Remorin, Martin Rsler, and Rainer Vosseler)",
+      "meta": {
+        "external_id": "T0883",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0883",
+          "https://documents.trendmicro.com/assets/white_papers/wp-caught-in-the-act-running-a-realistic-factory-honeypot-to-capture-real-threats.pdf",
+          "https://time.com/4270728/iran-cyber-attack-dam-fbi/",
+          "https://www.us-cert.gov/sites/default/files/Monitors/ICS-CERT_Monitor_Jan-April2014.pdf",
+          "https://www.wsj.com/articles/iranian-hackers-infiltrated-new-york-dam-in-2013-1450662559"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "f8df6b57-14bc-425f-9a91-6f59f6799307",
+      "value": "Internet Accessible Device - T0883"
+    },
+    {
+      "description": "Adversaries may modify alarm settings to prevent alerts that may inform operators of their presence or to prevent responses to dangerous and unintended scenarios. Reporting messages are a standard part of data acquisition in control systems. Reporting messages are used as a way to transmit system state information and acknowledgements that specific actions have occurred. These messages provide vital information for the management of a physical process, and keep operators, engineers, and administrators aware of the state of system devices and physical processes. \n\nIf an adversary is able to change the reporting settings, certain events could be prevented from being reported. This type of modification can also prevent operators or devices from performing actions to keep the system in a safe state. If critical reporting messages cannot trigger these actions then a [Impact](https://attack.mitre.org/tactics/TA0105) could occur. \n\nIn ICS environments, the adversary may have to use [Alarm Suppression](https://attack.mitre.org/techniques/T0878) or contend with multiple alarms and/or alarm propagation to achieve a specific goal to evade detection or prevent intended responses from occurring. (Citation: Jos Wetzels, Marina Krotofil 2019)  Methods of suppression often rely on modification of alarm settings, such as modifying in memory code to fixed values or tampering with assembly level instruction code. ",
+      "meta": {
+        "external_id": "T0838",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0838",
+          "https://troopers.de/downloads/troopers19/TROOPERS19_NGI_IoT_diet_poisoned_fruit.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+      "value": "Modify Alarm Settings - T0838"
+    },
+    {
+      "description": "Program Organizational Units (POUs) are block structures used within PLC programming to create programs and projects. (Citation: Guidance - IEC61131) POUs can be used to hold user programs written in IEC 61131-3 languages: Structured text, Instruction list, Function block, and Ladder logic. (Citation: Guidance - IEC61131) Application - 201203 They can also provide additional functionality, such as establishing connections between the PLC and other devices using TCON. (Citation: PLCBlaster - Spenneberg)\n  \nStuxnet uses a simple code-prepending infection technique to infect Organization Blocks (OB). For example, the following sequence of actions is performed when OB1 is infected  (Citation: Stuxnet - Symantec - 201102):\n*Increase the size of the original block.\n*Write malicious code to the beginning of the block.\n*Insert the original OB1 code after the malicious code.",
+      "meta": {
+        "external_id": "T0844",
+        "kill_chain": [
+          "ics-attack-Windows:lateral-movement",
+          "ics-attack-Safety-Instrumented-System/Protection-Relay:lateral-movement",
+          "ics-attack-Field-Controller/RTU/PLC/IED:lateral-movement",
+          "ics-attack-Windows:execution",
+          "ics-attack-Safety-Instrumented-System/Protection-Relay:execution",
+          "ics-attack-Field-Controller/RTU/PLC/IED:execution"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Safety Instrumented System/Protection Relay",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "http://www.dee.ufrj.br/controle%20automatico/cursos/IEC61131-3%20Programming%20Industrial%20Automation%20Systems.pdf",
+          "https://attack.mitre.org/techniques/T0844",
+          "https://www.blackhat.com/docs/asia-16/materials/asia-16-Spenneberg-PLC-Blaster-A-Worm-Living-Solely-In-The-PLC-wp.pdf",
+          "https://www.symantec.com/content/en/us/enterprise/media/security%20response/whitepapers/w32%20stuxnet%20dossier.pdf"
+        ]
+      },
+      "uuid": "ae62fe1a-ea1a-479b-8dc0-65d250bd8bc7",
+      "value": "Program Organization Units - T0844"
+    },
+    {
+      "description": "Adversaries may perform serial connection enumeration to gather situational awareness after gaining access to devices in the OT network. Control systems devices often communicate to each other via various types of serial communication mediums. These serial communications are used to facilitate informational communication, as well as commands.  Serial Connection Enumeration differs from I/O Module Discovery, as I/O modules are auxiliary systems to the main system, and devices that are connected via serial connection are normally discrete systems.\n\nWhile IT and OT networks may work in tandem, the exact structure of the OT network may not be discernible from the IT network alone. After gaining access to a device on the OT network, an adversary may be able to enumerate the serial connections. From this perspective, the adversary can see the specific physical devices to which the compromised device is connected to. This gives the adversary greater situational awareness and can influence the actions that the adversary can take in an attack.",
+      "meta": {
+        "external_id": "T0854",
+        "kill_chain": [
+          "ics-attack-Windows:discovery",
+          "ics-attack-Input/Output-Server:discovery",
+          "ics-attack-Field-Controller/RTU/PLC/IED:discovery"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Input/Output Server",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0854"
+        ]
+      },
+      "uuid": "5f3da2f3-91c8-4d8b-a02f-bf43a11def55",
+      "value": "Serial Connection Enumeration - T0854"
+    },
+    {
+      "description": "Adversaries may target devices that are transient across ICS networks and external networks. Normally, transient assets are brought into an environment by authorized personnel and do not remain in that environment on a permanent basis. (Citation: North American Electric Reliability Corporation June 2021) Transient assets are commonly needed to support management functions and may be more common in systems where a remotely managed asset is not feasible, external connections for remote access do not exist, or 3rd party contractor/vendor access is required. \n\nAdversaries may take advantage of transient assets in different ways. For instance, adversaries may target a transient asset when it is connected to an external network and then leverage its trusted access in another environment to launch an attack. They may also take advantage of installed applications and libraries that are used by legitimate end-users to interact with control system devices. \n\nTransient assets, in some cases, may not be deployed with a secure configuration leading to weaknesses that could allow an adversary to propagate malicious executable code, e.g., the transient asset may be infected by malware and when connected to an ICS environment the malware propagates onto other systems. ",
+      "meta": {
+        "external_id": "T0864",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0864",
+          "https://www.nerc.com/pa/Stand/Glossary%20of%20Terms/Glossary_of_Terms.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+      "value": "Transient Cyber Asset - T0864"
+    },
+    {
+      "description": "Adversaries may attempt to get a listing of other systems by IP address, hostname, or other logical identifier on a network that may be used for subsequent Lateral Movement or Discovery techniques. Functionality could exist within adversary tools to enable this, but utilities available on the operating system or vendor software could also be used.(Citation: Enterprise ATT&CK January 2018)",
+      "meta": {
+        "external_id": "T0846",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0846",
+          "https://attack.mitre.org/wiki/Technique/T1018"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+      "value": "Remote System Discovery - T0846"
+    },
+    {
+      "description": "Adversaries may send unauthorized command messages to instruct control system assets to perform actions outside of their intended functionality, or without the logical preconditions to trigger their expected function. Command messages are used in ICS networks to give direct instructions to control systems devices. If an adversary can send an unauthorized command message to a control system, then it can instruct the control systems device to perform an action outside the normal bounds of the device's actions. An adversary could potentially instruct a control systems device to perform an action that will cause an [Impact](https://attack.mitre.org/tactics/TA0105). (Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)\n\nIn the Dallas Siren incident, adversaries were able to send command messages to activate tornado alarm systems across the city without an impending tornado or other disaster. (Citation: Zack Whittaker April 2017) (Citation: Benjamin Freed March 2019)",
+      "meta": {
+        "external_id": "T0855",
+        "kill_chain": [
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T0855",
+          "https://statescoop.com/tornado-sirens-in-dallas-suburbs-deactivated-after-being-hacked-and-set-off/",
+          "https://www.zdnet.com/article/experts-think-they-know-how-dallas-emergency-sirens-were-hacked/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "40b300ba-f553-48bf-862e-9471b220d455",
+      "value": "Unauthorized Command Message - T0855"
+    },
+    {
+      "description": "Adversaries may spoof reporting messages in control system environments for evasion and to impair process control. In control systems, reporting messages contain telemetry data (e.g., I/O values) pertaining to the current state of equipment and the industrial process. Reporting messages are important for monitoring the normal operation of a system or identifying important events such as deviations from expected values. \n\nIf an adversary has the ability to Spoof Reporting Messages, they can impact the control system in many ways. The adversary can Spoof Reporting Messages that state that the process is operating normally, as a form of evasion. The adversary could also Spoof Reporting Messages to make the defenders and operators think that other errors are occurring in order to distract them from the actual source of a problem. (Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011) ",
+      "meta": {
+        "external_id": "T0856",
+        "kill_chain": [
+          "ics-attack:evasion",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T0856"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "8535b71e-3c12-4258-a4ab-40257a1becc4",
+      "value": "Spoof Reporting Message - T0856"
+    },
+    {
+      "description": "Adversaries may attempt to change the state of the current program on a control device. Program state changes may be used to allow for another program to take over control or be loaded onto the device.",
+      "meta": {
+        "external_id": "T0875",
+        "kill_chain": [
+          "ics-attack-Field-Controller/RTU/PLC/IED:execution",
+          "ics-attack-Field-Controller/RTU/PLC/IED:impair-process-control"
+        ],
+        "mitre_platforms": [
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0875"
+        ]
+      },
+      "uuid": "a8cfd474-9358-464f-a169-9c6f099a8e8a",
+      "value": "Change Program State - T0875"
+    },
+    {
+      "description": "Adversaries may change the operating mode of a controller to gain additional access to engineering functions such as Program Download.   Programmable controllers typically have several modes of operation that control the state of the user program and control access to the controllers API. Operating modes can be physically selected using a key switch on the face of the controller but may also be selected with calls to the controllers API. Operating modes and the mechanisms by which they are selected often vary by vendor and product line. Some commonly implemented operating modes are described below:  \n\n* Program - This mode must be enabled before changes can be made to a devices program. This allows program uploads and downloads between the device and an engineering workstation. Often the PLCs logic Is halted, and all outputs may be forced off. (Citation: N.A. October 2017)  \n* Run - Execution of the devices program occurs in this mode. Input and output (values, points, tags, elements, etc.) are monitored and used according to the programs logic. [Program Upload](https://attack.mitre.org/techniques/T0845) and [Program Download](https://attack.mitre.org/techniques/T0843) are disabled while in this mode. (Citation: Omron) (Citation: Machine Information Systems 2007)  (Citation: N.A. October 2017) (Citation: PLCgurus 2021)   \n* Remote - Allows for remote changes to a PLCs operation mode. (Citation: PLCgurus 2021)    \n* Stop - The PLC and program is stopped, while in this mode, outputs are forced off. (Citation: Machine Information Systems 2007)   \n* Reset - Conditions on the PLC are reset to their original states. Warm resets may retain some memory while cold resets will reset all I/O and data registers. (Citation: Machine Information Systems 2007)   \n* Test / Monitor mode - Similar to run mode, I/O is processed, although this mode allows for monitoring, force set, resets, and more generally tuning or debugging of the system. Often monitor mode may be used as a trial for initialization. (Citation: Omron)",
+      "meta": {
+        "external_id": "T0858",
+        "kill_chain": [
+          "ics-attack:execution",
+          "ics-attack:evasion"
+        ],
+        "refs": [
+          "http://www.machine-information-systems.com/How_PLCs_Work.html",
+          "https://attack.mitre.org/techniques/T0858",
+          "https://forumautomation.com/t/what-are-the-different-operating-modes-in-plc/2489",
+          "https://www.omron-ap.com/service_support/FAQ/FAQ00002/index.asp#:~:text=In%20PROGRAM%20mode%2C%20the%20CPU,can%20be%20created%20or%20modified.",
+          "https://www.plcgurus.net/plc-basics/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+      "value": "Change Operating Mode - T0858"
+    },
+    {
+      "description": "Adversaries may communicate over a commonly used port to bypass firewalls or network detection systems and to blend in with normal network activity, to avoid more detailed inspection. They may use the protocol associated with the port, or a completely different protocol. They may use commonly open ports, such as the examples provided below. \n \n * TCP:80 (HTTP) \n * TCP:443 (HTTPS) \n * TCP/UDP:53 (DNS) \n * TCP:1024-4999 (OPC on XP/Win2k3) \n * TCP:49152-65535 (OPC on Vista and later) \n * TCP:23 (TELNET) \n * UDP:161 (SNMP) \n * TCP:502 (MODBUS) \n * TCP:102 (S7comm/ISO-TSAP) \n * TCP:20000 (DNP3) \n * TCP:44818 (Ethernet/IP)",
+      "meta": {
+        "external_id": "T0885",
+        "kill_chain": [
+          "ics-attack:command-and-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0885"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+      "value": "Commonly Used Port - T0885"
+    },
+    {
+      "description": "Adversaries may transfer tools or other files from one system to another to stage adversary tools or other files over the course of an operation. (Citation: Enterprise ATT&CK) Copying of files may also be performed laterally between internal victim systems to support Lateral Movement with remote Execution using inherent file sharing protocols such as file sharing over SMB to connected network shares. (Citation: Enterprise ATT&CK)\n\nIn control systems environments, malware may use SMB and other file sharing protocols to move laterally through industrial networks.",
+      "meta": {
+        "external_id": "T0867",
+        "kill_chain": [
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0867",
+          "https://attack.mitre.org/techniques/T1570/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
+      "value": "Lateral Tool Transfer - T0867"
+    },
+    {
+      "description": "Adversaries may gather information about a PLCs or controllers current operating mode. Operating modes dictate what change or maintenance functions can be manipulated and are often controlled by a key switch on the PLC (e.g.,  run, prog [program], and remote). Knowledge of these states may be valuable to an adversary to determine if they are able to reprogram the PLC. Operating modes and the mechanisms by which they are selected often vary by vendor and product line. Some commonly implemented operating modes are described below:  \n\n* Program - This mode must be enabled before changes can be made to a devices program. This allows program uploads and downloads between the device and an engineering workstation. Often the PLCs logic Is halted, and all outputs may be forced off. (Citation: N.A. October 2017)  \n* Run - Execution of the devices program occurs in this mode. Input and output (values, points, tags, elements, etc.) are monitored and used according to the programs logic.[Program Upload](https://attack.mitre.org/techniques/T0845) and [Program Download](https://attack.mitre.org/techniques/T0843) are disabled while in this mode. (Citation: Omron) (Citation: Machine Information Systems 2007)  (Citation: N.A. October 2017) (Citation: PLCgurus 2021)   \n* Remote - Allows for remote changes to a PLCs operation mode. (Citation: PLCgurus 2021)    \n* Stop - The PLC and program is stopped, while in this mode, outputs are forced off. (Citation: Machine Information Systems 2007)   \n* Reset - Conditions on the PLC are reset to their original states. Warm resets may retain some memory while cold resets will reset all I/O and data registers. (Citation: Machine Information Systems 2007)   \n* Test / Monitor mode - Similar to run mode, I/O is processed, although this mode allows for monitoring, force set, resets, and more generally tuning or debugging of the system. Often monitor mode may be used as a trial for initialization. (Citation: Omron)",
+      "meta": {
+        "external_id": "T0868",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "http://www.machine-information-systems.com/How_PLCs_Work.html",
+          "https://attack.mitre.org/techniques/T0868",
+          "https://forumautomation.com/t/what-are-the-different-operating-modes-in-plc/2489",
+          "https://www.omron-ap.com/service_support/FAQ/FAQ00002/index.asp#:~:text=In%20PROGRAM%20mode%2C%20the%20CPU,can%20be%20created%20or%20modified.",
+          "https://www.plcgurus.net/plc-basics/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+      "value": "Detect Operating Mode - T0868"
+    },
+    {
+      "description": "Adversaries may cause damage and destruction of property to infrastructure, equipment, and the surrounding environment when attacking control systems. This technique may result in device and operational equipment breakdown, or represent tangential damage from other techniques used in an attack. Depending on the severity of physical damage and disruption caused to control processes and systems, this technique may result in [Loss of Safety](https://attack.mitre.org/techniques/T0880). Operations that result in [Loss of Control](https://attack.mitre.org/techniques/T0827) may also cause damage to property, which may be directly or indirectly motivated by an adversary seeking to cause impact in the form of [Loss of Productivity and Revenue](https://attack.mitre.org/techniques/T0828). \n\n\nThe German Federal Office for Information Security (BSI) reported a targeted attack on a steel mill under an incidents affecting business section of its 2014 IT Security Report. (Citation: BSI State of IT Security 2014)  These targeted attacks affected industrial operations and resulted in breakdowns of control system components and even entire installations. As a result of these breakdowns, massive impact and damage resulted from the uncontrolled shutdown of a blast furnace. \n\nA Polish student used a remote controller device to interface with the Lodz city tram system in Poland. (Citation: John Bill May 2017) (Citation: Shelley Smith February 2008) (Citation: Bruce Schneier January 2008) Using this remote, the student was able to capture and replay legitimate tram signals. This resulted in damage to impacted trams, people, and the surrounding property. Reportedly, four trams were derailed and were forced to make emergency stops. (Citation: Shelley Smith February 2008) Commands issued by the student may have also resulted in tram collisions, causing harm to those on board and the environment outside. (Citation: Bruce Schneier January 2008)",
+      "meta": {
+        "external_id": "T0879",
+        "kill_chain": [
+          "ics-attack:impact"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0879",
+          "https://inhomelandsecurity.com/teen_hacker_in_poland_plays_tr/",
+          "https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/Securitysituation/IT-Security-Situation-in-Germany-2014.pdf?__blob=publicationFile&v=3",
+          "https://www.londonreconnections.com/2017/hacked-cyber-security-railways/",
+          "https://www.schneier.com/blog/archives/2008/01/hacking_the_pol.html"
+        ]
+      },
+      "uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+      "value": "Damage to Property - T0879"
     },
     {
       "description": "Adversaries may exploit vulnerabilities to evade detection by hiding activity, suppressing logging, or operating within trusted or unmonitored components. \n\nAdversaries may exploit a system or application vulnerability to avoid detection while maintaining access within an environment. Exploitation occurs when an adversary leverages a programming flaw to execute code in a manner that minimizes visibility or blends in with legitimate activity. \n\nRather than directly disabling defenses, adversaries may use exploitation to circumvent monitoring and logging mechanisms. This can include abusing vulnerabilities in logging pipelines, security tools, or cloud infrastructure to evade audit trails, suppress alerts, or operate without generating telemetry. \n\nAdversaries may identify these opportunities through prior reconnaissance or by performing discovery of security controls after initial access. In some cases, vulnerabilities in SaaS or public cloud environments may be exploited to evade logging, obscure activity, or deploy infrastructure that remains hidden from standard monitoring tools.(Citation: Bypassing CloudTrail in AWS Service Catalog)(Citation: GhostToken GCP flaw)",
@@ -19085,6 +21553,59 @@
       "value": "Obtain/re-use payloads - T1346"
     },
     {
+      "description": "Adversaries may utilize command-line interfaces (CLIs) to interact with systems and execute commands. CLIs provide a means of interacting with computer systems and are a common feature across many types of platforms and devices within control systems environments. (Citation: Enterprise ATT&CK January 2018) Adversaries may also use CLIs to install and run new software, including malicious tools that may be installed over the course of an operation.\n\nCLIs are typically accessed locally, but can also be exposed via services, such as SSH, Telnet, and RDP.  Commands that are executed in the CLI execute with the current permissions level of the process running the terminal emulator, unless the command specifies a change in permissions context. Many controllers have CLI interfaces for management purposes.",
+      "meta": {
+        "external_id": "T0807",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0807",
+          "https://attack.mitre.org/wiki/Technique/T1059"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+      "value": "Command-Line Interface - T0807"
+    },
+    {
       "description": "Adversaries may create multiple stages for command and control that are employed under different conditions or for certain functions. Use of multiple stages may obfuscate the command and control channel to make detection more difficult.\n\nRemote access tools will call back to the first-stage command and control server for instructions. The first stage may have automated capabilities to collect basic host information, update tools, and upload additional files. A second remote access tool (RAT) could be uploaded at that point to redirect the host to the second-stage command and control server. The second stage will likely be more fully featured and allow the adversary to interact with the system through a reverse shell and additional RAT features.\n\nThe different stages will likely be hosted separately with no overlapping infrastructure. The loader may also have backup first-stage callbacks or [Fallback Channels](https://attack.mitre.org/techniques/T1008) in case the original first-stage communication path is discovered and blocked.",
       "meta": {
         "external_id": "T1104",
@@ -19182,6 +21703,27 @@
       },
       "uuid": "948a447c-d783-4ba0-8516-a64140fcacd5",
       "value": "Non-Standard Port - T1509"
+    },
+    {
+      "description": "Adversaries may gain access to a system during a drive-by compromise, when a user visits a website as part of a regular browsing session. With this technique, the user's web browser is targeted and exploited simply by visiting the compromised website. \n\nThe adversary may target a specific community, such as trusted third party suppliers or other industry specific groups, which often visit the target website. This kind of targeted attack relies on a common interest, and is known as a strategic web compromise or watering hole attack. \n\nThe National Cyber Awareness System (NCAS) has issued a Technical Alert (TA) regarding Russian government cyber activity targeting critical infrastructure sectors. (Citation: Cybersecurity & Infrastructure Security Agency March 2018) Analysis by DHS and FBI has noted two distinct categories of victims in the Dragonfly campaign on the Western energy sector: staging and intended targets. The adversary targeted the less secure networks of staging targets, including trusted third-party suppliers and related peripheral organizations. Initial access to the intended targets used watering hole attacks to target process control, ICS, and critical infrastructure related trade publications and informational websites.",
+      "meta": {
+        "external_id": "T0817",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0817",
+          "https://us-cert.cisa.gov/ncas/alerts/TA18-074A"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+      "value": "Drive-by Compromise - T0817"
     },
     {
       "description": "Starting in Mac OS X 10.7 (Lion), users can specify certain applications to be re-opened when a user reboots their machine. While this is usually done via a Graphical User Interface (GUI) on an app-by-app basis, there are property list files (plist) that contain this information as well located at <code>~/Library/Preferences/com.apple.loginwindow.plist</code> and <code>~/Library/Preferences/ByHost/com.apple.loginwindow.* .plist</code>. \n\nAn adversary can modify one of these files directly to include a link to their malicious executable to provide a persistence mechanism each time the user reboots their machine (Citation: Methods of Mac Malware Persistence).",
@@ -21444,6 +23986,42 @@
       "value": "RC Scripts - T1037.004"
     },
     {
+      "description": "Adversaries may execute a full program download to a PLC to overwrite the entire PLC program and configuration to deploy a new project or make major changes. This typically requires stopping the PLC and adversely impacting control processes.\n\nThe ability to perform a full program download to the PLC typically relies on access to a workstation with the vendor-specific PLC programming software installed.\n",
+      "meta": {
+        "external_id": "T0843.001",
+        "kill_chain": [
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0843/001"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+      "value": "Download All - T0843.001"
+    },
+    {
       "description": "Adversaries may abuse the Windows Task Scheduler to perform task scheduling for initial or recurring execution of malicious code. There are multiple ways to access the Task Scheduler in Windows. The [schtasks](https://attack.mitre.org/software/S0111) utility can be run directly on the command line, or the Task Scheduler can be opened through the GUI within the Administrator Tools section of the Control Panel.(Citation: Stack Overflow) In some cases, adversaries have used a .NET wrapper for the Windows Task Scheduler, and alternatively, adversaries have used the Windows netapi32 library and [Windows Management Instrumentation](https://attack.mitre.org/techniques/T1047) (WMI) to create a scheduled task. Adversaries may also utilize the Powershell Cmdlet `Invoke-CimMethod`, which leverages WMI class `PS_ScheduledTask` to create a scheduled task via an XML path.(Citation: Red Canary - Atomic Red Team)\n\nAn adversary may use Windows Task Scheduler to execute programs at system startup or on a scheduled basis for persistence. The Windows Task Scheduler can also be abused to conduct remote Execution as part of Lateral Movement and/or to run a process under the context of a specified account (such as SYSTEM). Similar to [System Binary Proxy Execution](https://attack.mitre.org/techniques/T1218), adversaries have also abused the Windows Task Scheduler to potentially mask one-time execution under signed/trusted system processes.(Citation: ProofPoint Serpent)\n\nAdversaries may also create \"hidden\" scheduled tasks (i.e. [Hide Artifacts](https://attack.mitre.org/techniques/T1564)) that may not be visible to defender tools and manual queries used to enumerate tasks. Specifically, an adversary may hide a task from `schtasks /query` and the Task Scheduler by deleting the associated Security Descriptor (SD) registry value (where deletion of this value must be completed using SYSTEM permissions).(Citation: SigmaHQ)(Citation: Tarrask scheduled task) Adversaries may also employ alternate methods to hide tasks, such as altering the metadata (e.g., `Index` value) within associated registry keys.(Citation: Defending Against Scheduled Task Attacks in Windows Environments) ",
       "meta": {
         "external_id": "T1053.005",
@@ -21829,6 +24407,95 @@
       "value": "Unix Shell - T1059.004"
     },
     {
+      "description": "Adversaries may perform a port scan on a system, device, or network to identify live hosts, enumerate open ports and running services, identify operating systems, and map out the network.(Citation: NIST SP 800-82r3) The results of a port scan may inform adversary [Discovery](https://attack.mitre.org/tactics/TA0102), [Lateral Movement](https://attack.mitre.org/tactics/TA0109), and vulnerability exploitation decisions ([Exploitation for Evasion](https://attack.mitre.org/techniques/T0820), [Exploitation for Privilege Escalation](https://attack.mitre.org/techniques/T0890), [Exploitation of Remote Services](https://attack.mitre.org/techniques/T0866)). \n\nSome common tools for executing a port scan include `nmap`, `netcat`, and the Advanced Port Scanner.\n",
+      "meta": {
+        "external_id": "T0846.001",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0846/001",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r3.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+      "value": "Port Scan - T0846.001"
+    },
+    {
       "description": "Valid accounts in cloud environments may allow adversaries to perform actions to achieve Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Cloud accounts are those created and configured by an organization for use by users, remote support, services, or for administration of resources within a cloud service provider or SaaS application. Cloud Accounts can exist solely in the cloud; alternatively, they may be hybrid-joined between on-premises systems and the cloud through syncing or federation with other identity sources such as Windows Active Directory.(Citation: AWS Identity Federation)(Citation: Google Federating GC)(Citation: Microsoft Deploying AD Federation)\n\nService or user accounts may be targeted by adversaries through [Brute Force](https://attack.mitre.org/techniques/T1110), [Phishing](https://attack.mitre.org/techniques/T1566), or various other means to gain access to the environment. Federated or synced accounts may be a pathway for the adversary to affect both on-premises systems and cloud environments - for example, by leveraging shared credentials to log onto [Remote Services](https://attack.mitre.org/techniques/T1021). High privileged cloud accounts, whether federated, synced, or cloud-only, may also allow pivoting to on-premises environments by leveraging SaaS-based [Software Deployment Tools](https://attack.mitre.org/techniques/T1072) to run commands on hybrid-joined devices.\n\nAn adversary may create long lasting [Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001) on a compromised cloud account to maintain persistence in the environment. Such credentials may also be used to bypass security controls such as multi-factor authentication. \n\nCloud accounts may also be able to assume [Temporary Elevated Cloud Access](https://attack.mitre.org/techniques/T1548/005) or other privileges through various means within the environment. Misconfigurations in role assignments or role assumption policies may allow an adversary to use these mechanisms to leverage permissions outside the intended scope of the account. Such over privileged accounts may be used to harvest sensitive data from online storage accounts and databases through [Cloud API](https://attack.mitre.org/techniques/T1059/009) or other methods. For example, in Azure environments, adversaries may target Azure Managed Identities, which allow associated Azure resources to request access tokens. By compromising a resource with an attached Managed Identity, such as an Azure VM, adversaries may be able to [Steal Application Access Token](https://attack.mitre.org/techniques/T1528)s to move laterally across the cloud environment.(Citation: SpecterOps Managed Identity 2022)",
       "meta": {
         "external_id": "T1078.004",
@@ -22159,6 +24826,257 @@
       "value": "SEO Poisoning - T1608.006"
     },
     {
+      "description": "Adversaries may execute an online edit of a PLC to update parts of an existing program. It does not require stopping the PLC which allows it to continue running during transfer and reconfiguration without interruption to process control. Adversaries may leverage this approach to minimize downtime and evade detection. \n\nThe ability to perform an online edit to the PLC typically relies on access to a workstation with the vendor-specific PLC programming software installed.\n",
+      "meta": {
+        "external_id": "T0843.002",
+        "kill_chain": [
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0843/002"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+      "value": "Online Edit - T0843.002"
+    },
+    {
+      "description": "Adversaries may perform broadcast discovery requests to enumerate systems and devices on a network. Broadcast discovery works by one system or device sending messages to all systems and devices on a network (or subnet) and then waiting for a response. If a response is received that means the system or device that responded is live and can communicate over that protocol. Adversaries may leverage different protocols supported on the network for sending broadcast messages. \n\nSome common OT protocols that have broadcast discovery mechanisms are Building Automation and Control Network (BACNet) Who-Is requests, Common Industrial Protocol (CIP) List Identity User Datagram Protocol (UDP) broadcast requests, and Siemens S7 broadcast identification requests.(Citation: Broadcasting BACnet)(Citation: Cisco Active Discovery)\n",
+      "meta": {
+        "external_id": "T0846.002",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0846/002",
+          "https://bacnet.org/wp-content/uploads/sites/4/2022/06/Newman_2010.pdf",
+          "https://www.cisco.com/c/en/us/td/docs/security/cyber_vision/publications/Active-Discovery/Release-4-3-0/b_Cisco_Cyber_Vision_Active_Discovery_Configuration_Guide.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "c55f0be5-044e-4577-8095-65b37680d28c",
+      "value": "Broadcast Discovery - T0846.002"
+    },
+    {
+      "description": "Adversaries may execute a program append to a PLC to update parts of an existing program. It may or may not require stopping the PLC which may allow it to continue running during transfer and reconfiguration without interruption to process control. Adversaries may leverage this approach to minimize downtime and evade detection. \n\nThe ability to perform a program append to the PLC typically relies on access to a workstation with the vendor-specific PLC programming software installed.\n",
+      "meta": {
+        "external_id": "T0843.003",
+        "kill_chain": [
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0843/003"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+      "value": "Program Append - T0843.003"
+    },
+    {
+      "description": "Adversaries may perform multicast discovery requests which is when one system or device sends messages to all systems and devices in a pre-defined group on a network (or subnet) and then waits for a response. If a response is received that means the system or device that responded is live and can communicate over that protocol.  Multicast discovery tends to be stealthier than broadcast discovery because every system or device on the network (or subnet) is not being messaged. \n\nOne common OT protocol that has a multicast discovery mechanism is the Process Field Network (PROFINET) Discovery and Configuration Protocol (DCP) with its Identify All requests.(Citation: Cisco Active Discovery)\n",
+      "meta": {
+        "external_id": "T0846.003",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0846/003",
+          "https://www.cisco.com/c/en/us/td/docs/security/cyber_vision/publications/Active-Discovery/Release-4-3-0/b_Cisco_Cyber_Vision_Active_Discovery_Configuration_Guide.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "64bbc1b2-101f-4322-af1d-0c9cc25cef91",
+      "value": "Multicast Discovery - T0846.003"
+    },
+    {
       "description": "Adversaries may encode data with a standard data encoding system to make the content of command and control traffic more difficult to detect. Command and control (C2) information can be encoded using a standard data encoding system that adheres to existing protocol specifications. Common data encoding schemes include ASCII, Unicode, hexadecimal, Base64, and MIME.(Citation: Wikipedia Binary-to-text Encoding)(Citation: Wikipedia Character Encoding) Some data encoding systems may also result in data compression, such as gzip.",
       "meta": {
         "external_id": "T1132.001",
@@ -22417,6 +25335,64 @@
       ],
       "uuid": "278716b1-61ce-4a74-8d17-891d0c494101",
       "value": "Browser Extensions - T1176.001"
+    },
+    {
+      "description": "Adversaries may block a command message from reaching its intended target to prevent command execution. In OT networks, command messages are sent to provide instructions to control system devices. A blocked command message can inhibit response functions from correcting a disruption or unsafe condition.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)(Citation: Electricity Information Sharing and Analysis Center; SANS Industrial Control Systems March 2016)",
+      "meta": {
+        "external_id": "T1691.001",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://assets.contentstack.io/v3/assets/blt36c2e63521272fdc/blt6a77276749b76a40/607f235992f0063e5c070fff/E-ISAC_SANS_Ukraine_DUC_5%5b73%5d.pdf",
+          "https://attack.mitre.org/techniques/T1691/001"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "338f4364-2269-4f70-9079-b20384b16628",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+      "value": "Command Message - T1691.001"
     },
     {
       "description": "Adversaries may modify file or directory permissions/attributes to evade access control lists (ACLs) and access protected files.(Citation: Hybrid Analysis Icacls1 June 2018)(Citation: Hybrid Analysis Icacls2 May 2018) File and directory permissions are commonly managed by ACLs configured by the file or directory owner, or users with the appropriate permissions. File and directory ACL implementations vary by platform, but generally explicitly designate which users or groups can perform which actions (read, write, execute, etc.).\n\nWindows implements file and directory ACLs as Discretionary Access Control Lists (DACLs).(Citation: Microsoft DACL May 2018) Similar to a standard ACL, DACLs identifies the accounts that are allowed or denied access to a securable object. When an attempt is made to access a securable object, the system checks the access control entries in the DACL in order. If a matching entry is found, access to the object is granted. Otherwise, access is denied.(Citation: Microsoft Access Control Lists May 2018)\n\nAdversaries can interact with the DACLs using built-in Windows commands, such as `icacls`, `cacls`, `takeown`, and `attrib`, which can grant adversaries higher permissions on specific files and folders. Further, [PowerShell](https://attack.mitre.org/techniques/T1059/001) provides cmdlets that can be used to retrieve or modify file and directory DACLs. Specific file and directory modifications may be a required step for many techniques, such as establishing Persistence via [Accessibility Features](https://attack.mitre.org/techniques/T1546/008), [Boot or Logon Initialization Scripts](https://attack.mitre.org/techniques/T1037), or tainting/hijacking other instrumental binary/configuration files via [Hijack Execution Flow](https://attack.mitre.org/techniques/T1574).",
@@ -23045,6 +26021,124 @@
       "value": "IDE Extensions - T1176.002"
     },
     {
+      "description": "Adversaries may send unauthorized command messages to instruct control system assets to perform actions outside of their intended functionality, or without the logical preconditions to trigger their expected function. Command messages are used in ICS networks to give direct instructions to control systems devices. If an adversary can send an unauthorized command message to a control system, then it can instruct the control systems device to perform an action outside the normal bounds of the device's actions. An adversary could potentially instruct a control systems device to perform an action that will cause an [Impact](https://attack.mitre.org/tactics/TA0105).(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)\n\nIn the Dallas Siren incident, adversaries were able to send command messages to activate tornado alarm systems across the city without an impending tornado or other disaster.(Citation: Zack Whittaker April 2017)(Citation: Benjamin Freed March 2019)",
+      "meta": {
+        "external_id": "T1692.001",
+        "kill_chain": [
+          "ics-attack:evasion",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T1692/001",
+          "https://statescoop.com/tornado-sirens-in-dallas-suburbs-deactivated-after-being-hacked-and-set-off/",
+          "https://www.zdnet.com/article/experts-think-they-know-how-dallas-emergency-sirens-were-hacked/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+      "value": "Command Message - T1692.001"
+    },
+    {
+      "description": "Adversaries may block or prevent a reporting message from reaching its intended target. In control systems, reporting messages contain telemetry data (e.g., I/O values) pertaining to the current state of equipment and the industrial process. By blocking these reporting messages, an adversary can potentially hide their actions from an operator.\n\nBlocking reporting messages in control systems that manage physical processes may contribute to system impact, causing inhibition of a response function. A control system may not be able to respond in a proper or timely manner to an event, such as a dangerous fault, if its corresponding reporting message is blocked.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)(Citation: Electricity Information Sharing and Analysis Center; SANS Industrial Control Systems March 2016)",
+      "meta": {
+        "external_id": "T1691.002",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://assets.contentstack.io/v3/assets/blt36c2e63521272fdc/blt6a77276749b76a40/607f235992f0063e5c070fff/E-ISAC_SANS_Ukraine_DUC_5%5b73%5d.pdf",
+          "https://attack.mitre.org/techniques/T1691/002"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "338f4364-2269-4f70-9079-b20384b16628",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+      "value": "Reporting Message - T1691.002"
+    },
+    {
       "description": "Adversaries may smuggle data and files past content filters by hiding malicious payloads inside of seemingly benign SVG files.(Citation: Trustwave SVG Smuggling 2025) SVGs, or Scalable Vector Graphics, are vector-based image files constructed using XML. As such, they can legitimately include `<script>` tags that enable adversaries to include malicious JavaScript payloads. However, SVGs may appear less suspicious to users than other types of executable files, as they are often treated as image files. \n\nSVG smuggling can take a number of forms. For example, threat actors may include content that: \n\n* Assembles malicious payloads(Citation: Talos SVG Smuggling 2022)\n* Downloads malicious payloads(Citation: Cofense SVG Smuggling 2024)\n* Redirects users to malicious websites(Citation: Bleeping Computer SVG Smuggling 2024)\n* Displays interactive content to users, such as fake login forms and download buttons.(Citation: Bleeping Computer SVG Smuggling 2024)\n\nSVG Smuggling may be used in conjunction with [HTML Smuggling](https://attack.mitre.org/techniques/T1027/006) where an SVG with a malicious payload is included inside an HTML file.(Citation: Talos SVG Smuggling 2022) SVGs may also be included in other types of documents, such as PDFs.  ",
       "meta": {
         "external_id": "T1027.017",
@@ -23553,6 +26647,69 @@
       "value": "Written Content - T1683.001"
     },
     {
+      "description": "System firmware on modern assets is often designed with an update feature. Older device firmware may be factory installed and require special reprograming equipment. When available, the firmware update feature enables vendors to remotely patch bugs and perform upgrades. Device firmware updates are often delegated to the user and may be done using a software update package. It may also be possible to perform this task over the network.\n\nAn adversary may exploit the firmware update feature on accessible devices to upload malicious or out-of-date firmware. Malicious modification of device firmware may provide an adversary with root access to a device, given firmware is one of the lowest programming abstraction layers.(Citation: Basnight, Zachry, et al.)",
+      "meta": {
+        "external_id": "T1693.001",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:inhibit-response-function",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://www.sciencedirect.com/science/article/pii/S1874548213000231",
+          "https://attack.mitre.org/techniques/T1693/001"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        }
+      ],
+      "uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+      "value": "System Firmware - T1693.001"
+    },
+    {
       "description": "Adversaries may inject malicious code into processes via VDSO hijacking in order to evade process-based defenses as well as possibly elevate privileges. Virtual dynamic shared object (vdso) hijacking is a method of executing arbitrary code in the address space of a separate live process. \n\nVDSO hijacking involves redirecting calls to dynamically linked shared libraries. Memory protections may prevent writing executable code to a process via [Ptrace System Calls](https://attack.mitre.org/techniques/T1055/008). However, an adversary may hijack the syscall interface code stubs mapped into a process from the vdso shared object to execute syscalls to open and map a malicious shared object. This code can then be invoked by redirecting the execution flow of the process via patched memory address references stored in a process' global offset table (which store absolute addresses of mapped library functions).(Citation: ELF Injection May 2009)(Citation: Backtrace VDSO)(Citation: VDSO Aug 2005)(Citation: Syscall 2014)\n\nRunning code in the context of another process may allow access to the process's memory, system/network resources, and possibly elevated privileges. Execution via VDSO hijacking may also evade detection from security products since the execution is masked under a legitimate process.  ",
       "meta": {
         "external_id": "T1055.014",
@@ -23675,6 +26832,100 @@
       ],
       "uuid": "cc723aff-ec88-40e3-a224-5af9fd983cc4",
       "value": "Identify Roles - T1591.004"
+    },
+    {
+      "description": "Adversaries may leverage manufacturer or supplier set default credentials on control system devices. These default credentials may have administrative permissions and may be necessary for initial configuration of the device. It is general best practice to change the passwords for these accounts as soon as possible, but some manufacturers may have devices that have passwords or usernames that cannot be changed.(Citation: Keith Stouffer May 2015)\n\nDefault credentials are normally documented in an instruction manual that is either packaged with the device, published online through official means, or published online through unofficial means. Adversaries may leverage default credentials that have not been properly modified or disabled.",
+      "meta": {
+        "external_id": "T1694.001",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T1694/001",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3e9b182e-e493-49e1-9a9b-bd0dfcd34a7c",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+      "value": "Default Credentials - T1694.001"
     },
     {
       "description": "Adversaries may leverage the compute resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. \n\nOne common purpose for [Compute Hijacking](https://attack.mitre.org/techniques/T1496/001) is to validate transactions of cryptocurrency networks and earn virtual currency. Adversaries may consume enough system resources to negatively impact and/or cause affected machines to become unresponsive.(Citation: Kaspersky Lazarus Under The Hood Blog 2017) Servers and cloud-based systems are common targets because of the high potential for available resources, but user endpoint systems may also be compromised and used for [Compute Hijacking](https://attack.mitre.org/techniques/T1496/001) and cryptocurrency mining.(Citation: CloudSploit - Unused AWS Regions) Containerized environments may also be targeted due to the ease of deployment via exposed APIs and the potential for scaling mining activities by deploying or compromising multiple containers within an environment or cluster.(Citation: Unit 42 Hildegard Malware)(Citation: Trend Micro Exposed Docker APIs)\n\nAdditionally, some cryptocurrency mining malware identify then kill off processes for competing malware to ensure it’s not competing for resources.(Citation: Trend Micro War of Crypto Miners)",
@@ -23828,6 +27079,78 @@
       ],
       "uuid": "2e34237d-8574-43f6-aace-ae2915de8597",
       "value": "Spearphishing Attachment - T1566.001"
+    },
+    {
+      "description": "Adversaries may block access to serial COM to prevent instructions or configurations from reaching target devices. Serial Communication ports (COM) allow communication with control system devices. Devices can receive command and configuration messages over such serial COM. Devices also use serial COM to send command and reporting messages. Blocking device serial COM may also block command messages and block reporting messages.\n\nA serial to Ethernet converter is often connected to a serial COM to facilitate communication between serial and Ethernet devices. One approach to blocking a serial COM would be to create and hold open a TCP session with the Ethernet side of the converter. A serial to Ethernet converter may have a few ports open to facilitate multiple communications. For example, if there are three serial COM available -- 1, 2 and 3 --, the converter might be listening on the corresponding ports 20001, 20002, and 20003. If a TCP/IP connection is opened with one of these ports and held open, then the port will be unavailable for use by another party. One way the adversary could achieve this would be to initiate a TCP session with the serial to Ethernet converter at 10.0.0.1 via Telnet on serial port 1 with the following command: telnet 10.0.0.1 20001.",
+      "meta": {
+        "external_id": "T1695.001",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T1695/001"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+      "value": "Serial COM - T1695.001"
     },
     {
       "description": "An adversary may create a snapshot or data backup within a cloud account to evade defenses. A snapshot is a point-in-time copy of an existing cloud compute component such as a virtual machine (VM), virtual hard drive, or volume. An adversary may leverage permissions to create a snapshot in order to bypass restrictions that prevent access to existing compute service infrastructure, unlike in [Revert Cloud Instance](https://attack.mitre.org/techniques/T1578/004) where an adversary may revert to a snapshot to evade detection and remove evidence of their presence.\n\nAn adversary may [Create Cloud Instance](https://attack.mitre.org/techniques/T1578/002), mount one or more created snapshots to that instance, and then apply a policy that allows the adversary access to the created instance, such as a firewall policy that allows them inbound and outbound SSH access.(Citation: Mandiant M-Trends 2020)",
@@ -23996,6 +27319,64 @@
       ],
       "uuid": "acf8fd2a-dc98-43b4-8d37-64e10728e591",
       "value": "Device Lockout - T1629.002"
+    },
+    {
+      "description": "Adversaries may spoof reporting messages in control system environments for evasion and to impair process control. In control systems, reporting messages contain telemetry data (e.g., I/O values) pertaining to the current state of equipment and the industrial process. Reporting messages are important for monitoring the normal operation of a system or identifying important events such as deviations from expected values.\n\nIf an adversary has the ability to Spoof Reporting Messages, they can impact the control system in many ways. The adversary can Spoof Reporting Messages that state that the process is operating normally, as a form of evasion. The adversary could also Spoof Reporting Messages to make the defenders and operators think that other errors are occurring in order to distract them from the actual source of a problem.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)",
+      "meta": {
+        "external_id": "T1692.002",
+        "kill_chain": [
+          "ics-attack:evasion",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T1692/002"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+      "value": "Reporting Message - T1692.002"
     },
     {
       "description": "Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. Systemd is a system and service manager commonly used for managing background daemon processes (also known as services) and other system resources.(Citation: Linux man-pages: systemd January 2014) Systemd is the default initialization (init) system on many Linux distributions replacing legacy init systems, including SysVinit and Upstart, while remaining backwards compatible.  \n\nSystemd utilizes unit configuration files with the `.service` file extension to encode information about a service's process. By default, system level unit files are stored in the `/systemd/system` directory of the root owned directories (`/`). User level unit files are stored in the `/systemd/user` directories of the user owned directories (`$HOME`).(Citation: lambert systemd 2022) \n\nInside the `.service` unit files, the following directives are used to execute commands:(Citation: freedesktop systemd.service)  \n\n* `ExecStart`, `ExecStartPre`, and `ExecStartPost` directives execute when a service is started manually by `systemctl` or on system start if the service is set to automatically start.\n* `ExecReload` directive executes when a service restarts. \n* `ExecStop`, `ExecStopPre`, and `ExecStopPost` directives execute when a service is stopped.  \n\nAdversaries have created new service files, altered the commands a `.service` file’s directive executes, and modified the user directive a `.service` file executes as, which could result in privilege escalation. Adversaries may also place symbolic links in these directories, enabling systemd to find these payloads regardless of where they reside on the filesystem.(Citation: Anomali Rocke March 2019)(Citation: airwalk backdoor unix systems)(Citation: Rapid7 Service Persistence 22JUNE2016) \n\nThe `.service` file’s User directive can be used to run service as a specific user, which could result in privilege escalation based on specific user/group permissions. \n\nSystemd services can be created via systemd generators, which support the dynamic generation of unit files. Systemd generators are small executables that run during boot or configuration reloads to dynamically create or modify systemd unit files by converting non-native configurations into services, symlinks, or drop-ins (i.e., [Boot or Logon Initialization Scripts](https://attack.mitre.org/techniques/T1037)).(Citation: Elastic Security Labs Linux Persistence 2024)(Citation: Pepe Berba Systemd 2022)",
@@ -24249,6 +27630,45 @@
       ],
       "uuid": "1d1b1558-c833-482e-aabb-d07ef6eae63d",
       "value": "Call Log - T1636.002"
+    },
+    {
+      "description": "Adversaries may install malicious or vulnerable firmware onto modular hardware devices. Control system devices often contain modular hardware devices. These devices may have their own set of firmware that is separate from the firmware of the main control system equipment.\n\nThis technique is similar to System Firmware, but is conducted on other system components that may not have the same capabilities or level of integrity checking. Although it results in a device re-image, malicious device firmware may provide persistent access to remaining devices.(Citation: Daniel Peck,  Dale Peterson January 2009)\n\nAn easy point of access for an adversary is the Ethernet card, which may have its own CPU, RAM, and operating system. The adversary may attack and likely exploit the computer on an Ethernet card. Exploitation of the Ethernet card computer may enable the adversary to accomplish additional attacks, such as the following:(Citation: Daniel Peck,  Dale Peterson January 2009)\n\n* Delayed Attack - The adversary may stage an attack in advance and choose when to launch it, such as at a particularly damaging time.\n* Brick the Ethernet Card - Malicious firmware may be programmed to result in an Ethernet card failure, requiring a factory return.\n* Random Attack or Failure - The adversary may load malicious firmware onto multiple field devices. Execution of an attack and the time it occurs is generated by a pseudo-random number generator.\n* A Field Device Worm - The adversary may choose to identify all field devices of the same model, with the end goal of performing a device-wide compromise.\n* Attack Other Cards on the Field Device - Although it is not the most important module in a field device, the Ethernet card is most accessible to the adversary and malware. Compromise of the Ethernet card may provide a more direct route to compromising other modules, such as the CPU module.",
+      "meta": {
+        "external_id": "T1693.002",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:inhibit-response-function",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T1693/002",
+          "https://www.researchgate.net/publication/228849043_Leveraging_ethernet_card_vulnerabilities_in_field_devices"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "subtechnique-of"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+      "value": "Module Firmware - T1693.002"
     },
     {
       "description": "Adversaries may add new domain trusts, modify the properties of existing domain trusts, or otherwise change the configuration of trust relationships between domains and tenants to evade defenses and/or elevate privileges.Trust details, such as whether or not user identities are federated, allow authentication and authorization properties to apply between domains or tenants for the purpose of accessing shared resources.(Citation: Microsoft - Azure AD Federation) These trust objects may include accounts, credentials, and other authentication material applied to servers, tokens, and domains.\n\nManipulating these trusts may allow an adversary to escalate privileges and/or evade defenses by modifying settings to add objects which they control. For example, in Microsoft Active Directory (AD) environments, this may be used to forge [SAML Tokens](https://attack.mitre.org/techniques/T1606/002) without the need to compromise the signing certificate to forge new credentials. Instead, an adversary can manipulate domain trusts to add their own signing certificate. An adversary may also convert an AD domain to a federated domain using Active Directory Federation Services (AD FS), which may enable malicious trust modifications such as altering the claim issuance rules to log in any valid set of credentials as a specified user.(Citation: AADInternals zure AD Federated Domain) \n\nAn adversary may also add a new federated identity provider to an identity tenant such as Okta or AWS IAM Identity Center, which may enable the adversary to authenticate as any user of the tenant.(Citation: Okta Cross-Tenant Impersonation 2023) This may enable the threat actor to gain broad access into a variety of cloud-based services that leverage the identity tenant. For example, in AWS environments, an adversary that creates a new identity provider for an AWS Organization will be able to federate into all of the AWS Organization member accounts without creating identities for each of the member accounts.(Citation: AWS re Inforce Trust Mod)",
@@ -24565,6 +27985,33 @@
       ],
       "uuid": "718cb208-6446-4572-a2f0-9c799c60091e",
       "value": "Bandwidth Hijacking - T1496.002"
+    },
+    {
+      "description": "Adversaries may leverage credentials that are hardcoded in software or firmware to gain an unauthorized interactive user session to an asset. Examples credentials that may be hardcoded in an asset include:\n\n* Username/Passwords\n* Cryptographic keys/Certificates\n* API tokens\n\nUnlike [Default Credentials](https://attack.mitre.org/techniques/T0812), these credentials are built into the system in a way that they either cannot be changed by the asset owner, or may be infeasible to change because of the impact it would cause to the control system operation. These credentials may be reused across whole product lines or device models and are often not published or known to the owner and operators of the asset.(Citation: ICS-ALERT-13-164-01)(Citation: OT IceFall)\n\nAdversaries may utilize these hardcoded credentials to move throughout the control system environment or provide reliable access for their tools to interact with industrial assets.",
+      "meta": {
+        "external_id": "T1694.002",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T1694/002",
+          "https://www.cisa.gov/news-events/ics-alerts/ics-alert-13-164-01",
+          "https://www.forescout.com/resources/ot-icefall-report/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3e9b182e-e493-49e1-9a9b-bd0dfcd34a7c",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "6b335943-c3af-430e-a135-ab09623bdc20",
+      "value": "Hardcoded Credentials - T1694.002"
     },
     {
       "description": "Adversaries may attempt to cause a denial of service (DoS) by reflecting a high-volume of network traffic to a target. This type of Network DoS takes advantage of a third-party server intermediary that hosts and will respond to a given spoofed source IP address. This third-party server is commonly termed a reflector. An adversary accomplishes a reflection attack by sending packets to reflectors with the spoofed address of the victim. Similar to Direct Network Floods, more than one system may be used to conduct the attack, or a botnet may be used. Likewise, one or more reflectors may be used to focus traffic on the target.(Citation: Cloudflare ReflectionDoS May 2017) This Network DoS attack may also reduce the availability and functionality of the targeted system(s) and network.\n\nReflection attacks often take advantage of protocols with larger responses than requests in order to amplify their traffic, commonly known as a Reflection Amplification attack. Adversaries may be able to generate an increase in volume of attack traffic that is several orders of magnitude greater than the requests sent to the amplifiers. The extent of this increase will depending upon many variables, such as the protocol in question, the technique used, and the amplifying servers that actually produce the amplification in attack volume. Two prominent protocols that have enabled Reflection Amplification Floods are DNS(Citation: Cloudflare DNSamplficationDoS) and NTP(Citation: Cloudflare NTPamplifciationDoS), though the use of several others in the wild have been documented.(Citation: Arbor AnnualDoSreport Jan 2018)  In particular, the memcache protocol showed itself to be a powerful protocol, with amplification sizes up to 51,200 times the requesting packet.(Citation: Cloudflare Memcrashed Feb 2018)",
@@ -26807,6 +30254,128 @@
       "value": "Scheduled Task/Job - T1603"
     },
     {
+      "description": "Adversaries may forcibly restart or shutdown a device in an ICS environment to disrupt and potentially negatively impact physical processes. Methods of device restart and shutdown exist in some devices as built-in, standard functionalities. These functionalities can be executed using interactive device web interfaces, CLIs, and network protocol commands.\n\nUnexpected restart or shutdown of control system devices may prevent expected response functions happening during critical states.\n\nA device restart can also be a sign of malicious device modifications, as many updates require a shutdown in order to take effect.",
+      "meta": {
+        "external_id": "T0816",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0816"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+      "value": "Device Restart/Shutdown - T0816"
+    },
+    {
+      "description": "Adversaries may seek to capture process values related to the inputs and outputs of a PLC. During the scan cycle, a PLC reads the status of all inputs and stores them in an image table. (Citation: Nanjundaiah, Vaidyanath) The image table is the PLCs internal storage location where values of inputs/outputs for one scan are stored while it executes the user program. After the PLC has solved the entire logic program, it updates the output image table. The contents of this output image table are written to the corresponding output points in I/O Modules.\n\nThe Input and Output Image tables described above make up the I/O Image on a PLC. This image is used by the user program instead of directly interacting with physical I/O. (Citation: Spenneberg, Ralf 2016) \n\nAdversaries may collect the I/O Image state of a PLC by utilizing a devices [Native API](https://attack.mitre.org/techniques/T0834) to access the memory regions directly. The collection of the PLCs I/O state could be used to replace values or inform future stages of an attack.",
+      "meta": {
+        "external_id": "T0877",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0877",
+          "https://www.blackhat.com/docs/asia-16/materials/asia-16-Spenneberg-PLC-Blaster-A-Worm-Living-Solely-In-The-PLC.pdf",
+          "https://www.ezautomation.net/industry-articles/plc-ladder-logic-basics.htm"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "53a48c74-0025-45f4-b04a-baa853df8204",
+      "value": "I/O Image - T0877"
+    },
+    {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/techniques/T1227).\n\nLeadership derives Key Intelligence Topics (KITs) and Key Intelligence Questions (KIQs) from the areas of most interest to them.  KITs are an expression of management's intelligence needs with respect to early warning, strategic and operational decisions, knowing the competition, and understanding the competitive situation. KIQs are the critical questions aligned by KIT which provide the basis for collection plans, create a context for analytic work, and/or identify necessary external operations. (Citation: Herring1999)",
       "meta": {
         "external_id": "T1227",
@@ -27289,6 +30858,17 @@
       "value": "Indicator Removal - T1070"
     },
     {
+      "description": "The adversary is trying to get into your ICS environment.\n\nInitial Access consists of techniques that adversaries may use as entry vectors to gain an initial foothold within an ICS environment. These techniques include compromising operational technology assets, IT resources in the OT network, and external remote services and websites. They may also target third party entities and users with privileged access. In particular, these initial access footholds may include devices and communication mechanisms with access to and privileges in both the IT and OT environments. IT resources in the OT environment are also potentially vulnerable to the same attacks as enterprise IT systems. Trusted third parties of concern may include vendors, maintenance personnel, engineers, external integrators, and other outside entities involved in expected ICS operations. Vendor maintained assets may include physical devices, software, and operational equipment. Initial access techniques may also leverage outside devices, such as radios, controllers, or removable media, to remotely interfere with and possibly infect OT operations.",
+      "meta": {
+        "external_id": "TA0108",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0108"
+        ]
+      },
+      "uuid": "69da72d2-f550-41c5-ab9e-e8255707f28a",
+      "value": "Initial Access - TA0108"
+    },
+    {
       "description": "Adversaries may use fallback or alternate communication channels if the primary channel is compromised or inaccessible in order to maintain reliable command and control and to avoid data transfer thresholds.",
       "meta": {
         "external_id": "T1008",
@@ -27315,6 +30895,17 @@
       },
       "uuid": "f24faf46-3b26-4dbb-98f2-63460498e433",
       "value": "Fallback Channels - T1008"
+    },
+    {
+      "description": "The adversary is trying to move through your ICS environment.\n\nLateral Movement consists of techniques that adversaries use to enter and control remote systems on a network. These techniques abuse default credentials, known accounts, and vulnerable services, and may also leverage dual-homed devices and systems that reside on both the IT and OT networks. The adversary uses these techniques to pivot to their next point in the environment, positioning themselves to where they want to be or think they should be. Following through on their primary objective often requires [Discovery](https://attack.mitre.org/tactics/TA0102) of the network and [Collection](https://attack.mitre.org/tactics/TA0100) to develop awareness of unique ICS devices and processes, in order to find their target and subsequently gain access to it. Reaching this objective often involves pivoting through multiple systems, devices, and accounts. Adversaries may install their own remote tools to accomplish Lateral Movement or leverage default tools, programs, and manufacturer set or other legitimate credentials native to the network, which may be stealthier.",
+      "meta": {
+        "external_id": "TA0109",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0109"
+        ]
+      },
+      "uuid": "51c25a9e-8615-40c0-8afd-1da578847924",
+      "value": "Lateral Movement - TA0109"
     },
     {
       "description": "Adversaries can use binary padding to add junk data and change the on-disk representation of malware without affecting the functionality or behavior of the binary. This will often increase the size of the binary beyond what some security tools are capable of handling due to file size limitations.\n\nBinary padding effectively changes the checksum of the file and can also be used to avoid hash-based blacklists and static anti-virus signatures.(Citation: ESET OceanLotus) The padding used is commonly generated by a function to create junk data and then appended to the end or applied to sections of malware.(Citation: Securelist Malware Tricks April 2017) Increasing the file size may decrease the effectiveness of certain tools and detection capabilities that are not designed or configured to scan large files. This may also reduce the likelihood of being collected for analysis. Public file scanning services, such as VirusTotal, limits the maximum size of an uploaded file to be analyzed.(Citation: VirusTotal FAQ)\n",
@@ -27415,6 +31006,42 @@
       "value": "Initial Access - TA0027"
     },
     {
+      "description": "Adversaries may automate collection of industrial environment information using tools or scripts. This automated collection may leverage native control protocols and tools available in the control systems environment. For example, the OPC protocol may be used to enumerate and gather information. Access to a system or interface with these native protocols may allow collection and enumeration of other attached, communicating servers and devices.",
+      "meta": {
+        "external_id": "T0802",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0802"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+      "value": "Automated Collection - T0802"
+    },
+    {
       "description": " The adversary is trying to gain higher-level permissions.\n\nPrivilege escalation includes techniques that allow an attacker to obtain a higher level of permissions on the mobile device. Attackers may enter the mobile device with very limited privileges and may be required to take advantage of a device weakness to obtain higher privileges necessary to successfully carry out their mission objectives.",
       "meta": {
         "external_id": "TA0029",
@@ -27446,6 +31073,160 @@
       },
       "uuid": "9eb4c21e-4fa8-44c9-b167-dbfc455f9210",
       "value": "Network Effects - TA0038"
+    },
+    {
+      "description": "Adversaries may perform role identification of devices involved with physical processes of interest in a target control system. Control systems devices often work in concert to control a physical process. Each device can have one or more roles that it performs within that control process. By collecting this role-based data, an adversary can construct a more targeted attack.\n\nFor example, a power generation plant may have unique devices such as one that monitors power output of a generator and another that controls the speed of a turbine. Examining devices roles allows the adversary to observe how the two devices work together to monitor and control a physical process. Understanding the role of a target device can inform the adversary's decision on what action to take, in order to cause Impact and influence or disrupt the integrity of operations. Furthermore, an adversary may be able to capture control system protocol traffic. By studying this traffic, the adversary may be able to determine which devices are outstations, and which are masters. Understanding of master devices and their role within control processes can enable the use of Rogue Master Device",
+      "meta": {
+        "external_id": "T0850",
+        "kill_chain": [
+          "ics-attack-Windows:collection",
+          "ics-attack-Human-Machine-Interface:collection",
+          "ics-attack-Control-Server:collection",
+          "ics-attack-Data-Historian:collection",
+          "ics-attack-Field-Controller/RTU/PLC/IED:collection"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Human-Machine Interface",
+          "Control Server",
+          "Data Historian",
+          "Field Controller/RTU/PLC/IED"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0850"
+        ]
+      },
+      "uuid": "23270e54-1d68-4c3b-b763-b25607bcef80",
+      "value": "Role Identification - T0850"
+    },
+    {
+      "description": "Adversaries may perform wireless compromise as a method of gaining communications and unauthorized access to a wireless network. Access to a wireless network may be gained through the compromise of a wireless device. (Citation: Alexander Bolshev, Gleb Cherbov July 2014) (Citation: Alexander Bolshev March 2014) Adversaries may also utilize radios and other wireless communication devices on the same frequency as the wireless network. Wireless compromise can be done as an initial access vector from a remote distance. \n\nA Polish student used a modified TV remote controller to gain access to and control over the Lodz city tram system in Poland. (Citation: John Bill May 2017) (Citation: Shelley Smith February 2008) The remote controller device allowed the student to interface with the trams network to modify track settings and override operator control. The adversary may have accomplished this by aligning the controller to the frequency and amplitude of IR control protocol signals. (Citation: Bruce Schneier January 2008) The controller then enabled initial access to the network, allowing the capture and replay of tram signals. (Citation: John Bill May 2017)",
+      "meta": {
+        "external_id": "T0860",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0860",
+          "https://inhomelandsecurity.com/teen_hacker_in_poland_plays_tr/",
+          "https://www.blackhat.com/docs/us-14/materials/us-14-Bolshev-ICSCorsair-How-I-Will-PWN-Your-ERP-Through-4-20mA-Current-Loop-WP.pdf",
+          "https://www.londonreconnections.com/2017/hacked-cyber-security-railways/",
+          "https://www.schneier.com/blog/archives/2008/01/hacking_the_pol.html",
+          "https://www.slideshare.net/slideshow/17-bolshev-1-13/32178888"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+      "value": "Wireless Compromise - T0860"
+    },
+    {
+      "description": "Adversaries may perform data destruction over the course of an operation. The adversary may drop or create malware, tools, or other non-native files on a target system to accomplish this, potentially leaving behind traces of malicious activities. Such non-native files and other data may be removed over the course of an intrusion to maintain a small footprint or as a standard part of the post-intrusion cleanup process. (Citation: Enterprise ATT&CK January 2018)\n\nData destruction may also be used to render operator interfaces unable to respond and to disrupt response functions from occurring as expected. An adversary may also destroy data backups that are vital to recovery after an incident.\n\nStandard file deletion commands are available on most operating system and device interfaces to perform cleanup, but adversaries may use other tools as well. Two examples are Windows Sysinternals SDelete and Active@ Killdisk.",
+      "meta": {
+        "external_id": "T0809",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0809",
+          "https://attack.mitre.org/wiki/Technique/T1107"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+      "value": "Data Destruction - T0809"
+    },
+    {
+      "description": "The adversary is trying to gain higher-level permissions.\n\nPrivilege Escalation consists of techniques that adversaries use to gain higher-level permissions on a system or network. Adversaries can often enter and explore a network with unprivileged access but require elevated permissions to follow through on their objectives. Common approaches are to take advantage of system weaknesses, misconfigurations, and vulnerabilities.",
+      "meta": {
+        "external_id": "TA0111",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0111"
+        ]
+      },
+      "uuid": "33752ae7-f875-4f43-bdb6-d8d02d341046",
+      "value": "Privilege Escalation - TA0111"
     },
     {
       "description": "Adversaries may use brute force techniques to gain access to accounts when passwords are unknown or when password hashes are obtained.(Citation: TrendMicro Pawn Storm Dec 2020) Without knowledge of the password for an account or set of accounts, an adversary may systematically guess the password using a repetitive or iterative mechanism.(Citation: Dragos Crashoverride 2018) Brute forcing passwords can take place via interaction with a service that will check the validity of those credentials or offline against previously acquired credential data, such as password hashes.\n\nBrute forcing credentials may take place at various points during a breach. For example, adversaries may attempt to brute force access to [Valid Accounts](https://attack.mitre.org/techniques/T1078) within a victim environment leveraging knowledge gathered from other post-compromise behaviors such as [OS Credential Dumping](https://attack.mitre.org/techniques/T1003), [Account Discovery](https://attack.mitre.org/techniques/T1087), or [Password Policy Discovery](https://attack.mitre.org/techniques/T1201). Adversaries may also combine brute forcing activity with behaviors such as [External Remote Services](https://attack.mitre.org/techniques/T1133) as part of Initial Access. \n\nIf an adversary guesses the correct password but fails to login to a compromised account due to location-based conditional access policies, they may change their infrastructure until they match the victim’s location and therefore bypass those policies.(Citation: ReliaQuest Health Care Social Engineering Campaign 2024)",
@@ -28263,6 +32044,28 @@
       "value": "Sudo Caching - T1206"
     },
     {
+      "description": "Adversaries may leverage manufacturer or supplier set default credentials on control system devices. These default credentials may have administrative permissions and may be necessary for initial configuration of the device. It is general best practice to change the passwords for these accounts as soon as possible, but some manufacturers may have devices that have passwords or usernames that cannot be changed. (Citation: Keith Stouffer May 2015)\n\nDefault credentials are normally documented in an instruction manual that is either packaged with the device, published online through official means, or published online through unofficial means. Adversaries may leverage default credentials that have not been properly modified or disabled.",
+      "meta": {
+        "external_id": "T0812",
+        "kill_chain": [
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0812",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "8bb4538f-f16f-49f0-a431-70b5444c7349",
+      "value": "Default Credentials - T0812"
+    },
+    {
       "description": "The Windows Time service (W32Time) enables time synchronization across and within domains. (Citation: Microsoft W32Time Feb 2018) W32Time time providers are responsible for retrieving time stamps from hardware/network resources and outputting these values to other network clients. (Citation: Microsoft TimeProvider)\n\nTime providers are implemented as dynamic-link libraries (DLLs) that are registered in the subkeys of  <code>HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\W32Time\\TimeProviders\\</code>. (Citation: Microsoft TimeProvider) The time provider manager, directed by the service control manager, loads and starts time providers listed and enabled under this key at system startup and/or whenever parameters are changed. (Citation: Microsoft TimeProvider)\n\nAdversaries may abuse this architecture to establish Persistence, specifically by registering and enabling a malicious DLL as a time provider. Administrator privileges are required for time provider registration, though execution will run in context of the Local Service account. (Citation: Github W32Time Oct 2017)",
       "meta": {
         "external_id": "T1209",
@@ -28992,6 +32795,75 @@
       "value": "Multilayer Encryption - T1079"
     },
     {
+      "description": "Adversaries may stop or disable services on a system to render those services unavailable to legitimate users. Stopping critical services can inhibit or stop response to an incident or aid in the adversary's overall objectives to cause damage to the environment. (Citation: Enterprise ATT&CK)  Services may not allow for modification of their data stores while running. Adversaries may stop services in order to conduct Data Destruction. (Citation: Enterprise ATT&CK)",
+      "meta": {
+        "external_id": "T0881",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0881",
+          "https://attack.mitre.org/techniques/T1489/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+      "value": "Service Stop - T0881"
+    },
+    {
       "description": "Adversaries may manipulate accounts to maintain and/or elevate access to victim systems. Account manipulation may consist of any action that preserves or modifies adversary access to a compromised account, such as modifying credentials or permission groups.(Citation: FireEye SMOKEDHAM June 2021) These actions could also include account activity designed to subvert security policies, such as performing iterative password updates to bypass password duration policies and preserve the life of compromised credentials. \n\nIn order to create or manipulate accounts, the adversary must already have sufficient permissions on systems or the domain. However, account manipulation may also lead to privilege escalation where modifications grant access to additional roles, permissions, or higher-privileged [Valid Accounts](https://attack.mitre.org/techniques/T1078).",
       "meta": {
         "external_id": "T1098",
@@ -29048,6 +32920,979 @@
       },
       "uuid": "a10641f4-87b4-45a3-a906-92a149cb2c27",
       "value": "Account Manipulation - T1098"
+    },
+    {
+      "description": "Adversaries may leverage credentials that are hardcoded in software or firmware to gain an unauthorized interactive user session to an asset. Examples credentials that may be hardcoded in an asset include:\n\n* Username/Passwords\n* Cryptographic keys/Certificates\n* API tokens\n\nUnlike [Default Credentials](https://attack.mitre.org/techniques/T0812), these credentials are built into the system in a way that they either cannot be changed by the asset owner, or may be infeasible to change because of the impact it would cause to the control system operation. These credentials may be reused across whole product lines or device models and are often not published or known to the owner and operators of the asset. \n\nAdversaries may utilize these hardcoded credentials to move throughout the control system environment or provide reliable access for their tools to interact with industrial assets. \n",
+      "meta": {
+        "external_id": "T0891",
+        "kill_chain": [
+          "ics-attack:lateral-movement",
+          "ics-attack:persistence"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0891"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "6b335943-c3af-430e-a135-ab09623bdc20",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "c9a8d958-fcdb-40d2-af4c-461c8031651a",
+      "value": "Hardcoded Credentials - T0891"
+    },
+    {
+      "description": "Network sniffing is the practice of using a network interface on a computer system to monitor or capture information (Citation: Enterprise ATT&CK January 2018) regardless of whether it is the specified destination for the information. \n\nAn adversary may attempt to sniff the traffic to gain information about the target. This information can vary in the level of importance. Relatively unimportant information is general communications to and from machines.  Relatively important information would be login information. User credentials may be sent over an unencrypted protocol, such as Telnet, that can be captured and obtained through network packet analysis. \n\nIn addition, ARP and Domain Name Service (DNS) poisoning can be used to capture credentials to websites, proxies, and internal systems by redirecting traffic to an adversary.",
+      "meta": {
+        "external_id": "T0842",
+        "kill_chain": [
+          "ics-attack:discovery"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0842",
+          "https://attack.mitre.org/wiki/Technique/T1040"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+      "value": "Network Sniffing - T0842"
+    },
+    {
+      "description": "Adversaries may attempt to perform screen capture of devices in the control system environment. Screenshots may be taken of workstations, HMIs, or other devices that display environment-relevant process, device, reporting, alarm, or related data. These device displays may reveal information regarding the ICS process, layout, control, and related schematics. In particular, an HMI can provide a lot of important industrial process information. (Citation: ICS-CERT October 2017) Analysis of screen captures may provide the adversary with an understanding of intended operations and interactions between critical devices.",
+      "meta": {
+        "external_id": "T0852",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0852",
+          "https://www.us-cert.gov/ncas/alerts/TA17-293A"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
+      "value": "Screen Capture - T0852"
+    },
+    {
+      "description": "Adversaries may perform location identification using device data to inform operations and targeted impact for attacks. Location identification data can come in a number of forms, including geographic location, location relative to other control system devices, time zone, and current time. An adversary may use an embedded global positioning system (GPS) module in a device to figure out the physical coordinates of a device. NIST SP800-82 recommends that devices utilize GPS or another location determining mechanism to attach appropriate timestamps to log entries (Citation: Guidance - NIST SP800-82). While this assists in logging and event tracking, an adversary could use the underlying positioning mechanism to determine the general location of a device. An adversary can also infer the physical location of serially connected devices by using serial connection enumeration. \n\nAn adversary attempt to attack and cause Impact could potentially affect other control system devices in close proximity. Device local-time and time-zone settings can also provide adversaries a rough indicator of device location, when specific geographic identifiers cannot be determined from the system.",
+      "meta": {
+        "external_id": "T0825",
+        "kill_chain": [
+          "ics-attack-Windows:collection",
+          "ics-attack-Control-Server:collection"
+        ],
+        "mitre_platforms": [
+          "Windows",
+          "Control Server"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0825",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
+        ]
+      },
+      "uuid": "7374ab87-0782-41f8-b415-678c0950bb2a",
+      "value": "Location Identification - T0825"
+    },
+    {
+      "description": "Adversaries may modify software and device credentials to prevent operator and responder access. Depending on the device, the modification or addition of this password could prevent any device configuration actions from being accomplished and may require a factory reset or replacement of hardware. These credentials are often built-in features provided by the device vendors as a means to restrict access to management interfaces.\n\nAn adversary with access to valid or hardcoded credentials could change the credential to prevent future authorized device access. Change Credential may be especially damaging when paired with other techniques such as Modify Program, Data Destruction, or Modify Controller Tasking. In these cases, a device’s configuration may be destroyed or include malicious actions for the process environment, which cannot not be removed through normal device configuration actions. \n\nAdditionally, recovery of the device and original configuration may be difficult depending on the features provided by the device. In some cases, these passwords cannot be removed onsite and may require that the device be sent back to the vendor for additional recovery steps.\n\n\nA chain of incidents occurred in Germany, where adversaries locked operators out of their building automation system (BAS) controllers by enabling a previously unset BCU key. (Citation: German BAS Lockout Dec 2021) \n",
+      "meta": {
+        "external_id": "T0892",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0892",
+          "https://www.darkreading.com/attacks-breaches/lights-out-cyberattacks-shut-down-building-automation-systems"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "fab8fc7d-f27f-4fbb-9de6-44740aade05f",
+      "value": "Change Credential - T0892"
+    },
+    {
+      "description": "Adversaries may directly interact with the native OS application programming interface (API) to access system functions. Native APIs provide a controlled means of calling low-level OS services within the kernel, such as those involving hardware/devices, memory, and processes. (Citation: The MITRE Corporation May 2017) These native APIs are leveraged by the OS during system boot (when other system components are not yet initialized) as well as carrying out tasks and requests during routine operations. \n\nFunctionality provided by native APIs are often also exposed to user-mode applications via interfaces and libraries. For example, functions such as memcpy and direct operations on memory registers can be used to modify user and system memory space.",
+      "meta": {
+        "external_id": "T0834",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0834",
+          "https://attack.mitre.org/techniques/T1106/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "b52870cc-83f3-473c-b895-72d91751030b",
+      "value": "Native API - T0834"
+    },
+    {
+      "description": "Adversaries may perform a program download to transfer a user program to a controller. \n\nVariations of program download, such as online edit and program append, allow a controller to continue running during the transfer and reconfiguration process without interruption to process control. However, before starting a full program download (i.e., download all) a controller may need to go into a stop state. This can have negative consequences on the physical process, especially if the controller is not able to fulfill a time-sensitive action. Adversaries may choose to avoid a download all in favor of an online edit or program append to avoid disrupting the physical process. An adversary may need to use the technique Detect Operating Mode or Change Operating Mode to make sure the controller is in the proper mode to accept a program download.\n\nThe granularity of control to transfer a user program in whole or parts is dictated by the management protocol (e.g., S7CommPlus, TriStation) and underlying controller API. Thus, program download is a high-level term for the suite of vendor-specific API calls used to configure a controllers user program memory space.  \n\n[Modify Controller Tasking](https://attack.mitre.org/techniques/T0821) and [Modify Program](https://attack.mitre.org/techniques/T0889) represent the configuration changes that are transferred to a controller via a program download.",
+      "meta": {
+        "external_id": "T0843",
+        "kill_chain": [
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0843"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+      "value": "Program Download - T0843"
+    },
+    {
+      "description": "Adversaries may rely on a targeted organizations user interaction for the execution of malicious code. User interaction may consist of installing applications, opening email attachments, or granting higher permissions to documents. \n\nAdversaries may embed malicious code or visual basic code into files such as Microsoft Word and Excel documents or software installers. (Citation: Booz Allen Hamilton) Execution of this code requires that the user enable scripting or write access within the document. Embedded code may not always be noticeable to the user especially in cases of trojanized software. (Citation: Daavid Hentunen, Antti Tikkanen June 2014) \n\nA Chinese spearphishing campaign running from December 9, 2011 through February 29, 2012 delivered malware through spearphishing attachments which required user action to achieve execution. (Citation: CISA AA21-201A Pipeline Intrusion July 2021)",
+      "meta": {
+        "external_id": "T0863",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0863",
+          "https://us-cert.cisa.gov/sites/default/files/publications/AA21-201A_Chinese_Gas_Pipeline_Intrusion_Campaign_2011_to_2013%20(1).pdf",
+          "https://www.boozallen.com/content/dam/boozallen/documents/2016/09/ukraine-report-when-the-lights-went-out.pdf",
+          "https://www.f-secure.com/weblog/archives/00002718.html"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+      "value": "User Execution - T0863"
+    },
+    {
+      "description": "Adversaries may modify parameters used to instruct industrial control system devices. These devices operate via programs that dictate how and when to perform actions based on such parameters. Such parameters can determine the extent to which an action is performed and may specify additional options. For example, a program on a control system device dictating motor processes may take a parameter defining the total number of seconds to run that motor.      \n\nAn adversary can potentially modify these parameters to produce an outcome outside of what was intended by the operators. By modifying system and process critical parameters, the adversary may cause [Impact](https://attack.mitre.org/tactics/TA0105) to equipment and/or control processes. Modified parameters may be turned into dangerous, out-of-bounds, or unexpected values from typical operations. For example, specifying that a process run for more or less time than it should, or dictating an unusually high, low, or invalid value as a parameter.",
+      "meta": {
+        "external_id": "T0836",
+        "kill_chain": [
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0836"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+      "value": "Modify Parameter - T0836"
+    },
+    {
+      "description": "Adversaries may install malicious or vulnerable firmware onto modular hardware devices. Control system devices often contain modular hardware devices. These devices may have their own set of firmware that is separate from the firmware of the main control system equipment.   \n\nThis technique is similar to [System Firmware](https://attack.mitre.org/techniques/T0857), but is conducted on other system components that may not have the same capabilities or level of integrity checking. Although it results in a device re-image, malicious device firmware may provide persistent access to remaining devices. (Citation: Daniel Peck,  Dale Peterson January 2009)  \n\nAn easy point of access for an adversary is the Ethernet card, which may have its own CPU, RAM, and operating system. The adversary may attack and likely exploit the computer on an Ethernet card. Exploitation of the Ethernet card computer may enable the adversary to accomplish additional attacks, such as the following: (Citation: Daniel Peck,  Dale Peterson January 2009)  \n\n* Delayed Attack - The adversary may stage an attack in advance and choose when to launch it, such as at a particularly damaging time.  \n* Brick the Ethernet Card - Malicious firmware may be programmed to result in an Ethernet card failure, requiring a factory return.  \n* Random Attack or Failure - The adversary may load malicious firmware onto multiple field devices. Execution of an attack and the time it occurs is generated by a pseudo-random number generator.   \n* A Field Device Worm - The adversary may choose to identify all field devices of the same model, with the end goal of performing a device-wide compromise.  \n* Attack Other Cards on the Field Device - Although it is not the most important module in a field device, the Ethernet card is most accessible to the adversary and malware. Compromise of the Ethernet card may provide a more direct route to compromising other modules, such as the CPU module.",
+      "meta": {
+        "external_id": "T0839",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0839",
+          "https://www.researchgate.net/publication/228849043_Leveraging_ethernet_card_vulnerabilities_in_field_devices"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "efbf7888-f61b-4572-9c80-7e2965c60707",
+      "value": "Module Firmware - T0839"
+    },
+    {
+      "description": "Adversaries may attempt to upload a program from a PLC to gather information about an industrial process. Uploading a program may allow them to acquire and study the underlying logic. Methods of program upload include vendor software, which enables the user to upload and read a program running on a PLC. This software can be used to upload the target program to a workstation, jump box, or an interfacing device.",
+      "meta": {
+        "external_id": "T0845",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0845"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+      "value": "Program Upload - T0845"
+    },
+    {
+      "description": "Adversaries may use a connection proxy to direct network traffic between systems or act as an intermediary for network communications.\n\nThe definition of a proxy can also be expanded to encompass trust relationships between networks in peer-to-peer, mesh, or trusted connections between networks consisting of hosts or systems that regularly communicate with each other.\n\nThe network may be within a single organization or across multiple organizations with trust relationships. Adversaries could use these types of relationships to manage command and control communications, to reduce the number of simultaneous outbound network connections, to provide resiliency in the face of connection loss, or to ride over existing trusted communications paths between victims to avoid suspicion. (Citation: Enterprise ATT&CK January 2018)",
+      "meta": {
+        "external_id": "T0884",
+        "kill_chain": [
+          "ics-attack:command-and-control"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0884",
+          "https://attack.mitre.org/wiki/Technique/T1090"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+      "value": "Connection Proxy - T0884"
+    },
+    {
+      "description": "Adversaries may setup a rogue master to leverage control server functions to communicate with outstations. A rogue master can be used to send legitimate control messages to other control system devices, affecting processes in unintended ways. It may also be used to disrupt network communications by capturing and receiving the network traffic meant for the actual master. Impersonating a master may also allow an adversary to avoid detection. \n\nIn the case of the 2017 Dallas Siren incident, adversaries used a rogue master to send command messages to the 156 distributed sirens across the city, either through a single rogue transmitter with a strong signal, or using many distributed repeaters. (Citation: Bastille April 2017) (Citation: Zack Whittaker April 2017)",
+      "meta": {
+        "external_id": "T0848",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0848",
+          "https://www.bastille.net/blogs/2017/4/17/dallas-siren-attack",
+          "https://www.zdnet.com/article/experts-think-they-know-how-dallas-emergency-sirens-were-hacked/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+      "value": "Rogue Master - T0848"
+    },
+    {
+      "description": "Adversaries may use a spearphishing attachment, a variant of spearphishing, as a form of a social engineering attack against specific targets. Spearphishing attachments are different from other forms of spearphishing in that they employ malware attached to an email. All forms of spearphishing are electronically delivered and target a specific individual, company, or industry. In this scenario, adversaries attach a file to the spearphishing email and usually rely upon [User Execution](https://attack.mitre.org/techniques/T0863) to gain execution and access. (Citation: Enterprise ATT&CK October 2019) \n\nA Chinese spearphishing campaign running from December 9, 2011 through February 29, 2012, targeted ONG organizations and their employees. The emails were constructed with a high level of sophistication to convince employees to open the malicious file attachments. (Citation: CISA AA21-201A Pipeline Intrusion July 2021)",
+      "meta": {
+        "external_id": "T0865",
+        "kill_chain": [
+          "ics-attack:initial-access"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0865",
+          "https://attack.mitre.org/techniques/T1193/",
+          "https://us-cert.cisa.gov/sites/default/files/publications/AA21-201A_Chinese_Gas_Pipeline_Intrusion_Campaign_2011_to_2013%20(1).pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+      "value": "Spearphishing Attachment - T0865"
+    },
+    {
+      "description": "System firmware on modern assets is often designed with an update feature. Older device firmware may be factory installed and require special reprograming equipment. When available, the firmware update feature enables vendors to remotely patch bugs and perform upgrades. Device firmware updates are often delegated to the user and may be done using a software update package. It may also be possible to perform this task over the network. \n\nAn adversary may exploit the firmware update feature on accessible devices to upload malicious or out-of-date firmware. Malicious modification of device firmware may provide an adversary with root access to a device, given firmware is one of the lowest programming abstraction layers. (Citation: Basnight, Zachry, et al.)",
+      "meta": {
+        "external_id": "T0857",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://www.sciencedirect.com/science/article/pii/S1874548213000231",
+          "https://attack.mitre.org/techniques/T0857"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "revoked-by"
+        }
+      ],
+      "revoked": true,
+      "uuid": "b9160e77-ea9e-4ba9-b1c8-53a3c466b13d",
+      "value": "System Firmware - T0857"
+    },
+    {
+      "description": "Adversaries may leverage AutoRun functionality or scripts to execute malicious code. Devices configured to enable AutoRun functionality or legacy operating systems may be susceptible to abuse of these features to run malicious code stored on various forms of removeable media (i.e., USB, Disk Images [.ISO]). Commonly, AutoRun or AutoPlay are disabled in many operating systems configurations to mitigate against this technique. If a device is configured to enable AutoRun or AutoPlay, adversaries may execute code on the device by mounting the removable media to the device, either through physical or virtual means. This may be especially relevant for virtual machine environments where disk images may be dynamically mapped to a guest system on a hypervisor.  \n\nAn example could include an adversary gaining access to a hypervisor through the management interface to modify a virtual machine’s hardware configuration. They could then deploy an iso image with a malicious AutoRun script to cause the virtual machine to automatically execute the code contained on the disk image. This would enable the execution of malicious code within a virtual machine without needing any prior remote access to that system.\n",
+      "meta": {
+        "external_id": "T0895",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0895"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "77d9c726-b53e-481d-8bcc-1068aebfbb9d",
+      "value": "Autorun Image - T0895"
+    },
+    {
+      "description": "Adversaries may steal the credentials of a specific user or service account using credential access techniques. In some cases, default credentials for control system devices may be publicly available. Compromised credentials may be used to bypass access controls placed on various resources on hosts and within the network, and may even be used for persistent access to remote systems. Compromised and default credentials may also grant an adversary increased privilege to specific systems and devices or access to restricted areas of the network. Adversaries may choose not to use malware or tools, in conjunction with the legitimate access those credentials provide, to make it harder to detect their presence or to control devices and send legitimate commands in an unintended way. \n\nAdversaries may also create accounts, sometimes using predefined account names and passwords, to provide a means of backup access for persistence. (Citation: Booz Allen Hamilton) \n\nThe overlap of credentials and permissions across a network of systems is of concern because the adversary may be able to pivot across accounts and systems to reach a high level of access (i.e., domain or enterprise administrator)  and possibly between the enterprise and operational technology environments. Adversaries may be able to leverage valid credentials from one system to gain access to another system.",
+      "meta": {
+        "external_id": "T0859",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0859",
+          "https://www.boozallen.com/content/dam/boozallen/documents/2016/09/ukraine-report-when-the-lights-went-out.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+      "value": "Valid Accounts - T0859"
+    },
+    {
+      "description": "Adversaries may leverage remote services to move between assets and network segments. These services are often used to allow operators to interact with systems remotely within the network, some examples are RDP, SMB, SSH, and other similar mechanisms. (Citation: Blake Johnson, Dan Caban, Marina Krotofil, Dan Scali, Nathan Brubaker, Christopher Glyer December 2017) (Citation: Dragos December 2017) (Citation: Joe Slowik April 2019) \n\nRemote services could be used to support remote access, data transmission, authentication, name resolution, and other remote functions. Further, remote services may be necessary to allow operators and administrators to configure systems within the network from their engineering or management workstations. An adversary may use this technique to access devices which may be dual-homed (Citation: Blake Johnson, Dan Caban, Marina Krotofil, Dan Scali, Nathan Brubaker, Christopher Glyer December 2017) to multiple network segments, and can be used for [Program Download](https://attack.mitre.org/techniques/T0843) or to execute attacks on control devices directly through [Valid Accounts](https://attack.mitre.org/techniques/T0859).\n\nSpecific remote services (RDP & VNC) may be a precursor to enable [Graphical User Interface](https://attack.mitre.org/techniques/T0823) execution on devices such as HMIs or engineering workstation software.\n\nBased on incident data, CISA and FBI assessed that Chinese state-sponsored actors also compromised various authorized remote access channels, including systems designed to transfer data and/or allow access between corporate and ICS networks.  (Citation: CISA AA21-201A Pipeline Intrusion July 2021)",
+      "meta": {
+        "external_id": "T0886",
+        "kill_chain": [
+          "ics-attack:initial-access",
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0886",
+          "https://dragos.com/blog/industry-news/implications-of-it-ransomware-for-ics-environments/",
+          "https://dragos.com/blog/trisis/TRISIS-01.pdf",
+          "https://us-cert.cisa.gov/sites/default/files/publications/AA21-201A_Chinese_Gas_Pipeline_Intrusion_Campaign_2011_to_2013%20(1).pdf",
+          "https://www.fireeye.com/blog/threat-research/2017/12/attackers-deploy-new-ics-attack-framework-triton.html"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+      "value": "Remote Services - T0886"
+    },
+    {
+      "description": "Adversaries may target protection function alarms to prevent them from notifying operators of critical conditions. Alarm messages may be a part of an overall reporting system and of particular interest for adversaries. Disruption of the alarm system does not imply the disruption of the reporting system as a whole.\n\nA Secura presentation on targeting OT notes a dual fold goal for adversaries attempting alarm suppression: prevent outgoing alarms from being raised and prevent incoming alarms from being responded to. (Citation: Jos Wetzels, Marina Krotofil 2019) The method of suppression may greatly depend on the type of alarm in question:  \n\n* An alarm raised by a protocol message \n* An alarm signaled with I/O \n* An alarm bit set in a flag (and read) \n\nIn ICS environments, the adversary may have to suppress or contend with multiple alarms and/or alarm propagation to achieve a specific goal to evade detection or prevent intended responses from occurring. (Citation: Jos Wetzels, Marina Krotofil 2019)  Methods of suppression may involve tampering or altering device displays and logs, modifying in memory code to fixed values, or even tampering with assembly level instruction code.",
+      "meta": {
+        "external_id": "T0878",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0878",
+          "https://troopers.de/downloads/troopers19/TROOPERS19_NGI_IoT_diet_poisoned_fruit.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+      "value": "Alarm Suppression - T0878"
+    },
+    {
+      "description": "Adversaries may seek to capture radio frequency (RF) communication used for remote control and reporting in distributed environments. RF communication frequencies vary between 3 kHz to 300 GHz, although are commonly between 300 MHz to 6 GHz. (Citation: Candell, R., Hany, M., Lee, K. B., Liu,Y., Quimby, J., Remley, K. April 2018)  The wavelength and frequency of the signal affect how the signal propagates through open air, obstacles (e.g. walls and trees) and the type of radio required to capture them. These characteristics are often standardized in the protocol and hardware and may have an effect on how the signal is captured. Some examples of wireless protocols that may be found in cyber-physical environments are: WirelessHART, Zigbee, WIA-FA, and 700 MHz Public Safety Spectrum. \n\nAdversaries may capture RF communications by using specialized hardware, such as software defined radio (SDR), handheld radio, or a computer with radio demodulator tuned to the communication frequency. (Citation: Bastille April 2017) Information transmitted over a wireless medium may be captured in-transit whether the sniffing device is the intended destination or not. This technique may be particularly useful to an adversary when the communications are not encrypted. (Citation: Gallagher, S. April 2017) \n\nIn the 2017 Dallas Siren incident, it is suspected that adversaries likely captured wireless command message broadcasts on a 700 MHz frequency during a regular test of the system. These messages were later replayed to trigger the alarm systems. (Citation: Gallagher, S. April 2017)",
+      "meta": {
+        "external_id": "T0887",
+        "kill_chain": [
+          "ics-attack:discovery",
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "https://arstechnica.com/information-technology/2017/04/dallas-siren-hack-used-radio-signals-to-spoof-alarm-says-city-manager/",
+          "https://attack.mitre.org/techniques/T0887",
+          "https://nvlpubs.nist.gov/nistpubs/ams/NIST.AMS.300-4.pdf",
+          "https://www.bastille.net/blogs/2017/4/17/dallas-siren-attack"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "0fe075d5-beac-4d02-b93e-0f874997db72",
+      "value": "Wireless Sniffing - T0887"
+    },
+    {
+      "description": "Adversaries may modify or add a program on a controller to affect how it interacts with the physical process, peripheral devices and other hosts on the network. Modification to controller programs can be accomplished using a Program Download in addition to other types of program modification such as online edit and program append. \n\nProgram modification encompasses the addition and modification of instructions and logic contained in Program Organization Units (POU)  (Citation: IEC February 2013) and similar programming elements found on controllers. This can include, for example, adding new functions to a controller, modifying the logic in existing functions and making new calls from one function to another. \n\nSome programs may allow an adversary to interact directly with the native API of the controller to take advantage of obscure features or vulnerabilities.",
+      "meta": {
+        "external_id": "T0889",
+        "kill_chain": [
+          "ics-attack:persistence"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0889",
+          "https://webstore.iec.ch/publication/4552"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+      "value": "Modify Program - T0889"
     },
     {
       "description": "Adversaries may interact with the Windows Registry as part of a variety of other techniques to aid in defense evasion, persistence, and execution.\n\nAccess to specific areas of the Registry depends on account permissions, with some keys requiring administrator-level access. The built-in Windows command-line utility [Reg](https://attack.mitre.org/software/S0075) may be used for local or remote Registry modification.(Citation: Microsoft Reg) Other tools, such as remote access tools, may also contain functionality to interact with the Registry through the Windows API.\n\nThe Registry may be modified in order to hide configuration information or malicious payloads via [Obfuscated Files or Information](https://attack.mitre.org/techniques/T1027).(Citation: Unit42 BabyShark Feb 2019)(Citation: Avaddon Ransomware 2021)(Citation: Microsoft BlackCat Jun 2022)(Citation: CISA Russian Gov Critical Infra 2018) The Registry may also be modified to impair defenses, such as by enabling macros for all Microsoft Office products, allowing privilege escalation without alerting the user, increasing the maximum number of allowed outbound requests, and/or modifying systems to store plaintext credentials in memory.(Citation: CISA LockBit 2023)(Citation: Unit42 BabyShark Feb 2019)\n\nThe Registry of a remote system may be modified to aid in execution of files as part of lateral movement. It requires the remote Registry service to be running on the target system.(Citation: Microsoft Remote) Often [Valid Accounts](https://attack.mitre.org/techniques/T1078) are required, along with access to the remote system's [SMB/Windows Admin Shares](https://attack.mitre.org/techniques/T1021/002) for RPC communication.\n\nFinally, Registry modifications may also include actions to hide keys, such as prepending key names with a null character, which will cause an error and/or be ignored when read via [Reg](https://attack.mitre.org/software/S0075) or other utilities using the Win32 API.(Citation: Microsoft Reghide NOV 2006) Adversaries may abuse these pseudo-hidden keys to conceal payloads/commands used to maintain persistence.(Citation: TrendMicro POWELIKS AUG 2014)(Citation: SpectorOps Hiding Reg Jul 2017)",
@@ -31108,6 +35953,56 @@
       "value": "Impair Defenses - T1629"
     },
     {
+      "description": "Adversaries may send unauthorized messages to ICS systems and devices to evade defenses or manipulate processes. Unauthorized messages can be categorized as either reporting messages that contain telemetry data about the current state of systems, devices, and processes or as command messages which instruct systems and devices on how to operate. By injecting unauthorized messages, adversaries can make it appear as if everything is working correctly when it isn’t, trigger alarms to misdirect personnel or impact processes, and manipulate controls to disrupt processes.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)\n\nAdversaries may send unauthorized messages in an ICS environment using software found within the environment (living-off-the-land, vendor-specific interfaces, etc.), custom tooling leveraging OT protocols and libraries, or by positioning themselves between systems and devices and injecting messages into the communications such as the case with an [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) attack.\n",
+      "meta": {
+        "external_id": "T1692",
+        "kill_chain": [
+          "ics-attack:evasion",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T1692"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        }
+      ],
+      "uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+      "value": "Unauthorized Message - T1692"
+    },
+    {
       "description": "This object is deprecated as its content has been merged into the enterprise domain. Please see the [PRE](http://attack.mitre.org/matrices/enterprise/pre/) matrix for its replacement. The prior content of this page has been preserved [here](https://attack.mitre.org/versions/v7/techniques/T1333).\n\nDynamic DNS is a automated method to rapidly update the domain name system mapping of hostnames to IPs. (Citation: FireEyeSupplyChain)",
       "meta": {
         "external_id": "T1333",
@@ -31321,6 +36216,41 @@
       },
       "uuid": "b512fb8a-18dd-4bfc-bbad-acbaaeb7dde3",
       "value": "Generate Content - T1683"
+    },
+    {
+      "description": "Firmware is low-level software embedded in hardware that enables systems and devices to function properly and is commonly found in ICS environments. Adversaries may modify firmware on a system or device by installing malicious or vulnerable versions that enable them to achieve objectives such as [Persistence](https://attack.mitre.org/tactics/TA0110), [Impair Process Control](https://attack.mitre.org/tactics/TA0106), and [Inhibit Response Function](https://attack.mitre.org/tactics/TA0107). \n\nAdversaries may modify system and device firmware by using the built-in firmware update functionality which may support local or remote installation. The malicious or vulnerable firmware may be delivered via [Replication Through Removable Media](https://attack.mitre.org/techniques/T0847), [Supply Chain Compromise](https://attack.mitre.org/techniques/T0862), or [Remote Services](https://attack.mitre.org/techniques/T0886). Once installed, the malicious or vulnerable firmware could be used to provide [Rootkit](https://attack.mitre.org/techniques/T0851) and [Hooking](https://attack.mitre.org/techniques/T0874) functionality, [Exploitation for Privilege Escalation](https://attack.mitre.org/techniques/T0890), or [Denial of Service](https://attack.mitre.org/techniques/T0814).(Citation: Basnight, Zachry, et al.)\n",
+      "meta": {
+        "external_id": "T1693",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:inhibit-response-function",
+          "ics-attack:impair-process-control"
+        ],
+        "refs": [
+          "http://www.sciencedirect.com/science/article/pii/S1874548213000231",
+          "https://attack.mitre.org/techniques/T1693"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        }
+      ],
+      "uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+      "value": "Modify Firmware - T1693"
     },
     {
       "description": "An adversary may seek to lock the legitimate user out of the device, for example to inhibit user interaction or to obtain a ransom payment.\n\nOn Android versions prior to 7, apps can abuse Device Administrator access to reset the device lock passcode to prevent the user from unlocking the device. After Android 7, only device or profile owners (e.g. MDMs) can reset the device’s passcode.(Citation: Android resetPassword)\n\nOn iOS devices, this technique does not work because mobile device management servers can only remove the screen lock passcode, they cannot set a new passcode. However, on jailbroken devices, malware has been discovered that can lock the user out of the device.(Citation: Xiao-KeyRaider)",
@@ -31638,6 +36568,98 @@
       "value": "Serverless Execution - T1648"
     },
     {
+      "description": "Adversaries may target insecure credentials as a means to persist on a system or device or move laterally from one system or device to another. Insecure credentials may appear as default credentials which are pre-configured credentials on a system, device, or software that are well-known in documentation or hard-coded credentials which are built into the system, device, or software that cannot be changed or not easily changed because of the impact on control processes.(Citation: NIST SP 800-82r3)(Citation: ICS-ALERT-13-164-01)(Citation: OT IceFall)\n Adversaries often times use insecure credentials to evade detection as they are typically forgotten about by system and device owners.",
+      "meta": {
+        "external_id": "T1694",
+        "kill_chain": [
+          "ics-attack:persistence",
+          "ics-attack:lateral-movement"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T1694",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r3.pdf",
+          "https://www.cisa.gov/news-events/ics-alerts/ics-alert-13-164-01",
+          "https://www.forescout.com/resources/ot-icefall-report/"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "3e9b182e-e493-49e1-9a9b-bd0dfcd34a7c",
+      "value": "Insecure Credentials - T1694"
+    },
+    {
       "description": "Adversaries may leverage the resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. \n\nResource hijacking may take a number of different forms. For example, adversaries may:\n\n* Leverage compute resources in order to mine cryptocurrency\n* Sell network bandwidth to proxy networks\n* Generate SMS traffic for profit\n* Abuse cloud-based messaging services to send large quantities of spam messages\n\nIn some cases, adversaries may leverage multiple types of Resource Hijacking at once.(Citation: Sysdig Cryptojacking Proxyjacking 2023)",
       "meta": {
         "external_id": "T1496",
@@ -31951,6 +36973,95 @@
       "value": "Dynamic Resolution - T1568"
     },
     {
+      "description": "Operational technology communications occur over serial COM, Ethernet, Wi-Fi, cellular (4G/5G), and satellite mediums. Adversaries may block communications to prevent reporting messages and command messages from reaching their intended target devices disrupting processes, operations, and causing cyber-physical impacts.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)  \n\nAdversaries may block communications by either making modifications to software ([System Firmware](https://attack.mitre.org/techniques/T0857), [Module Firmware](https://attack.mitre.org/techniques/T0839), [Hooking](https://attack.mitre.org/techniques/T0874), and [Rootkit](https://attack.mitre.org/techniques/T0851)) and services ([Service Stop](https://attack.mitre.org/techniques/T0881), [Denial of Service](https://attack.mitre.org/techniques/T0814)) on systems and devices or by positioning themselves between systems and devices and intercepting and blocking the communications such as the case with an [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) attack.\n",
+      "meta": {
+        "external_id": "T1695",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T1695"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+      "value": "Block Communications - T1695"
+    },
+    {
       "description": "Adversaries may gain access and continuously communicate with victims by injecting malicious content into systems through online network traffic. Rather than luring victims to malicious payloads hosted on a compromised website (i.e., [Drive-by Target](https://attack.mitre.org/techniques/T1608/004) followed by [Drive-by Compromise](https://attack.mitre.org/techniques/T1189)), adversaries may initially access victims through compromised data-transfer channels where they can manipulate traffic and/or inject their own content. These compromised online network channels may also be used to deliver additional payloads (i.e., [Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105)) and other data to already compromised systems.(Citation: ESET MoustachedBouncer)\n\nAdversaries may inject content to victim systems in various ways, including:\n\n* From the middle, where the adversary is in-between legitimate online client-server communications (**Note:** this is similar but distinct from [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T1557), which describes AiTM activity solely within an enterprise environment) (Citation: Kaspersky Encyclopedia MiTM)\n* From the side, where malicious content is injected and races to the client as a fake response to requests of a legitimate online server (Citation: Kaspersky ManOnTheSide)\n\nContent injection is often the result of compromised upstream communication channels, for example at the level of an internet service provider (ISP) as is the case with \"lawful interception.\"(Citation: Kaspersky ManOnTheSide)(Citation: ESET MoustachedBouncer)(Citation: EFF China GitHub Attack)",
       "meta": {
         "external_id": "T1659",
@@ -32225,6 +37336,96 @@
       "value": "Downgrade Attack - T1689"
     },
     {
+      "description": "Adversaries with privileged network access may seek to modify network traffic in real time using adversary-in-the-middle (AiTM) attacks. (Citation: Gabriel Sanchez October 2017) This type of attack allows the adversary to intercept traffic to and/or from a particular device on the network. If a AiTM attack is established, then the adversary has the ability to block, log, modify, or inject traffic into the communication stream. There are several ways to accomplish this attack, but some of the most-common are Address Resolution Protocol (ARP) poisoning and the use of a proxy. (Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)  \n\nAn AiTM attack may allow an adversary to perform the following attacks:  \n[Block Reporting Message](https://attack.mitre.org/techniques/T0804), [Spoof Reporting Message](https://attack.mitre.org/techniques/T0856), [Modify Parameter](https://attack.mitre.org/techniques/T0836), [Unauthorized Command Message](https://attack.mitre.org/techniques/T0855)",
+      "meta": {
+        "external_id": "T0830",
+        "kill_chain": [
+          "ics-attack:collection"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T0830",
+          "https://www.sans.org/reading-room/whitepapers/ICS/man-in-the-middle-attack-modbus-tcp-illustrated-wireshark-38095"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+      "value": "Adversary-in-the-Middle - T0830"
+    },
+    {
       "description": "Adversaries may attempt to position themselves between two or more networked devices to support follow-on behaviors such as [Transmitted Data Manipulation](https://attack.mitre.org/techniques/T1565/002) or [Endpoint Denial of Service](https://attack.mitre.org/techniques/T1642).  \n\n \n\n[Adversary-in-the-Middle](https://attack.mitre.org/techniques/T1638) can be achieved through several mechanisms. For example, a malicious application may register itself as a VPN client, effectively redirecting device traffic to adversary-owned resources. Registering as a VPN client requires user consent on both Android and iOS; additionally, a special entitlement granted by Apple is needed for iOS devices. Alternatively, a malicious application with escalation privileges may utilize those privileges to gain access to network traffic.   \n\n\n Specific to Android devices, adversary-in-the-disk is a type of AiTM attack where adversaries monitor and manipulate data that is exchanged between applications and external storage.(Citation: mitd_kaspersky)(Citation: mitd_checkpoint)(Citation: mitd_checkpoint_research) To accomplish this, a malicious application firsts requests for access to multimedia files on the device (`READ_EXTERNAL STORAGE` and `WRITE_EXTERNAL_STORAGE`), then the application reads data on the device and/or writes malware to the device. Though the request for access is common, when used maliciously, adversaries may access files and other sensitive data due to abusing the permission. Multiple applications were shown to be vulnerable against this attack; however, scrutiny of permissions and input validations may mitigate this attack.    \n\nOutside of a mobile device, adversaries may be able to capture traffic by employing a rogue base station or Wi-Fi access point. These devices will allow adversaries to capture network traffic after it has left the device, while it is flowing to its destination. On a local network, enterprise techniques could be used, such as [ARP Cache Poisoning](https://attack.mitre.org/techniques/T1557/002) or [DHCP Spoofing](https://attack.mitre.org/techniques/T1557/003).  \n\n \n\nIf applications properly encrypt their network traffic, sensitive data may not be accessible to adversaries, depending on the point of capture. For example, properly implementing Apple’s Application Transport Security (ATS) and Android’s Network Security Configuration (NSC) may prevent sensitive data leaks.(Citation: NSC_Android)",
       "meta": {
         "external_id": "T1638",
@@ -32331,6 +37532,99 @@
       ],
       "uuid": "34f1d81d-fe88-4f97-bd3b-a3164536255d",
       "value": "Add-ins - T1137.006"
+    },
+    {
+      "description": "Adversaries may block access to Wi-Fi communications to prevent messages from reaching target systems and devices. Wi-Fi connections allow for communications between IT and OT systems and devices. Blocking Wi-Fi communications may also block command and reporting messages.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)\n\nAn adversary may block Wi-Fi communications by disabling network interfaces, [Service Stop](https://attack.mitre.org/techniques/T0881), conducting an [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) attack and dropping the network traffic, or by jamming the Wi-Fi signal.\n",
+      "meta": {
+        "external_id": "T1695.003",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T1695/003"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "71f2d49e-65dd-4fb6-a4cc-0d2b19d427fa",
+      "value": "Wi-Fi - T1695.003"
     },
     {
       "description": "Adversaries may abuse Regsvcs and Regasm to proxy execution of code through a trusted Windows utility. Regsvcs and Regasm are Windows command-line utilities that are used to register .NET [Component Object Model](https://attack.mitre.org/techniques/T1559/001) (COM) assemblies. Both are binaries that may be digitally signed by Microsoft. (Citation: MSDN Regsvcs) (Citation: MSDN Regasm)\n\nBoth utilities may be used to bypass application control through use of attributes within the binary to specify code that should be run before registration or unregistration: <code>[ComRegisterFunction]</code> or <code>[ComUnregisterFunction]</code> respectively. The code with the registration and unregistration attributes will be executed even if the process is run under insufficient privileges and fails to execute. (Citation: LOLBAS Regsvcs)(Citation: LOLBAS Regasm)",
@@ -34148,6 +39442,99 @@
       "value": "Screensaver - T1546.002"
     },
     {
+      "description": "Adversaries may block access to Ethernet communications to prevent instructions or configurations messages from reaching target systems and devices. Ethernet connections allow for communications between IT and OT systems and devices. Blocking Ethernet communications may also block command and reporting messages.(Citation: Bonnie Zhu, Anthony Joseph, Shankar Sastry 2011)\n\nAn adversary may block Ethernet communications by disabling network interfaces, [Service Stop](https://attack.mitre.org/techniques/T0881), or conducting an [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T0830) attack and dropping the network traffic.\n",
+      "meta": {
+        "external_id": "T1695.002",
+        "kill_chain": [
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258",
+          "https://attack.mitre.org/techniques/T1695/002"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "subtechnique-of"
+        }
+      ],
+      "uuid": "6008c1f0-1b68-4614-8f5b-a547436b8855",
+      "value": "Ethernet - T1695.002"
+    },
+    {
       "description": "Adversaries may search public WHOIS data for information about victims that can be used during targeting. WHOIS data is stored by regional Internet registries (RIR) responsible for allocating and assigning Internet resources such as domain names. Anyone can query WHOIS servers for information about a registered domain, such as assigned IP blocks, contact information, and DNS nameservers.(Citation: WHOIS)\n\nAdversaries may search WHOIS data to gather actionable information. Threat actors can use online resources or command-line utilities to pillage through WHOIS data for information about potential victims. Information from these sources may reveal opportunities for other forms of reconnaissance (ex: [Active Scanning](https://attack.mitre.org/techniques/T1595) or [Phishing for Information](https://attack.mitre.org/techniques/T1598)), establishing operational resources (ex: [Acquire Infrastructure](https://attack.mitre.org/techniques/T1583) or [Compromise Infrastructure](https://attack.mitre.org/techniques/T1584)), and/or initial access (ex: [External Remote Services](https://attack.mitre.org/techniques/T1133) or [Trusted Relationship](https://attack.mitre.org/techniques/T1199)).",
       "meta": {
         "external_id": "T1596.002",
@@ -34961,6 +40348,17 @@
       "value": "Regsvcs/Regasm - T1121"
     },
     {
+      "description": "The adversary is trying to gather data of interest and domain knowledge on your ICS environment to inform their goal.\n\nCollection consists of techniques adversaries use to gather domain knowledge and obtain contextual feedback in an ICS environment. This tactic is often performed as part of [Discovery](https://attack.mitre.org/tactics/TA0102), to compile data on control systems and targets of interest that may be used to follow through on the adversary’s objective. Examples of these techniques include observing operation states, capturing screenshots, identifying unique device roles, and gathering system and diagram schematics. Collection of this data can play a key role in planning, executing, and even revising an ICS-targeted attack. Methods of collection depend on the categories of data being targeted, which can include protocol specific, device specific, and process specific configurations and functionality. Information collected may pertain to a combination of system, supervisory, device, and network related data, which conceptually fall under high, medium, and low levels of plan operations. For example, information repositories on plant data at a high level or device specific programs at a low level. Sensitive floor plans, vendor device manuals, and other references may also be at risk and exposed on the internet or otherwise publicly accessible.",
+      "meta": {
+        "external_id": "TA0100",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0100"
+        ]
+      },
+      "uuid": "b2a67b1e-913c-46f6-b219-048a90560bb9",
+      "value": "Collection - TA0100"
+    },
+    {
       "description": "The adversary is trying to steal data.\n\nExfiltration consists of techniques that adversaries may use to steal data from your network. Once they’ve collected data, adversaries often package it to avoid detection while removing it. This can include compression and encryption. Techniques for getting data out of a target network typically include transferring it over their command and control channel or an alternate channel and may also include putting size limits on the transmission.",
       "meta": {
         "external_id": "TA0010",
@@ -35038,6 +40436,39 @@
       "value": "Collection - TA0009"
     },
     {
+      "description": "The adversary is trying to maintain their foothold in your ICS environment.\n\nPersistence consists of techniques that adversaries use to maintain access to ICS systems and devices across restarts, changed credentials, and other interruptions that could cut off their access. Techniques used for persistence include any access, action, or configuration changes that allow them to secure their ongoing activity and keep their foothold on systems. This may include replacing or hijacking legitimate code, firmware, and other project files, or adding startup code and downloading programs onto devices.",
+      "meta": {
+        "external_id": "TA0110",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0110"
+        ]
+      },
+      "uuid": "78f1d2ae-a579-44c4-8fc5-3e1775c73fac",
+      "value": "Persistence - TA0110"
+    },
+    {
+      "description": "The adversary is locating information to assess and identify their targets in your environment.\n\nDiscovery consists of techniques that adversaries use to survey your ICS environment and gain knowledge about the internal network, control system devices, and how their processes interact. These techniques help adversaries observe the environment and determine next steps for target selection and Lateral Movement. They also allow adversaries to explore what they can control and gain insight on interactions between various control system processes. Discovery techniques are often an act of progression into the environment which enable the adversary to orient themselves before deciding how to act. Adversaries may use Discovery techniques that result in Collection, to help determine how available resources benefit their current objective. A combination of native device communications and functions, and custom tools are often used toward this post-compromise information-gathering objective.",
+      "meta": {
+        "external_id": "TA0102",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0102"
+        ]
+      },
+      "uuid": "696af733-728e-49d7-8261-75fdc590f453",
+      "value": "Discovery - TA0102"
+    },
+    {
+      "description": "The adversary is trying to avoid security defenses.\n\nEvasion consists of techniques that adversaries use to avoid technical defenses throughout their campaign. Techniques used for evasion include removal of indicators of compromise, spoofing communications, and exploiting software vulnerabilities. Adversaries may also leverage and abuse trusted devices and processes to hide their activity, possibly by masquerading as master devices or native software. Methods of defense evasion for this purpose are often more passive in nature.",
+      "meta": {
+        "external_id": "TA0103",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0103"
+        ]
+      },
+      "uuid": "ddf70682-f3ce-479c-a9a4-7eadf9bfead7",
+      "value": "Evasion - TA0103"
+    },
+    {
       "description": "The adversary is trying to run malicious code.\n\nExecution consists of techniques that result in adversary-controlled code running on a mobile device. Techniques that run malicious code are often paired with techniques from all other tactics to achieve broader goals, like exploring a network or stealing data.",
       "meta": {
         "external_id": "TA0041",
@@ -35047,6 +40478,28 @@
       },
       "uuid": "4a800987-a3a8-4d56-a1bd-0d7171431756",
       "value": "Execution - TA0041"
+    },
+    {
+      "description": "The adversary is trying to run code or manipulate system functions, parameters, and data in an unauthorized way.\n\nExecution consists of techniques that result in adversary-controlled code running on a local or remote system, device, or other asset. This execution may also rely on unknowing end users or the manipulation of device operating modes to run. Adversaries may infect remote targets with programmed executables or malicious project files that operate according to specified behavior and may alter expected device behavior in subtle ways. Commands for execution may also be issued from command-line interfaces, APIs, GUIs, or other available interfaces. Techniques that run malicious code may also be paired with techniques from other tactics, particularly to aid network [Discovery](https://attack.mitre.org/tactics/TA0102) and [Collection](https://attack.mitre.org/tactics/TA0100), impact operations, and inhibit response functions.",
+      "meta": {
+        "external_id": "TA0104",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0104"
+        ]
+      },
+      "uuid": "93bf9a8e-b14c-4587-b6d5-9efc7c12eb45",
+      "value": "Execution - TA0104"
+    },
+    {
+      "description": "The adversary is trying to manipulate, interrupt, or destroy your ICS systems, data, and their surrounding environment.\n\nImpact consists of techniques that adversaries use to disrupt, compromise, destroy, and manipulate the integrity and availability of control system operations, processes, devices, and data. These techniques encompass the influence and effects resulting from adversarial efforts to attack the ICS environment or that tangentially impact it. Impact techniques can result in more instantaneous disruption to control processes and the operator, or may result in more long term damage or loss to the ICS environment and related operations. The adversary may leverage [Impair Process Control](https://attack.mitre.org/tactics/TA0106) techniques, which often manifest in more self-revealing impacts on operations, or [Impair Process Control](https://attack.mitre.org/tactics/TA0106) techniques to hinder safeguards and alarms in order to follow through with and provide cover for Impact. In some scenarios, control system processes can appear to function as expected, but may have been altered to benefit the adversary’s goal over the course of a longer duration. These techniques might be used by adversaries to follow through on their end goal or to provide cover for a confidentiality breach.\n\n[Loss of Productivity and Revenue](https://attack.mitre.org/techniques/T0828), [Theft of Operational Information](https://attack.mitre.org/techniques/T0882), and [Damage to Property](https://attack.mitre.org/techniques/T0879) are meant to encompass some of the more granular goals of adversaries in targeted and untargeted attacks. These techniques in and of themselves are not necessarily detectable, but the associated adversary behavior can potentially be mitigated and/or detected.",
+      "meta": {
+        "external_id": "TA0105",
+        "refs": [
+          "https://attack.mitre.org/tactics/TA0105"
+        ]
+      },
+      "uuid": "77542f83-70d0-40c2-8a9d-ad2eb8b00279",
+      "value": "Impact - TA0105"
     },
     {
       "description": "Adversaries may use a connection proxy to direct network traffic between systems or act as an intermediary for network communications to a command and control server to avoid direct connections to their infrastructure. Many tools exist that enable traffic redirection through proxies or port redirection, including [HTRAN](https://attack.mitre.org/software/S0040), ZXProxy, and ZXPortMap. (Citation: Trend Micro APT Attack Tools) Adversaries use these types of proxies to manage command and control communications, reduce the number of simultaneous outbound network connections, provide resiliency in the face of connection loss, or to ride over existing trusted communications paths between victims to avoid suspicion. Adversaries may chain together multiple proxies to further disguise the source of malicious traffic.\n\nAdversaries can also take advantage of routing schemes in Content Delivery Networks (CDNs) to proxy command and control traffic.",
@@ -35385,6 +40838,88 @@
       "value": "Scripting - T1064"
     },
     {
+      "description": "Adversaries may deploy rootkits to hide the presence of programs, files, network connections, services, drivers, and other system components. Rootkits are programs that hide the existence of malware by intercepting and modifying operating-system API calls that supply system information. Rootkits or rootkit-enabling functionality may reside at the user or kernel level in the operating system, or lower. (Citation: Enterprise ATT&CK January 2018)   \n\nFirmware rootkits that affect the operating system yield nearly full control of the system. While firmware rootkits are normally developed for the main processing board, they can also be developed for the I/O that is attached to an asset. Compromise of this firmware allows the modification of all of the process variables and functions the module engages in. This may result in commands being disregarded and false information being fed to the main device. By tampering with device processes, an adversary may inhibit its expected response functions and possibly enable [Impact](https://attack.mitre.org/tactics/TA0105).",
+      "meta": {
+        "external_id": "T0851",
+        "kill_chain": [
+          "ics-attack:evasion",
+          "ics-attack:inhibit-response-function"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0851",
+          "https://attack.mitre.org/wiki/Technique/T1014"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "2b676abd-8263-49ea-81a4-78a7e1f776fe",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9",
+      "value": "Rootkit - T0851"
+    },
+    {
       "description": "Adversaries may send malicious content to users in order to gain access to their mobile devices. All forms of phishing are electronically delivered social engineering. Adversaries can conduct both non-targeted phishing, such as in mass malware spam campaigns, as well as more targeted phishing tailored for a specific individual, company, or industry, known as “spearphishing.” Phishing often involves social engineering techniques, such as posing as a trusted source, as well as evasion techniques, such as removing or manipulating emails or metadata/headers from compromised accounts being abused to send messages.\n\nMobile phishing may take various forms. For example, adversaries may send emails containing malicious attachments or links, typically to deliver and then execute malicious code on victim devices. Phishing may also be conducted via third-party services, like social media platforms. Adversaries may also impersonate executives of organizations to persuade victims into performing some action on their behalf. For example, adversaries will often use social engineering techniques in text messages to trick the victims into acting quickly, which leads to adversaries obtaining credentials and other information. \n\nMobile devices are a particularly attractive target for adversaries executing phishing campaigns.  Due to their smaller form factor than traditional desktop endpoints, users may not be able to notice minor differences between genuine and phishing websites. Further, mobile devices have additional sensors and radios that allow adversaries to execute phishing attempts over several different vectors, such as: \n\n- SMS messages: Adversaries may send SMS messages (known as “smishing”) from compromised devices to potential targets to convince the target to, for example, install malware, navigate to a specific website, or enable certain insecure configurations on their device.\n- Quick Response (QR) Codes: Adversaries may use QR codes (known as “quishing”) to redirect users to a phishing website. For example, an adversary could replace a legitimate public QR Code with one that leads to a different destination, such as a phishing website. A malicious QR code could also be delivered via other means, such as SMS or email. In the latter case, an adversary could utilize a malicious QR code in an email to pivot from the user’s desktop computer to their mobile device.\n- Phone Calls: Adversaries may call victims (known as \"vishing\") to persuade them to perform an action, such as providing login credentials or navigating to malicious websites. Common vishing targets include employees, especially executives of organizations, and help desks. This may also be used as a technique to perform the initial access on a mobile device, but then pivot to a desktop computer by having the victims perform actions on a desktop computer. With the rise of artificial intelligence (AI), adversaries may also use AI to clone a person’s voice, resulting in deepfake vishing. The cloned voice provides familiarity to the victims, increasing the likelihood of successful malicious actions performed by the victims. Additionally, adversaries may leave voicemails, which may use a real person’s voice or an AI-generated voice; these scams would urgently ask victims into calling back to perform an action, e.g. sending money or providing sensitive information and credentials.\n",
       "meta": {
         "external_id": "T1660",
@@ -35492,6 +41027,189 @@
       "revoked": true,
       "uuid": "128c55d3-aeba-469f-bd3e-c8996ab4112a",
       "value": "Timestomp - T1099"
+    },
+    {
+      "description": "Adversaries may use scripting languages to execute arbitrary code in the form of a pre-written script or in the form of user-supplied code to an interpreter. Scripting languages are programming languages that differ from compiled languages, in that scripting languages use an interpreter, instead of a compiler. These interpreters read and compile part of the source code just before it is executed, as opposed to compilers, which compile each and every line of code to an executable file. Scripting allows software developers to run their code on any system where the interpreter exists. This way, they can distribute one package, instead of precompiling executables for many different systems. Scripting languages, such as Python, have their interpreters shipped as a default with many Linux distributions. \n\nIn addition to being a useful tool for developers and administrators, scripting language interpreters may be abused by the adversary to execute code in the target environment. Due to the nature of scripting languages, this allows for weaponized code to be deployed to a target easily, and leaves open the possibility of on-the-fly scripting to perform a task.",
+      "meta": {
+        "external_id": "T0853",
+        "kill_chain": [
+          "ics-attack:execution"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0853"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+      "value": "Scripting - T0853"
+    },
+    {
+      "description": "Adversaries may hook into application programming interface (API) functions used by processes to redirect calls for execution and privilege escalation means. Windows processes often leverage these API functions to perform tasks that require reusable system resources. Windows API functions are typically stored in dynamic-link libraries (DLLs) as exported functions. (Citation: Enterprise ATT&CK)\n\nOne type of hooking seen in ICS involves redirecting calls to these functions via import address table (IAT) hooking. IAT hooking uses modifications to a process IAT, where pointers to imported API functions are stored. (Citation: Nicolas Falliere, Liam O Murchu, Eric Chien February 2011)",
+      "meta": {
+        "external_id": "T0874",
+        "kill_chain": [
+          "ics-attack:execution",
+          "ics-attack:privilege-escalation"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0874",
+          "https://attack.mitre.org/techniques/T1179/",
+          "https://docs.broadcom.com/doc/security-response-w32-stuxnet-dossier-11-en"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0804f037-a3b9-4715-98e1-9f73d19d6945",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "459e4335-74e1-4136-b730-0f116f0d541d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "85f285f9-0a48-4998-921d-8a47d81c0e6d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb141168-ae41-4974-8ece-dc9b63e59237",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "bb553fda-8355-40bc-87c6-5ae25124fa95",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "dcb1d1c1-b195-45bf-b4cf-5b98c5b859a5",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+      "value": "Hooking - T0874"
+    },
+    {
+      "description": "Adversaries may use masquerading to disguise a malicious application or executable as another file, to avoid operator and engineer suspicion. Possible disguises of these masquerading files can include commonly found programs, expected vendor executables and configuration files, and other commonplace application and naming conventions. By impersonating expected and vendor-relevant files and applications, operators and engineers may not notice the presence of the underlying malicious content and possibly end up running those masquerading as legitimate functions. \n\nApplications and other files commonly found on Windows systems or in engineering workstations have been impersonated before. This can be as simple as renaming a file to effectively disguise it in the ICS environment.",
+      "meta": {
+        "external_id": "T0849",
+        "kill_chain": [
+          "ics-attack:evasion"
+        ],
+        "refs": [
+          "https://attack.mitre.org/techniques/T0849"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "14932ed5-1098-4cc1-9f57-159ab7366787",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "973bc51e-c41e-4cec-ac03-9389c71f3d0d",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "targets"
+        },
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "targets"
+        }
+      ],
+      "uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+      "value": "Masquerading - T0849"
     },
     {
       "description": "Regsvr32.exe is a command-line program used to register and unregister object linking and embedding controls, including dynamic link libraries (DLLs), on Windows systems. Regsvr32.exe can be used to execute arbitrary binaries. (Citation: Microsoft Regsvr32)\n\nAdversaries may take advantage of this functionality to proxy execution of code to avoid triggering security tools that may not monitor execution of, and modules loaded by, the regsvr32.exe process because of whitelists or false positives from Windows using regsvr32.exe for normal operations. Regsvr32.exe is also a Microsoft signed binary.\n\nRegsvr32.exe can also be used to specifically bypass process whitelisting using functionality to load COM scriptlets to execute DLLs under user permissions. Since regsvr32.exe is network and proxy aware, the scripts can be loaded by passing a uniform resource locator (URL) to file on an external Web server as an argument during invocation. This method makes no changes to the Registry as the COM object is not actually registered, only executed. (Citation: LOLBAS Regsvr32) This variation of the technique is often referred to as a \"Squiblydoo\" attack and has been used in campaigns targeting governments. (Citation: Carbon Black Squiblydoo Apr 2016) (Citation: FireEye Regsvr32 Targeting Mongolian Gov)\n\nRegsvr32.exe can also be leveraged to register a COM Object used to establish Persistence via [Component Object Model Hijacking](https://attack.mitre.org/techniques/T1122). (Citation: Carbon Black Squiblydoo Apr 2016)",
@@ -36050,5 +41768,5 @@
       "value": "Keychain - T1579"
     }
   ],
-  "version": 39
+  "version": 41
 }

--- a/clusters/mitre-campaign.json
+++ b/clusters/mitre-campaign.json
@@ -157,7 +157,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "2959d63f-73fd-46a1-abd2-109d7dcede32",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
           "type": "uses"
         },
         {
@@ -197,7 +205,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "bf90d72c-c00b-45e3-b3aa-68560560d4c5",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
           "type": "uses"
         },
         {
@@ -221,11 +237,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "e358d692-23c0-4a31-9eb6-ecc13a8d7735",
           "type": "uses"
         },
         {
           "dest-uuid": "e401d4fe-f0c9-44f0-98e6-f93487678808",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
           "type": "uses"
         },
         {
@@ -262,7 +286,23 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "232b7f21-adf9-4b42-b936-b9d6f7df856e",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
           "type": "uses"
         },
         {
@@ -286,7 +326,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "57340c81-c025-4189-8fa0-fc7ede51bae4",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
           "type": "uses"
         },
         {
@@ -294,7 +346,27 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b0628bfc-5376-4a38-9182-f324501cb4cf",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "b17a1a56-e99c-403c-8948-561df0cffe81",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
           "type": "uses"
         },
         {
@@ -306,7 +378,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "d63a3fb8-9452-4e9d-a60a-54be68d5998c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
           "type": "uses"
         },
         {
@@ -318,7 +402,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "e221eb77-1502-4129-af1d-fe1ad55e7ec6",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
           "type": "uses"
         },
         {
@@ -327,6 +419,14 @@
         },
         {
           "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
           "type": "uses"
         }
       ],
@@ -352,8 +452,24 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "1c5cf58c-a34a-40d7-82f4-f987cdfc2b91",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "381fcf73-60f6-4ab2-9991-6af3cbc35192",
           "type": "attributed-to"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "uses"
         },
         {
           "dest-uuid": "4fe28b27-b13c-453e-a386-c2ef362a573b",
@@ -365,6 +481,10 @@
         },
         {
           "dest-uuid": "5d2be8b9-d24c-4e98-83bf-2f5f79477163",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "77d9c726-b53e-481d-8bcc-1068aebfbb9d",
           "type": "uses"
         },
         {
@@ -427,6 +547,30 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "65f2d882-3f41-4d48-8a06-29af77ec9f90",
           "type": "uses"
         },
@@ -451,6 +595,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "a2fdce72-04b2-409a-ac10-cc1695f4fce0",
           "type": "uses"
         },
@@ -464,6 +612,18 @@
         },
         {
           "dest-uuid": "b8902400-e6c5-4ba2-95aa-2d35b442b118",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
           "type": "uses"
         }
       ],
@@ -611,6 +771,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "149b477f-f364-4824-b1b5-aa1d56115869",
           "type": "uses"
         },
@@ -635,11 +799,23 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "26c87906-d750-42c5-946c-d4162c73fc7b",
           "type": "uses"
         },
         {
           "dest-uuid": "2e45723a-31da-4a7e-aaa6-e01998a6788f",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
           "type": "uses"
         },
         {
@@ -683,6 +859,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "506f6f49-7045-4156-9007-7474cb44ad6d",
           "type": "uses"
         },
@@ -691,11 +871,23 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "5d2be8b9-d24c-4e98-83bf-2f5f79477163",
           "type": "uses"
         },
         {
           "dest-uuid": "65f2d882-3f41-4d48-8a06-29af77ec9f90",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
           "type": "uses"
         },
         {
@@ -727,6 +919,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "8f4a33ec-8b1f-4b80-a2f6-642b2e479580",
           "type": "uses"
         },
@@ -739,7 +935,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "a9d4b653-6915-42af-98b2-5758c4ceee56",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b0628bfc-5376-4a38-9182-f324501cb4cf",
           "type": "uses"
         },
         {
@@ -759,6 +963,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "be055942-6e63-49d7-9fa1-9cb7d8a8f3f4",
           "type": "uses"
         },
@@ -771,11 +979,31 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "c55f0be5-044e-4577-8095-65b37680d28c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "d1fcf083-a721-4223-aedf-bf8960798d62",
           "type": "uses"
         },
         {
           "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
           "type": "uses"
         },
         {
@@ -796,6 +1024,14 @@
         },
         {
           "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
           "type": "uses"
         },
         {
@@ -824,6 +1060,10 @@
         },
         {
           "dest-uuid": "f9cc4d06-775f-4ee1-b401-4e2cc0da30ba",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "fab8fc7d-f27f-4fbb-9de6-44740aade05f",
           "type": "uses"
         },
         {
@@ -1337,7 +1577,56 @@
           "Maroochy Water Breach"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "uses"
+        }
+      ],
       "uuid": "70cab19e-1745-425e-b3db-c02cd5ff157a",
       "value": "Maroochy Water Breach - C0020"
     },
@@ -1357,8 +1646,32 @@
       },
       "related": [
         {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "a07a367a-146c-45a8-a830-d3d337b9befa",
           "type": "attributed-to"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f8df6b57-14bc-425f-9a91-6f59f6799307",
+          "type": "uses"
         }
       ],
       "uuid": "8fda050f-470d-4401-994e-35c1a6c301de",
@@ -3334,6 +3647,14 @@
       },
       "related": [
         {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "1644e709-12d2-41e5-a60f-3470991f5011",
           "type": "uses"
         },
@@ -3354,7 +3675,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "b34df04a-9d30-4d84-a03f-0d536ee19a05",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
           "type": "uses"
         }
       ],
@@ -6663,5 +6992,5 @@
       "value": "RedPenguin - C0056"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/clusters/mitre-course-of-action.json
+++ b/clusters/mitre-course-of-action.json
@@ -483,6 +483,68 @@
       "value": "Custom Command and Control Protocol Mitigation - T1094"
     },
     {
+      "description": "Remove or deny access to unnecessary and potentially vulnerable software to prevent abuse by adversaries.",
+      "meta": {
+        "external_id": "M0942",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0942"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "d0909119-2f71-4923-87db-b649881672d7",
+      "value": "Disable or Remove Feature or Program - M0942"
+    },
+    {
+      "description": "Prevent access to file shares, remote access to systems, unnecessary services. Mechanisms to limit access may include use of network concentrators, RDP gateways, etc.",
+      "meta": {
+        "external_id": "M0935",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0935"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "49b306c1-a046-42c5-a4d2-30f264ada110",
+      "value": "Limit Access to Resource Over Network - M0935"
+    },
+    {
       "description": "This type of attack technique cannot be easily mitigated with preventive controls since it is based on the abuse of operating system design features. For example, mitigating all IFEO will likely have unintended side effects, such as preventing legitimate software (i.e., security products) from operating properly. (Citation: Microsoft IFEOorMalware July 2015) Efforts should be focused on preventing adversary tools from running earlier in the chain of activity and on identifying subsequent malicious behavior.\n\nIdentify and block potentially malicious software that may be executed through IFEO by using whitelisting (Citation: Beechey 2010) tools, like AppLocker, (Citation: Windows Commands JPCERT) (Citation: NSA MS AppLocker) that are capable of auditing and/or blocking unknown executables.",
       "meta": {
         "external_id": "T1183",
@@ -1045,6 +1107,107 @@
       "value": "Communication Through Removable Media Mitigation - T1092"
     },
     {
+      "description": "Require the authentication of devices and software processes where appropriate. Devices that connect remotely to other systems should require strong authentication to prevent spoofing of communications. Furthermore, software processes should also require authentication when accessing APIs.",
+      "meta": {
+        "external_id": "M0813",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0813"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "72e46e53-e12d-4106-9c70-33241b6ed549",
+      "value": "Software Process and Device Authentication - M0813"
+    },
+    {
       "description": "File system activity is a common part of an operating system, so it is unlikely that mitigation would be appropriate for this technique. It may still be beneficial to identify and block unnecessary system utilities or potentially malicious software by using whitelisting (Citation: Beechey 2010) tools, like AppLocker, (Citation: Windows Commands JPCERT) (Citation: NSA MS AppLocker) or Software Restriction Policies (Citation: Corio 2008) where appropriate. (Citation: TechNet Applocker vs SRP)",
       "meta": {
         "external_id": "T1083",
@@ -1161,6 +1324,43 @@
       "value": "Exploitation for Privilege Escalation Mitigation - T1068"
     },
     {
+      "description": "This type of attack technique cannot be easily mitigated with preventative controls since it is based on the abuse of system features.",
+      "meta": {
+        "external_id": "M0816",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0816"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "36e9f5bc-ac13-4da4-a2f4-01f4877d9004",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "53a48c74-0025-45f4-b04a-baa853df8204",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b0628bfc-5376-4a38-9182-f324501cb4cf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "469b78dd-a54d-4f7c-8c3b-4a1dd916b433",
+      "value": "Mitigation Limited or Not Effective - M0816"
+    },
+    {
       "description": "Remove users from the local administrator group on systems. Although UAC bypass techniques exist, it is still prudent to use the highest enforcement level for UAC when possible and mitigate bypass opportunities that exist with techniques such as [DLL Search Order Hijacking](https://attack.mitre.org/techniques/T1038). \n\nCheck for common UAC bypass weaknesses on Windows systems to be aware of the risk posture and address issues where appropriate. (Citation: Github UACMe)",
       "meta": {
         "external_id": "T1088",
@@ -1172,6 +1372,55 @@
       "related": [],
       "uuid": "beb45abb-11e8-4aef-9778-1f9ac249784f",
       "value": "Bypass User Account Control Mitigation - T1088"
+    },
+    {
+      "description": "Restrict access by setting directory and file permissions that are not specific to users or privileged accounts.",
+      "meta": {
+        "external_id": "M0922",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0922"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "f9fcb3ec-6de0-4559-8cd9-ef1c0c7d1971",
+      "value": "Restrict File and Directory Permissions - M0922"
     },
     {
       "description": "Update software regularly by employing patch management for internal enterprise endpoints and servers. Develop a robust cyber threat intelligence capability to determine what types and levels of threat may use software exploits and 0-days against a particular organization. Make it difficult for adversaries to advance their operation through exploitation of undiscovered or unpatched vulnerabilities by using sandboxing, if available. Other types of virtualization and application microsegmentation may also mitigate the impact of some types of exploitation. The risks of additional exploits and weaknesses in implementation may still exist. (Citation: Ars Technica Pwn2Own 2017 VM Escape)\n\nSecurity applications that look for behavior used during exploitation such as Windows Defender Exploit Guard (WDEG) and the Enhanced Mitigation Experience Toolkit (EMET) can be used to mitigate some exploitation behavior. (Citation: TechNet Moving Beyond EMET) Control flow integrity checking is another way to potentially identify and stop a software exploit from occurring. (Citation: Wikipedia Control Flow Integrity) Many of these protections depend on the architecture and target application binary for compatibility and may not work for software targeted for defense evasion.",
@@ -1902,6 +2151,29 @@
       "value": "Taint Shared Content Mitigation - T1080"
     },
     {
+      "description": "Wireless signals frequently propagate outside of organizational boundaries, which provide opportunities for adversaries to monitor or gain unauthorized access to the wireless network. (Citation: CISA March 2010) To minimize this threat, organizations should implement measures to detect, understand, and reduce unnecessary RF propagation. (Citation: DHS  National Urban Security Technology Laboratory April 2019)",
+      "meta": {
+        "external_id": "M0806",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0806",
+          "https://us-cert.cisa.gov/ncas/tips/ST05-003",
+          "https://www.dhs.gov/sites/default/files/saver-msr-rf-detection_cod-508_10july2019.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0fe075d5-beac-4d02-b93e-0f874997db72",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "fce6866f-9a87-4d3e-a73c-f02d8937fe0e",
+      "value": "Minimize Wireless Signal Propagation - M0806"
+    },
+    {
       "description": "Windows 8.1, Windows Server 2012 R2, and later versions may make LSA run as a Protected Process Light (PPL) by setting the Registry key <code>HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\RunAsPPL</code>, which requires all SSP DLLs to be signed by Microsoft. (Citation: Graeber 2014) (Citation: Microsoft Configure LSA)",
       "meta": {
         "external_id": "T1101",
@@ -2393,6 +2665,43 @@
       "value": "Disabling Security Tools Mitigation - T1089"
     },
     {
+      "description": "Restrict the execution of code to a virtual environment on or in-transit to an endpoint system.",
+      "meta": {
+        "external_id": "M0948",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0948"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "059ba11e-e3dc-49aa-84ca-88197f40d4ea",
+      "value": "Application Isolation and Sandboxing - M0948"
+    },
+    {
       "description": "Prevent files from having a trailing space after the extension.",
       "meta": {
         "external_id": "T1151",
@@ -2760,6 +3069,85 @@
       "value": "Out-of-Band Communications Channel - M1060"
     },
     {
+      "description": "Have alternative methods to support communication requirements during communication failures and data integrity attacks. (Citation: National Institute of Standards and Technology April 2013) (Citation: Defense Advanced Research Projects Agency)",
+      "meta": {
+        "external_id": "M0810",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0810",
+          "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf",
+          "https://www.darpa.mil/program/rapid-attack-detection-isolation-and-characterization-systems"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "338f4364-2269-4f70-9079-b20384b16628",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "6008c1f0-1b68-4614-8f5b-a547436b8855",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "71f2d49e-65dd-4fb6-a4cc-0d2b19d427fa",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "b11cad63-ef30-4eb8-af0d-6cc46eef3f3e",
+      "value": "Out-of-Band Communications Channel - M0810"
+    },
+    {
       "description": "Disable LLMNR and NetBIOS in local computer security settings or by group policy if they are not needed within an environment. (Citation: ADSecurity Windows Secure Baseline)\n\nUse host-based security software to block LLMNR/NetBIOS traffic. Enabling SMB Signing can stop NTLMv2 relay attacks.(Citation: byt3bl33d3r NTLM Relaying)(Citation: Secure Ideas SMB Relay)(Citation: Microsoft SMB Packet Signing)",
       "meta": {
         "external_id": "T1171",
@@ -2936,6 +3324,31 @@
       "related": [],
       "uuid": "160af6af-e733-4b6a-a04a-71c620ac0930",
       "value": "Third-party Software Mitigation - T1072"
+    },
+    {
+      "description": "Restrict use of certain websites, block downloads/attachments, block Javascript, restrict browser extensions, etc.",
+      "meta": {
+        "external_id": "M0921",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0921"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "143b4398-3222-480a-b6a4-e131bc2d3144",
+      "value": "Restrict Web-Based Content - M0921"
     },
     {
       "description": "Update software regularly. Install software in write-protected locations. Use the program sxstrace.exe that is included with Windows along with manual inspection to check manifest files for side-loading vulnerabilities in software.",
@@ -3230,6 +3643,196 @@
       ],
       "uuid": "8220b57e-c400-4525-bf69-f8edc6b389a8",
       "value": "Encrypt Network Traffic - M1009"
+    },
+    {
+      "description": "Data Loss Prevention (DLP) technologies can be used to help identify adversarial attempts to exfiltrate operational information, such as engineering plans, trade secrets, recipes, intellectual property, or process telemetry. DLP functionality may be built into other security products such as firewalls or standalone suites running on the network and host-based agents. DLP may be configured to prevent the transfer of information through corporate resources such as email, web, and physical media such as USB for host-based solutions.",
+      "meta": {
+        "external_id": "M0803",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0803"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "337c4e2a-21a7-4d9a-bfee-9efd6cebf0e5",
+      "value": "Data Loss Prevention - M0803"
+    },
+    {
+      "description": "Require user authentication before allowing access to data or accepting commands to a device. While strong multi-factor authentication is preferable, it is not always feasible within ICS environments. Performing strong user authentication also requires additional security controls and processes which are often the target of related adversarial techniques (e.g., Valid Accounts, Default Credentials). Therefore, associated ATT&CK mitigations should be considered in addition to this, including [Multi-factor Authentication](https://attack.mitre.org/mitigations/M0932), [Account Use Policies](https://attack.mitre.org/mitigations/M0936), [Password Policies](https://attack.mitre.org/mitigations/M0927), [User Account Management](https://attack.mitre.org/mitigations/M0918), [Privileged Account Management](https://attack.mitre.org/mitigations/M0926), and [User Account Control](https://attack.mitre.org/mitigations/M1052).",
+      "meta": {
+        "external_id": "M0804",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0804"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "66cfe23e-34b6-4583-b178-ed6a412db2b0",
+      "value": "Human User Authentication - M0804"
+    },
+    {
+      "description": "Utilize a layered protection design based on physical or mechanical protection systems to prevent damage to property, equipment, human safety, or the environment. Examples include interlocks, rupture disk, release values, etc. (Citation: A G Foord, W G Gulland, C R Howard, T Kellacher, W H Smith 2004) ",
+      "meta": {
+        "external_id": "M0805",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0805",
+          "https://www.icheme.org/media/9906/xviii-paper-23.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5fa00fdd-4a55-4191-94a0-564181d7fec2",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "8bc4a54e-810c-4600-8b6c-08fa8413a401",
+      "value": "Mechanical Protection Layers - M0805"
+    },
+    {
+      "description": "Utilize strong cryptographic techniques and protocols to prevent eavesdropping on network communications.",
+      "meta": {
+        "external_id": "M0808",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0808"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0fe075d5-beac-4d02-b93e-0f874997db72",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "7f153c28-e5f1-4764-88fb-eea1d9b0ad4a",
+      "value": "Encrypt Network Traffic - M0808"
+    },
+    {
+      "description": "Deploy mechanisms to protect the confidentiality of information related to operational processes, facility locations, device configurations, programs, or databases that may have information that can be used to infer organizational trade-secrets, recipes, and other intellectual property (IP).",
+      "meta": {
+        "external_id": "M0809",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0809"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "99c746d7-a08a-4169-94f9-b8c0dad716fa",
+      "value": "Operational Information Confidentiality - M0809"
     },
     {
       "description": "Set account lockout policies after a certain number of failed login attempts to prevent passwords from being guessed. \nToo strict a policy can create a denial of service condition and render environments un-usable, with all accounts being locked-out permanently. Use multifactor authentication. Follow best practices for mitigating access to [Valid Accounts](https://attack.mitre.org/techniques/T1078)\n\nRefer to NIST guidelines when creating passwords.(Citation: NIST 800-63-3)\n\nWhere possible, also enable multi factor authentication on external facing services.",
@@ -4472,6 +5075,43 @@
       "value": "Redundant Access Mitigation - T1108"
     },
     {
+      "description": "Redundancy could be provided for both critical ICS devices and services, such as back-up devices or hot-standbys.",
+      "meta": {
+        "external_id": "M0811",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0811"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fab8fc7d-f27f-4fbb-9de6-44740aade05f",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "f0f5c87a-a58d-440a-b3b5-ca679d98c6dd",
+      "value": "Redundancy of Service - M0811"
+    },
+    {
       "description": "Prevent adversary access to privileged accounts or access necessary to perform this technique.\n\nConsider removing and replacing system components suspected of being compromised.",
       "meta": {
         "external_id": "T1109",
@@ -5419,6 +6059,28 @@
       "value": "Operating System Configuration - M1028"
     },
     {
+      "description": "Utilize Safety Instrumented Systems (SIS) to provide an additional layer of protection to hazard scenarios that may cause property damage. A SIS will typically include sensors, logic solvers, and a final control element that can be used to automatically respond to an hazardous condition  (Citation: A G Foord, W G Gulland, C R Howard, T Kellacher, W H Smith 2004) . Ensure that all SISs are segmented from operational networks to prevent them from being targeted by additional adversarial behavior.",
+      "meta": {
+        "external_id": "M0812",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0812",
+          "https://www.icheme.org/media/9906/xviii-paper-23.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5fa00fdd-4a55-4191-94a0-564181d7fec2",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "da44255d-85c5-492c-baf3-ee823d44f848",
+      "value": "Safety Instrumented Systems - M0812"
+    },
+    {
       "description": "Remote Data Storage focuses on moving critical data, such as security logs and sensitive files, to secure, off-host locations to minimize unauthorized access, tampering, or destruction by adversaries. By leveraging remote storage solutions, organizations enhance the protection of forensic evidence, sensitive information, and monitoring data. This mitigation can be implemented through the following measures:\n\nCentralized Log Management:\n\n- Configure endpoints to forward security logs to a centralized log collector or SIEM.\n- Use tools like Splunk Graylog, or Security Onion to aggregate and store logs.\n- Example command (Linux): `sudo auditd | tee /var/log/audit/audit.log | nc <remote-log-server> 514`\n\nRemote File Storage Solutions:\n\n- Utilize cloud storage solutions like AWS S3, Google Cloud Storage, or Azure Blob Storage for sensitive data.\n- Ensure proper encryption at rest and access control policies (IAM roles, ACLs).\n\nIntrusion Detection Log Forwarding:\n\n- Forward logs from IDS/IPS systems (e.g., Zeek/Suricata) to a remote security information system.\n- Example for Suricata log forwarding:\n`outputs:\n  - type: syslog\n    protocol: tls\n    address: <remote-syslog-server>`\n\nImmutable Backup Configurations:\n\n- Enable immutable storage settings for backups to prevent adversaries from modifying or deleting data.\n- Example: AWS S3 Object Lock.\n\nData Encryption:\n\n- Ensure encryption for sensitive data using AES-256 at rest and TLS 1.2+ for data in transit.\nTools: OpenSSL, BitLocker, LUKS for Linux.",
       "meta": {
         "external_id": "M1029",
@@ -6017,6 +6679,23 @@
       "value": "Logon Scripts Mitigation - T1037"
     },
     {
+      "description": "This mitigation describes any guidance or training given to developers of applications to avoid introducing security weaknesses that an adversary may be able to take advantage of.",
+      "meta": {
+        "external_id": "M0913",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0913"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "8a3aadd0-b5f4-433a-800e-4893e4196bb7",
+      "value": "Application Developer Guidance - M0913"
+    },
+    {
       "description": "Restrict the modification of environment variables to authorized users and processes by enforcing strict permissions and policies. This ensures the integrity of environment variables, preventing adversaries from abusing or altering them for malicious purposes. This mitigation can be implemented through the following measures:\n\nRestrict Write Access:\n\n- Use Case: Set file system-level permissions to restrict access to environment variable configuration files (e.g., `.bashrc`, `.bash_profile`, `.zshrc`, `systemd` service files).\n- Implementation: Configure `/etc/environment` or `/etc/profile` on Linux systems to only allow root or administrators to modify the file.\n\nSecure Access Controls:\n\n- Use Case: Limit access to environment variable settings in application deployment tools or CI/CD pipelines to authorized personnel.\n- Implementation: Use role-based access control (RBAC) in tools like Jenkins or GitLab to ensure only specific users can modify environment variables.\n\nRestrict Process Scope:\n\n- Use Case: Configure policies to ensure environment variables are only accessible to the processes they are explicitly intended for.\n- Implementation: Use containerized environments like Docker to isolate environment variables to specific containers and ensure they are not inherited by other processes.\n\nAudit Environment Variable Changes:\n\n- Use Case: Enable logging for changes to critical environment variables.\n- Implementation: Use `auditd` on Linux to monitor changes to files like `/etc/environment` or application-specific environment files.",
       "meta": {
         "external_id": "M1039",
@@ -6053,6 +6732,51 @@
       "related": [],
       "uuid": "7c39ebbf-244e-4d1c-b0ac-b282453ece43",
       "value": "Process Hollowing Mitigation - T1093"
+    },
+    {
+      "description": "Use intrusion detection signatures to block traffic at network boundaries.  In industrial control environments, network intrusion prevention should be configured so it will not disrupt protocols and communications responsible for real-time functions related to control or safety.",
+      "meta": {
+        "external_id": "M0931",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0931"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "3172222b-4983-43f7-8983-753ded4f13bc",
+      "value": "Network Intrusion Prevention - M0931"
     },
     {
       "description": "Restricting library loading involves implementing security controls to ensure that only trusted and verified libraries (DLLs, shared objects, etc.) are loaded into processes. Adversaries often abuse Dynamic-Link Library (DLL) Injection, DLL Search Order Hijacking, or LD_PRELOAD mechanisms to execute malicious code by forcing the operating system to load untrusted libraries. This mitigation can be implemented through the following measures: \n\nEnforce Safe Library Loading Practices:\n\n- Enable `SafeDLLSearchMode` on Windows.\n- Restrict `LD_PRELOAD` and `LD_LIBRARY_PATH` usage on Linux systems.\n\nCode Signing Enforcement:\n\n- Require digital signatures for all libraries loaded into processes.\n- Use tools like Signtool, and WDAC to enforce signed DLL execution.\n\nEnvironment Hardening:\n\n- Secure library paths and directories to prevent adversaries from placing rogue libraries.\n- Monitor user-writable directories and system configurations for unauthorized changes.\n\nAudit and Monitor Library Loading:\n\n- Enable `Sysmon` on Windows to monitor for suspicious library loads.\n- Use `auditd` on Linux to monitor shared library paths and configuration file changes.\n\nUse Application Control Solutions:\n\n- Implement AppLocker, WDAC, or SELinux to allow only trusted libraries.\n\n*Tools for Implementation*\n\nWindows-Specific Tools:\n\n- AppLocker: Application whitelisting for DLLs.\n- Windows Defender Application Control (WDAC): Restrict unauthorized library execution.\n- Signtool: Verify and enforce code signing.\n- Sysmon: Monitor DLL load events (Event ID 7).\n\nLinux-Specific Tools:\n\n- auditd: Monitor changes to library paths and critical files.\n- SELinux/AppArmor: Define policies to restrict library loading.\n- ldconfig and chattr: Secure LD configuration files and prevent unauthorized modifications.\n\nCross-Platform Solutions:\n\n- Wazuh or OSSEC: File integrity monitoring for library changes.\n- Tripwire: Detect and alert on unauthorized library modifications.",
@@ -6122,6 +6846,63 @@
       "value": "Data Staged Mitigation - T1074"
     },
     {
+      "description": "Configure hosts and devices to use static network configurations when possible, protocols that require dynamic discovery/addressing (e.g., ARP, DHCP, DNS) can be used to manipulate network message forwarding and enable various AiTM attacks. This mitigation may not always be usable due to limited device features or challenges introduced with different network configurations.",
+      "meta": {
+        "external_id": "M0814",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0814"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "338f4364-2269-4f70-9079-b20384b16628",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "64bbc1b2-101f-4322-af1d-0c9cc25cef91",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "c55f0be5-044e-4577-8095-65b37680d28c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "52c7a1a9-3a78-4528-a44f-cd7b0fa3541a",
+      "value": "Static Network Configuration - M0814"
+    },
+    {
       "description": "This technique likely should not be mitigated with preventative controls because it may protect unintended targets from being compromised. If targeted, efforts should be focused on preventing adversary tools from running earlier in the chain of activity and on identifying subsequent malicious behavior if compromised.",
       "meta": {
         "external_id": "T1480",
@@ -6132,6 +6913,55 @@
       "related": [],
       "uuid": "c61e2da1-f51f-424c-b152-dc930d4f2e70",
       "value": "Environmental Keying Mitigation - T1480"
+    },
+    {
+      "description": "Protect sensitive data-at-rest with strong encryption.",
+      "meta": {
+        "external_id": "M0941",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0941"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "9f99fcfd-772e-4e63-9d39-e45612e546dc",
+      "value": "Encrypt Sensitive Information - M0941"
     },
     {
       "description": "The Do Not Mitigate category highlights scenarios where attempting to mitigate a specific technique may inadvertently increase the organization's security risk or operational instability. This could happen due to the complexity of the system, the integration of critical processes, or the potential for introducing new vulnerabilities. Instead of direct mitigation, these situations may call for alternative strategies such as detection, monitoring, or response. The Do Not Mitigate category underscores the importance of assessing the trade-offs between mitigation efforts and overall system integrity. This mitigation can be implemented through the following measures:\n\nComplex Systems Where Mitigation is Risky:\n\n- Interpretation: In certain systems, direct mitigation could introduce new risks, especially if the system is highly interconnected or complex, such as in legacy industrial control systems (ICS). Patching or modifying these systems could result in unplanned downtime, disruptions, or even safety risks.\n- Use Case: In a power grid control system, attempting to patch or disable certain services related to device communications might disrupt critical operations, leading to unintended service outages.\n\nRisk of Reducing Security Coverage:\n\n- Interpretation: In some cases, mitigating a technique might reduce the visibility or effectiveness of other security controls, limiting an organization’s ability to detect broader attacks.\n- Use Case: Disabling script execution on a web server to mitigate potential PowerShell-based attacks could interfere with legitimate administrative operations that rely on scripting, while attackers may still find alternate ways to execute code.\n\nIntroduction of New Vulnerabilities:\n\n- Interpretation: In highly sensitive or tightly controlled environments, implementing certain mitigations might create vulnerabilities in other parts of the system. For instance, disabling default security mechanisms in an attempt to resolve compatibility issues may open the system to exploitation.\n- Use Case: Disabling certificate validation to resolve internal communication issues in a secure environment could lead to man-in-the-middle attacks, creating a greater vulnerability than the original problem.\n\nNegative Impact on Performance and Availability:\n\n- Interpretation: Mitigations that involve removing or restricting system functionalities can have unintended consequences for system performance and availability. Some mitigations, while effective at blocking certain attacks, may introduce performance bottlenecks or compromise essential operations.\n- Use Case: Implementing high levels of encryption to mitigate data theft might result in significant performance degradation in systems handling large volumes of real-time transactions.",
@@ -6238,6 +7068,23 @@
       "value": "Process Discovery Mitigation - T1057"
     },
     {
+      "description": "Configure Active Directory to prevent use of certain techniques; use security identifier (SID) Filtering, etc.",
+      "meta": {
+        "external_id": "M0915",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0915"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "2f0160b7-e982-49d7-9612-f19b810f1722",
+      "value": "Active Directory Configuration - M0915"
+    },
+    {
       "description": "This category is to associate techniques that mitigation might increase risk of compromise and therefore mitigation is not recommended.",
       "meta": {
         "external_id": "M1059",
@@ -6289,6 +7136,23 @@
       "value": "Valid Accounts Mitigation - T1078"
     },
     {
+      "description": "Implement a supply chain management program, including policies and procedures to ensure all devices and components originate from a trusted supplier and are tested to verify their integrity.",
+      "meta": {
+        "external_id": "M0817",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0817"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "ac8f3492-7fbb-4a0a-b0b4-b75ec676136c",
+      "value": "Supply Chain Management - M0817"
+    },
+    {
       "description": "Network intrusion detection and prevention systems that use network signatures to identify traffic for specific adversary malware can be used to mitigate activity at the network level. Use of encryption protocols may make typical network-based C2 detection more difficult due to a reduced ability to signature the traffic. Prior knowledge of adversary C2 infrastructure may be useful for domain and IP address blocking, but will likely not be an effective long-term solution because adversaries can change infrastructure often. (Citation: University of Birmingham C2)",
       "meta": {
         "external_id": "T1079",
@@ -6300,6 +7164,314 @@
       "related": [],
       "uuid": "24478001-2eb3-4b06-a02e-96b3d61d27ec",
       "value": "Multilayer Encryption Mitigation - T1079"
+    },
+    {
+      "description": "Devices and programs designed to interact with control system parameters should validate the format and content of all user inputs and actions to ensure the values are within intended operational ranges. These values should be evaluated and further enforced through the program logic running on the field controller. If a problematic or invalid input is identified, the programs should either utilize a predetermined safe value or enter a known safe state, while also logging or alerting on the event.(Citation: PLCTop20 Mar 2023)",
+      "meta": {
+        "external_id": "M0818",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0818",
+          "https://plc-security.com/content/Top_20_Secure_PLC_Coding_Practices_V1.0.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "1cbcceef-3233-4062-aa86-ec91afe39517",
+      "value": "Validate Program Inputs - M0818"
+    },
+    {
+      "description": "Manage the creation, modification, use, and permissions associated to user accounts.",
+      "meta": {
+        "external_id": "M0918",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0918"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "e57ebc6d-785f-40c8-adb1-b5b5e09b3b48",
+      "value": "User Account Management - M0918"
+    },
+    {
+      "description": "A threat intelligence program helps an organization generate their own threat intelligence information and track trends to inform defensive priorities to mitigate risk.",
+      "meta": {
+        "external_id": "M0919",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0919"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "d48b79b2-076d-483e-949c-0d38aa347499",
+      "value": "Threat Intelligence Program - M0919"
+    },
+    {
+      "description": "Restrict the ability to modify certain hives or keys in the Windows Registry.",
+      "meta": {
+        "external_id": "M0924",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0924"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "3222a807-521b-4a1a-aa13-f1cda45734b3",
+      "value": "Restrict Registry Permissions - M0924"
+    },
+    {
+      "description": "Manage the creation, modification, use, and permissions associated to privileged accounts, including SYSTEM and root.",
+      "meta": {
+        "external_id": "M0926",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0926"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "622fe4d4-0e8e-4d17-9c25-6c9cef1f15d5",
+      "value": "Privileged Account Management - M0926"
+    },
+    {
+      "description": "Make configuration changes related to the operating system or a common feature of the operating system that result in system hardening against techniques.",
+      "meta": {
+        "external_id": "M0928",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0928"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "77d9c726-b53e-481d-8bcc-1068aebfbb9d",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "9a945a29-5233-4422-a9e3-3e957b0e8bce",
+      "value": "Operating System Configuration - M0928"
+    },
+    {
+      "description": "Block users or groups from installing or using unapproved hardware on systems, including USB devices.",
+      "meta": {
+        "external_id": "M0934",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0934"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "9e3adcad-0b8f-4ecc-a2f3-06f607f53bf0",
+      "value": "Limit Hardware Installation - M0934"
+    },
+    {
+      "description": "Configure features related to account use like login attempt lockouts, specific login times, etc.",
+      "meta": {
+        "external_id": "M0936",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0936"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "86b455f2-fb63-4043-93a8-32a3a7703a02",
+      "value": "Account Use Policies - M0936"
+    },
+    {
+      "description": "Use network appliances to filter ingress or egress traffic and perform protocol-based filtering. Configure software on endpoints to filter network traffic.   Perform inline allow/denylisting of network messages based on the application layer (OSI Layer 7) protocol, especially for automation protocols. Application allowlists are beneficial when there are well-defined communication sequences, types, rates, or patterns needed during expected system operations. Application denylists may be needed if all acceptable communication sequences cannot be defined, but instead a set of known malicious uses can be denied (e.g., excessive communication  attempts, shutdown messages, invalid commands).  Devices performing these functions are often referred to as deep-packet inspection (DPI) firewalls, context-aware firewalls, or firewalls blocking specific automation/SCADA protocol aware firewalls. (Citation: Centre for the Protection of National Infrastructure February 2005)",
+      "meta": {
+        "external_id": "M0937",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0937",
+          "https://www.energy.gov/sites/prod/files/Good%20Practices%20Guide%20for%20Firewall%20Deployment.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "11f242bc-3121-438c-84b2-5cbd46a4bb17",
+      "value": "Filter Network Traffic - M0937"
+    },
+    {
+      "description": "Prevent abuse of library loading mechanisms in the operating system and software to load untrusted code by configuring appropriate library loading mechanisms and investigating potential vulnerable software.",
+      "meta": {
+        "external_id": "M0944",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0944"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "2ab9fc6d-3cf6-4d7b-85f1-3ad6949233b3",
+      "value": "Restrict Library Loading - M0944"
     },
     {
       "description": "Misconfiguration of permissions in the Registry may lead to opportunities for an adversary to execute code, like through [Service Registry Permissions Weakness](https://attack.mitre.org/techniques/T1058). Ensure proper permissions are set for Registry hives to prevent users from modifying keys for system components that may lead to privilege escalation.\n\nIdentify and block unnecessary system utilities or potentially malicious software that may be used to modify the Registry by using whitelisting (Citation: Beechey 2010) tools like AppLocker (Citation: Windows Commands JPCERT) (Citation: NSA MS AppLocker) or Software Restriction Policies (Citation: Corio 2008) where appropriate. (Citation: TechNet Applocker vs SRP)",
@@ -7063,6 +8235,31 @@
       "value": "Multi-factor Authentication - M1032"
     },
     {
+      "description": "Use two or more pieces of evidence to authenticate to a system; such as username and password in addition to a token from a physical smart card or token generator.  Within industrial control environments assets such as low-level controllers, workstations, and HMIs have real-time operational control and safety requirements which may restrict the use of multi-factor.",
+      "meta": {
+        "external_id": "M0932",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0932"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "ddf3e568-f065-49e2-9106-42029a28ddbd",
+      "value": "Multi-factor Authentication - M0932"
+    },
+    {
       "description": "Limit privileges of user accounts so only authorized users can edit the rc.common file.",
       "meta": {
         "external_id": "T1163",
@@ -7104,6 +8301,23 @@
       "value": "SSL/TLS Inspection - M1020"
     },
     {
+      "description": "Break and inspect SSL/TLS sessions to look at encrypted web traffic for adversary activity.",
+      "meta": {
+        "external_id": "M0920",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0920"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "6a02e38a-9629-40c0-8c7d-e98e3470315c",
+      "value": "SSL/TLS Inspection - M0920"
+    },
+    {
       "description": "Regsvcs and Regasm may not be necessary within a given environment. Block execution of Regsvcs.exe and Regasm.exe if they are not required for a given system or network to prevent potential misuse by adversaries.",
       "meta": {
         "external_id": "T1121",
@@ -7114,6 +8328,85 @@
       "related": [],
       "uuid": "a90da496-b460-47e8-92e7-cc36eb00bd9a",
       "value": "Regsvcs/Regasm Mitigation - T1121"
+    },
+    {
+      "description": "The device or system should restrict read, manipulate, or execute privileges to only authenticated users who require access based on approved security policies.  Role-based Access Control (RBAC) schemes can help reduce the overhead of assigning permissions to the large number of devices within an ICS. For example, IEC 62351 provides examples of roles used to support common system operations within the electric power sector  (Citation: International Electrotechnical Commission July 2020), while IEEE 1686 defines standard permissions for users of IEDs. (Citation: Institute of Electrical and Electronics Engineers January 2014)",
+      "meta": {
+        "external_id": "M0800",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0800",
+          "https://standards.ieee.org/standard/1686-2013.html",
+          "https://webstore.iec.ch/publication/6912"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "e0d38502-decb-481d-ad8b-b8f0a0c330bd",
+      "value": "Authorization Enforcement - M0800"
     },
     {
       "description": "Install security updates in response to discovered vulnerabilities.\n\nPurchase devices with a vendor and/or mobile carrier commitment to provide security updates in a prompt manner for a set period of time.\n\nDecommission devices that will no longer receive security updates.\n\nLimit or block access to enterprise resources from devices that have not installed recent security updates.\n\nOn Android devices, access can be controlled based on each device's security patch level. On iOS devices, access can be controlled based on the iOS version.",
@@ -7458,6 +8751,543 @@
       ],
       "uuid": "d2a24649-9694-4c97-9c62-ce7b270bf6a3",
       "value": "Exploit Protection - M1050"
+    },
+    {
+      "description": "Access Management technologies can be used to enforce authorization polices and decisions, especially when existing field devices do not provide sufficient capabilities to support user identification and authentication. (Citation: McCarthy, J et al. July 2018) These technologies typically utilize an in-line network device or gateway system to prevent access to unauthenticated users, while also integrating with an authentication service to first verify user credentials. (Citation: Centre for the Protection of National Infrastructure November 2010)",
+      "meta": {
+        "external_id": "M0801",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0801",
+          "https://doi.org/10.6028/NIST.SP.1800-2",
+          "https://us-cert.cisa.gov/sites/default/files/recommended_practices/RP_Managing_Remote_Access_S508NC.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3e9b182e-e493-49e1-9a9b-bd0dfcd34a7c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "6b335943-c3af-430e-a135-ab09623bdc20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "3992ce42-43e9-4bea-b8db-a102ec3ec1e3",
+      "value": "Access Management - M0801"
+    },
+    {
+      "description": "When communicating over an untrusted network, utilize secure network protocols that both authenticate the message sender and can verify its integrity. This can be done either through message authentication codes (MACs) or digital signatures, to detect spoofed network messages and unauthorized connections.",
+      "meta": {
+        "external_id": "M0802",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0802"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "c7257b6e-4159-4771-b1f3-2bb93adaecac",
+      "value": "Communication Authenticity - M0802"
+    },
+    {
+      "description": "Architect sections of the network to isolate critical systems, functions, or resources. Use physical and logical segmentation to prevent access to potentially sensitive systems and information. Use a DMZ to contain any internet-facing services that should not be exposed from the internal network.  Restrict network access to only required systems and services. In addition, prevent systems from other networks or business functions (e.g., enterprise) from accessing critical process control systems. For example, in IEC 62443, systems within the same secure level should be grouped into a zone, and access to that zone is restricted by a conduit, or mechanism to restrict data flows between zones by segmenting the network. (Citation: IEC February 2019) (Citation: IEC August 2013)",
+      "meta": {
+        "external_id": "M0930",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0930",
+          "https://webstore.iec.ch/publication/34421",
+          "https://webstore.iec.ch/publication/7033"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "6008c1f0-1b68-4614-8f5b-a547436b8855",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "64bbc1b2-101f-4322-af1d-0c9cc25cef91",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "71f2d49e-65dd-4fb6-a4cc-0d2b19d427fa",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "c55f0be5-044e-4577-8095-65b37680d28c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "f8df6b57-14bc-425f-9a91-6f59f6799307",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "1e7ccfc0-94c8-496e-8d27-032120892291",
+      "value": "Network Segmentation - M0930"
+    },
+    {
+      "description": "Use capabilities to detect and block conditions that may lead to or be indicative of a software exploit occurring.",
+      "meta": {
+        "external_id": "M0950",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0950"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "49363b74-d506-4342-bd63-320586ebadb9",
+      "value": "Exploit Protection - M0950"
+    },
+    {
+      "description": "Network allowlists can be implemented through either host-based files or system hosts files to specify what connections (e.g., IP address, MAC address, port, protocol) can be made from a device. Allowlist techniques that operate at the  application layer (e.g., DNP3, Modbus, HTTP) are addressed in [Filter Network Traffic](https://attack.mitre.org/mitigations/M0937) mitigation.",
+      "meta": {
+        "external_id": "M0807",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0807"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "338f4364-2269-4f70-9079-b20384b16628",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "6008c1f0-1b68-4614-8f5b-a547436b8855",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "71f2d49e-65dd-4fb6-a4cc-0d2b19d427fa",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "aadac250-bcdc-44e3-a4ae-f52bd0a7a16a",
+      "value": "Network Allowlists - M0807"
     },
     {
       "description": "Describes any guidance or training given to users to set particular configuration settings or avoid specific potentially risky behaviors.",
@@ -9280,6 +11110,68 @@
       "value": "Scripting Mitigation - T1064"
     },
     {
+      "description": "Utilize watchdog timers to ensure devices can quickly detect whether a system is unresponsive.",
+      "meta": {
+        "external_id": "M0815",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0815"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "98aa0d61-fc9d-4b2d-8f18-b25d03549f53",
+      "value": "Watchdog Timers - M0815"
+    },
+    {
+      "description": "Perform regular software updates to mitigate exploitation risk. Software updates may need to be scheduled around operational down times.",
+      "meta": {
+        "external_id": "M0951",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0951"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "97f33c84-8508-45b9-8a1d-cac921828c9e",
+      "value": "Update Software - M0951"
+    },
+    {
       "description": "Ensure proper permissions are in place to help prevent adversary access to privileged accounts necessary to perform this action. Use Trusted Platform Module technology and a secure or trusted boot process to prevent system integrity from being compromised. (Citation: TCG Trusted Platform Module) (Citation: TechNet Secure Boot Process)",
       "meta": {
         "external_id": "T1067",
@@ -9307,6 +11199,60 @@
       "value": "PowerShell Mitigation - T1086"
     },
     {
+      "description": "Vulnerability scanning is used to find potentially exploitable software vulnerabilities to remediate them.",
+      "meta": {
+        "external_id": "M0916",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0916"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "de0bc375-50e1-4e26-a342-a8ff8c9d3037",
+      "value": "Vulnerability Scanning - M0916"
+    },
+    {
+      "description": "Train users to be aware of access or manipulation attempts by an adversary to reduce the risk of successful spearphishing, social engineering, and other techniques that involve user interaction.",
+      "meta": {
+        "external_id": "M0917",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0917"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "dc61c280-c29d-44e5-a960-c0dd1623d2ba",
+      "value": "User Training - M0917"
+    },
+    {
       "description": "Mitigation of timestomping specifically is likely difficult. Efforts should be focused on preventing potentially malicious software from running. Identify and block potentially malicious software that may contain functionality to perform timestomping by using whitelisting (Citation: Beechey 2010) tools like AppLocker (Citation: Windows Commands JPCERT) (Citation: NSA MS AppLocker) or Software Restriction Policies (Citation: Corio 2008) where appropriate. (Citation: TechNet Applocker vs SRP)",
       "meta": {
         "external_id": "T1099",
@@ -9322,6 +11268,243 @@
       "related": [],
       "uuid": "5c167af7-c2cb-42c8-ae67-3fb275bf8488",
       "value": "Timestomp Mitigation - T1099"
+    },
+    {
+      "description": "Set and enforce secure password policies for accounts.",
+      "meta": {
+        "external_id": "M0927",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0927"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fab8fc7d-f27f-4fbb-9de6-44740aade05f",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "5d97c693-e054-48ba-a3a3-eaf6942dfb65",
+      "value": "Password Policies - M0927"
+    },
+    {
+      "description": "Take and store data backups from end user systems and critical servers. Ensure backup and storage systems are hardened and kept separate from the corporate network to prevent compromise.   Maintain and exercise incident response plans  (Citation: Department of Homeland Security October 2009), including the management of  'gold-copy' back-up images and configurations for key systems to enable quick recovery and response from adversarial activities that impact control, view, or availability.",
+      "meta": {
+        "external_id": "M0953",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0953",
+          "https://us-cert.cisa.gov/sites/default/files/recommended_practices/final-RP_ics_cybersecurity_incident_response_100609.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fab8fc7d-f27f-4fbb-9de6-44740aade05f",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "ad12819e-3211-4291-b360-069f280cff0a",
+      "value": "Data Backup - M0953"
+    },
+    {
+      "description": "Block execution of code on a system through application control, and/or script blocking.",
+      "meta": {
+        "external_id": "M0938",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0938"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1c5cf58c-a34a-40d7-82f4-f987cdfc2b91",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "b52870cc-83f3-473c-b895-72d91751030b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "4fa717d9-cabe-47c8-8cdd-86e9e2e37f30",
+      "value": "Execution Prevention - M0938"
+    },
+    {
+      "description": "Implement configuration changes to software (other than the operating system) to mitigate security risks associated with how the software operates.",
+      "meta": {
+        "external_id": "M0954",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0954"
+        ]
+      },
+      "uuid": "facb8840-ebe7-49f1-b464-8ef6c8131e21",
+      "value": "Software Configuration - M0954"
+    },
+    {
+      "description": "Enforce binary and application integrity with digital signature verification to prevent untrusted code from executing.",
+      "meta": {
+        "external_id": "M0945",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0945"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "71eb7dad-07eb-4bbc-9df0-ac57bf2fba4a",
+      "value": "Code Signing - M0945"
+    },
+    {
+      "description": "Use secure methods to boot a system and verify the integrity of the operating system and loading mechanisms.",
+      "meta": {
+        "external_id": "M0946",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0946"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "8ac1d6e1-b07f-476a-9732-84984ebc2405",
+      "value": "Boot Integrity - M0946"
     },
     {
       "description": "Microsoft's Enhanced Mitigation Experience Toolkit (EMET) Attack Surface Reduction (ASR) feature can be used to block regsvr32.exe from being used to bypass whitelisting. (Citation: Secure Host Baseline EMET)",
@@ -9964,6 +12147,32 @@
       "value": "Antivirus/Antimalware - M1058"
     },
     {
+      "description": "Use signatures or heuristics to detect malicious software.  Within industrial control environments, antivirus/antimalware installations should be limited to assets that are not involved in critical or real-time operations. To minimize the impact to system availability, all products should first be validated within a representative test environment before deployment to production systems. (Citation: NCCIC August 2018)",
+      "meta": {
+        "external_id": "M0949",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0949",
+          "https://us-cert.cisa.gov/sites/default/files/recommended_practices/Recommended%20Practice%20Updating%20Antivirus%20in%20an%20Industrial%20Control%20System_S508C.pdf"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "faf2b40e-5981-433f-aa46-17458e0026f7",
+      "value": "Antivirus/Antimalware - M0949"
+    },
+    {
       "description": "Enable remote attestation capabilities when available (such as Android SafetyNet or Samsung Knox TIMA Attestation) and prohibit devices that fail the attestation from accessing enterprise resources.",
       "meta": {
         "external_id": "M1002",
@@ -10480,7 +12689,96 @@
       ],
       "uuid": "cc2399fd-3cd3-4319-8d0a-fbd6420cdaf8",
       "value": "Audit - M1047"
+    },
+    {
+      "description": "Perform audits or scans of systems, permissions, insecure software, insecure configurations, etc. to identify potential weaknesses. Perform periodic integrity checks of the device to validate the correctness of the firmware, software, programs, and configurations. Integrity checks, which typically include cryptographic hashes or digital signatures, should be compared to those obtained at known valid states, especially after events like device reboots, program downloads, or program restarts.",
+      "meta": {
+        "external_id": "M0947",
+        "refs": [
+          "https://attack.mitre.org/mitigations/M0947"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "mitigates"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+          "type": "mitigates"
+        }
+      ],
+      "uuid": "bcf91ebc-f316-4e19-b2f6-444e9940c697",
+      "value": "Audit - M0947"
     }
   ],
-  "version": 37
+  "version": 38
 }

--- a/clusters/mitre-data-component.json
+++ b/clusters/mitre-data-component.json
@@ -118,6 +118,17 @@
       "value": "Active Directory Object Creation - DC0087"
     },
     {
+      "description": "This includes any data stores that maintain historical or real-time events and telemetry recorded from various sensors or devices",
+      "meta": {
+        "external_id": "DC0107",
+        "refs": [
+          "https://attack.mitre.org/datacomponents/DC0107"
+        ]
+      },
+      "uuid": "931b3fc6-ad68-42a8-9018-e98515eedc95",
+      "value": "Process History/Live Data - DC0107"
+    },
+    {
       "description": "Changes made to an existing user, service, or machine account, including alterations to attributes, permissions, roles, authentication methods, or group memberships.",
       "meta": {
         "external_id": "DC0010",
@@ -490,6 +501,17 @@
       "value": "Logon Session Metadata - DC0088"
     },
     {
+      "description": "This includes a list of any process alarms or alerts produced to indicate unusual or concerning activity within the operational process (e.g., increased temperature/pressure)",
+      "meta": {
+        "external_id": "DC0109",
+        "refs": [
+          "https://attack.mitre.org/datacomponents/DC0109"
+        ]
+      },
+      "uuid": "4c12c1c8-bcef-4daf-8e5b-fca235f71d9e",
+      "value": "Process/Event Alarm - DC0109"
+    },
+    {
       "description": "Contextual data about a cloud volume and activity around it, such as id, type, state, and size",
       "meta": {
         "external_id": "DC0100",
@@ -596,6 +618,17 @@
       "related": [],
       "uuid": "f8213cde-6b3a-420d-9ab7-41c9af1a919f",
       "value": "Instance Start - DC0080"
+    },
+    {
+      "description": "This includes sources of current and expected devices on the network, including the manufacturer, model, and necessary identifiers (e.g., IP and hardware addresses)",
+      "meta": {
+        "external_id": "DC0110",
+        "refs": [
+          "https://attack.mitre.org/datacomponents/DC0110"
+        ]
+      },
+      "uuid": "b05a614b-033c-4578-b4f2-c63a9feee706",
+      "value": "Asset Inventory - DC0110"
     },
     {
       "description": "Code, strings, signatures, and other identifying characteristics of a malicious payload stored within a malware repository. It includes both static (file-based) and dynamic (behavioral or execution-based) components that can be analyzed for threat intelligence, detection, and prevention purposes. Examples:\n\n- Static Analysis:\n    - Executable Code: Analyze binary data to identify unique patterns, obfuscated code, or embedded resources.\n    - Strings Extraction: Use tools like strings or YARA rules to identify hardcoded URLs, IPs, filenames, or suspicious function calls.\n    - Signatures: Extract cryptographic hashes (MD5, SHA256) of files to track known malware variants or detect previously unseen samples.\n- Dynamic Analysis:\n    - Behavioral Observations: Monitor execution traces to capture API calls, registry modifications, or network traffic patterns indicative of malicious behavior.\n    - Memory Analysis: Examine memory dumps to uncover injected code or runtime-decrypted payloads.\n    - Artifacts: Record file system changes, process creation events, and command-line arguments.\n- Threat Intelligence Integration:\n    - Campaign Attribution: Associate observed code snippets or signatures with known APT campaigns or ransomware families.\n    - Indicator Sharing: Share identified Indicators of Compromise (IOCs) with threat intelligence platforms (e.g., MISP, OpenCTI).\n- Examples of Malware Content:\n    - Embedded C2 domains (e.g., malicious-domain.com hardcoded in the payload).\n    - Fileless malware indicators, such as PowerShell scripts invoking Invoke-Mimikatz.\n    - Malware-specific signatures, such as unique PE header values for a particular strain.\n\n*Data Collection Measures:*\n\n- Collection from Public Malware Repositories:\n    - VirusTotal: Obtain samples for static analysis.\n    - Hybrid Analysis: Gather execution data from sandbox analysis.\n    - Any.Run: Access interactive malware execution traces.\n    - MalwareBazaar: Download malware samples for research and signature generation.\n    - Automate data extraction using repository APIs (e.g., VirusTotal API for hash lookups or sample retrieval).\n- Internal Malware Labs:\n    - Sandbox Environments: Use dynamic malware analysis tools such as Cuckoo Sandbox or Joe Sandbox to execute and monitor malware in a controlled environment. Capture runtime behavior logs, memory dumps, and file system changes.\n    - Reverse Engineering: Disassemble binaries with tools like IDA Pro, Ghidra, or Radare2 to identify malicious functionality and extract code patterns.\n- EDR/Endpoint Telemetry:\n    - Collect samples of malicious binaries or scripts from infected endpoints using tools like CrowdStrike, Carbon Black, or SentinelOne.\n    - Extract memory-resident payloads from live systems for analysis.\n- Threat Intelligence Platforms:\n    - Gather contextual metadata for identified malware using tools like OpenCTI, Recorded Future, or ThreatConnect. Participate in intelligence-sharing groups such as ISACs (e.g., FS-ISAC, IT-ISAC).\n- Custom Data Collection Pipelines: Use open-source tools like malwoverview or Maltrail to automate sample downloads, hash extraction, and IOC generation.",
@@ -728,6 +761,17 @@
       "related": [],
       "uuid": "1067aa74-5796-4d9b-b4f1-a4c9eb6fd9da",
       "value": "Response Metadata - DC0106"
+    },
+    {
+      "description": "This includes alarms associated with unexpected device functions, such as shutdowns, restarts, failures, or configuration changes",
+      "meta": {
+        "external_id": "DC0108",
+        "refs": [
+          "https://attack.mitre.org/datacomponents/DC0108"
+        ]
+      },
+      "uuid": "9d56be63-3501-4dd3-bb5f-63c580833298",
+      "value": "Device Alarm - DC0108"
     },
     {
       "description": "Removal of a virtual machine (VM) or compute instance within a cloud infrastructure. This activity results in the termination and deletion of the allocated resources (e.g., CPU, memory, storage), making the instance unavailable for future use. Examples:\n\n- AWS: instance deletion involves the `TerminateInstances` API call, which is recorded in CloudTrail logs.\n- Azure: VM deletion can be monitored via Azure Activity Logs, showing the `Microsoft.Compute/virtualMachines/delete` operation.\n- GCP: instance deletion is logged as an instance.delete operation within GCP Audit Logs.",
@@ -1423,7 +1467,18 @@
       },
       "uuid": "55c669d9-b42a-4cf6-a38a-07161b228ce9",
       "value": "Application State - DC0123"
+    },
+    {
+      "description": "This includes sources of current and expected software or application programs deployed to a device, along with information on the version and patch level for vendor products, full source code for any application programs, and unique identifiers (e.g., hashes, signatures).",
+      "meta": {
+        "external_id": "DC0111",
+        "refs": [
+          "https://attack.mitre.org/datacomponents/DC0111"
+        ]
+      },
+      "uuid": "8ed4e6d0-56d7-4e6b-8fa6-41f41631f30d",
+      "value": "Software - DC0111"
     }
   ],
-  "version": 10
+  "version": 11
 }

--- a/clusters/mitre-data-source.json
+++ b/clusters/mitre-data-source.json
@@ -71,6 +71,17 @@
       "value": "Scheduled Job - DS0003"
     },
     {
+      "description": "Operational databases contain information about the status of the operational process and associated devices, including any measurements, events, history, or alarms that have occurred",
+      "meta": {
+        "external_id": "DS0040",
+        "refs": [
+          "https://attack.mitre.org/datasources/DS0040"
+        ]
+      },
+      "uuid": "1b8c9f31-ad35-4850-bf8c-80c565ad3552",
+      "value": "Operational Databases - DS0040"
+    },
+    {
       "description": "Information obtained (via shared or submitted samples) regarding malicious software (droppers, backdoors, etc.) used by adversaries",
       "meta": {
         "external_id": "DS0004",
@@ -749,7 +760,18 @@
       "related": [],
       "uuid": "29aa4e0e-4a26-4f79-a9bc-1ae66df1c923",
       "value": "Certificate - DS0037"
+    },
+    {
+      "description": "Data sources with information about the set of devices found within the network, along with their current software and configurations",
+      "meta": {
+        "external_id": "DS0039",
+        "refs": [
+          "https://attack.mitre.org/datasources/DS0039"
+        ]
+      },
+      "uuid": "b1717cb4-d536-4e2b-b5e5-07e67e26183c",
+      "value": "Asset - DS0039"
     }
   ],
-  "version": 10
+  "version": 11
 }

--- a/clusters/mitre-detection-strategy.json
+++ b/clusters/mitre-detection-strategy.json
@@ -11535,6 +11535,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0906",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0906"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "6a510bf0-0289-4eb0-8645-89f0f4d32cf3",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "31773402-e407-4ed3-b86c-7a8587dc5ec9",
+      "value": "Detection of Siemens Project File Format Infection - DET0906"
+    },
+    {
+      "meta": {
         "external_id": "DET0609",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0609"
@@ -13035,6 +13055,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0757",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0757"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "89ca8617-20fd-404b-9afb-dcfd2684a791",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "c7737640-99e8-4efb-90ee-39332b623b33",
+      "value": "Detection of Loss of Productivity and Revenue - DET0757"
+    },
+    {
+      "meta": {
         "external_id": "DET0578",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0578"
@@ -13052,6 +13092,26 @@
       ],
       "uuid": "c4f5335d-8e85-4b45-86b1-1d5a8cc6523d",
       "value": "Detection Strategy for Cloud Storage Object Discovery - DET0578"
+    },
+    {
+      "meta": {
+        "external_id": "DET0788",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0788"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "484023ea-6fea-4f91-b40d-c6d87188cbfe",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "5604323b-6e7a-4801-91ae-4bf591f2e3ac",
+      "value": "Detection of Point & Tag Identification - DET0788"
     },
     {
       "meta": {
@@ -13999,6 +14059,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0802",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0802"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "96e7b86f-b960-489c-882b-9dcdb1c44aa9",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "6d2ba563-0aa9-4f64-a14d-da62b694b495",
+      "value": "Detection of Activate Firmware Update Mode - DET0802"
+    },
+    {
+      "meta": {
         "external_id": "DET0303",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0303"
@@ -14179,6 +14259,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0903",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0903"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "338f4364-2269-4f70-9079-b20384b16628",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "c556c91d-64a0-401c-9c41-18971eeca0f2",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "6f318bab-df4a-4a51-b849-e9c2ab2f9c4c",
+      "value": "Detection of Block Operational Technology Message - DET0903"
+    },
+    {
+      "meta": {
         "external_id": "DET0044",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0044"
@@ -14272,6 +14372,26 @@
       ],
       "uuid": "ef792e16-8b1c-452d-a3ae-1ad4b5577a4d",
       "value": "Detection of Compromise Hardware Supply Chain - DET0604"
+    },
+    {
+      "meta": {
+        "external_id": "DET0750",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0750"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "55544bb8-440f-4b67-aa35-7e7af5952aca",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "e8b537e6-04eb-4168-a206-88cc041edf50",
+      "value": "Detection of Indicator Removal on Host - DET0750"
     },
     {
       "meta": {
@@ -15023,6 +15143,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0732",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0732"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "cd4c92f9-3107-45c7-9d95-19a44d7dc92c",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "2145faf1-28da-4ebc-9730-f2e2a8764ced",
+      "value": "Detection of Theft of Operational Information - DET0732"
+    },
+    {
+      "meta": {
         "external_id": "DET0293",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0293"
@@ -15363,6 +15503,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0733",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0733"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "9ad83be0-5c88-4fb6-b59d-19db21176923",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
+          "type": "detects"
+        }
+      ],
+      "uuid": "cb273244-c117-4e32-afc7-f72f4e44e179",
+      "value": "Detection of Replication Through Removable Media - DET0733"
+    },
+    {
+      "meta": {
         "external_id": "DET0634",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0634"
@@ -15563,6 +15723,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0738",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0738"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "b6fb91d0-28f6-447d-ba25-e7b26116ebfe",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "detects"
+        }
+      ],
+      "uuid": "0f2e4927-401d-430e-96ed-90feb8df1b03",
+      "value": "Detection of Exploitation for Privilege Escalation - DET0738"
+    },
+    {
+      "meta": {
+        "external_id": "DET0793",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0793"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1c5cf58c-a34a-40d7-82f4-f987cdfc2b91",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "23ce0ac3-6afe-4647-be72-e1e9bcd1490e",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "519082ce-24ab-4f6b-9e86-b9443758c9d4",
+      "value": "Detection of System Binary Proxy Execution - DET0793"
+    },
+    {
+      "meta": {
         "external_id": "DET0455",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0455"
@@ -15600,6 +15800,46 @@
       ],
       "uuid": "fda20a62-ad83-4d45-8a65-84883b07707b",
       "value": "Detection Strategy for Cloud Administration Command - DET0545"
+    },
+    {
+      "meta": {
+        "external_id": "DET0754",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0754"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1672d2e3-8756-4380-b22c-517aa9f1cce0",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "detects"
+        }
+      ],
+      "uuid": "a366d027-d797-4957-949a-870aed0766dd",
+      "value": "Detection of Data from Information Repositories - DET0754"
+    },
+    {
+      "meta": {
+        "external_id": "DET0749",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0749"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0099659c-6a20-4331-9d47-b1c0c380fd6b",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "detects"
+        }
+      ],
+      "uuid": "3a772c6d-fda2-404a-86aa-85a0bdbb43e9",
+      "value": "Detection of Data from Local System - DET0749"
     },
     {
       "meta": {
@@ -15839,6 +16079,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0767",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0767"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3e456d4d-397d-4e04-9261-9399960c9633",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "detects"
+        }
+      ],
+      "uuid": "67c2be08-d31a-4385-a637-9d1a907c7a26",
+      "value": "Detection of Exploitation of Remote Services - DET0767"
+    },
+    {
+      "meta": {
         "external_id": "DET0678",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0678"
@@ -15944,6 +16204,46 @@
       ],
       "uuid": "9031c511-d7ff-410e-9144-d3afee390210",
       "value": "Detection of Gather Victim Network Information - DET0869"
+    },
+    {
+      "meta": {
+        "external_id": "DET0787",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0787"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "f123f13f-b6f4-4e86-96cd-14df0e855e0f",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "636329e6-32b9-4a71-acf8-ae6d01a6b4ef",
+      "value": "Detection of Remote System Information Discovery - DET0787"
+    },
+    {
+      "meta": {
+        "external_id": "DET0799",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0799"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "d271c7fc-d76a-4fb0-a645-5db2c1223a32",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "detects"
+        }
+      ],
+      "uuid": "732d2487-3241-4866-8bb5-044bb4acdd3b",
+      "value": "Detection of Standard Application Layer Protocol - DET0799"
     },
     {
       "meta": {
@@ -16120,6 +16420,26 @@
       ],
       "uuid": "f6dd18b4-8534-4883-8d57-80655418bed4",
       "value": "Detection of USB-Based Data Exfiltration - DET0220"
+    },
+    {
+      "meta": {
+        "external_id": "DET0740",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0740"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "dd25b818-ceb0-4518-9384-dcf895d4956b",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "ab3f0926-58e2-485e-987c-66b541d9de97",
+      "value": "Detection of Exploit Public-Facing Application - DET0740"
     },
     {
       "meta": {
@@ -16320,6 +16640,46 @@
       ],
       "uuid": "0f41110f-099f-468f-af46-65d2a34f05d9",
       "value": "Detection of Disguise Root/Jailbreak Indicators - DET0710"
+    },
+    {
+      "meta": {
+        "external_id": "DET0737",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0737"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "77857bc3-6a38-4826-8109-30facf6c23ec",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "detects"
+        }
+      ],
+      "uuid": "3ea60ac7-87a3-4033-9089-258941d8388a",
+      "value": "Detection of Brute Force I/O - DET0737"
+    },
+    {
+      "meta": {
+        "external_id": "DET0773",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0773"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "36e9f5bc-ac13-4da4-a2f4-01f4877d9004",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "7841eb6b-8a05-4754-b738-a475bfbb89fb",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "ad675d25-2829-48e5-8475-28f1ed5d813a",
+      "value": "Detection of Manipulate I/O Image - DET0773"
     },
     {
       "meta": {
@@ -16528,6 +16888,46 @@
       ],
       "uuid": "3f3f3518-90bb-44fc-8ef0-dbfab75b79cc",
       "value": "Detection of Device Administrator Permissions - DET0630"
+    },
+    {
+      "meta": {
+        "external_id": "DET0730",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0730"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "899d0dce-64f7-4924-93a1-8e3c83dd510f",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "58b4bda4-d69a-4a20-ab67-308c4451a5e8",
+      "value": "Detection of Supply Chain Compromise - DET0730"
+    },
+    {
+      "meta": {
+        "external_id": "DET0803",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0803"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "908fe88b-d8e2-47d1-b6a4-7a42b3bbe09b",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "e9f6c9ad-7368-43e3-9ba1-c9261323a1d1",
+      "value": "Detection of External Remote Services - DET0803"
     },
     {
       "meta": {
@@ -16791,6 +17191,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0770",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0770"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "7aa60595-5a1c-4de2-be60-cc1f9fea2313",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
+          "type": "detects"
+        }
+      ],
+      "uuid": "441ded70-7e25-47f1-b55c-0fafb7d4f44c",
+      "value": "Detection of Network Connection Enumeration - DET0770"
+    },
+    {
+      "meta": {
         "external_id": "DET0870",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0870"
@@ -17051,6 +17471,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0913",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0913"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "e379be82-39d7-4ae4-8557-f846ba19cd4b",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "2e99cd65-aad4-4796-9013-79837d498eb6",
+      "value": "Detection of Program Download All - DET0913"
+    },
+    {
+      "meta": {
         "external_id": "DET0714",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0714"
@@ -17068,6 +17508,26 @@
       ],
       "uuid": "611b9135-583e-47f8-b617-e9d52ae2d2c5",
       "value": "Detection of Suppress Application Icon - DET0714"
+    },
+    {
+      "meta": {
+        "external_id": "DET0741",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0741"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "2195ec67-7cea-4b0d-a678-18384089bf2c",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "fe11c904-752f-40e2-b269-c53bbb29541a",
+      "value": "Detection of Modify Controller Tasking - DET0741"
     },
     {
       "meta": {
@@ -17267,6 +17727,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0723",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0723"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "cff25f71-859e-48bf-88d6-852d05e22b33",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "08c090e3-c56f-4a8b-80f6-307a1daf46ea",
+      "value": "Detection of Denial of Service - DET0723"
+    },
+    {
+      "meta": {
         "external_id": "DET0823",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0823"
@@ -17308,6 +17788,26 @@
       ],
       "uuid": "c2155dfa-140f-4da9-bfe8-61481a9693c0",
       "value": "Detection of Remote Access Software - DET0624"
+    },
+    {
+      "meta": {
+        "external_id": "DET0742",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0742"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "e8f51c53-fc55-441b-a45f-ba7709ccbce2",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "f1a7e304-d05f-4e48-89b7-8b034f507c32",
+      "value": "Detection of Execution through API - DET0742"
     },
     {
       "meta": {
@@ -17371,6 +17871,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0762",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0762"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "636e612f-0b63-44e8-bf2c-31b62d20508b",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+          "type": "detects"
+        }
+      ],
+      "uuid": "f9b7143b-ce86-4cfb-a03a-f39c01904fb1",
+      "value": "Detection of Damage to Property - DET0762"
+    },
+    {
+      "meta": {
         "external_id": "DET0628",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0628"
@@ -17392,6 +17912,66 @@
       ],
       "uuid": "8d518627-1df4-4bf8-b1fb-0828fb9f6d31",
       "value": "Detection of Supply Chain Compromise - DET0628"
+    },
+    {
+      "meta": {
+        "external_id": "DET0772",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0772"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "b0628bfc-5376-4a38-9182-f324501cb4cf",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "dc014060-5116-4a2f-bac5-35ac1db8fabb",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "87493fa2-bb78-4e28-b882-d79eecd10740",
+      "value": "Detection of Graphical User Interface - DET0772"
+    },
+    {
+      "meta": {
+        "external_id": "DET0727",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0727"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1be515a0-2656-4b35-a561-e8157169350d",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "detects"
+        }
+      ],
+      "uuid": "60a55b7b-29a5-437e-83a7-edbe6f3c4415",
+      "value": "Detection of Monitor Process State - DET0727"
+    },
+    {
+      "meta": {
+        "external_id": "DET0729",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0729"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "8428e0cd-009e-41c1-8292-88651d4486c9",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "detects"
+        }
+      ],
+      "uuid": "d9469edc-7e55-41bc-8b17-a8db9fc6302e",
+      "value": "Detection of Loss of Availability - DET0729"
     },
     {
       "meta": {
@@ -17515,6 +18095,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0736",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0736"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "981b659b-992a-4d71-9404-0e1b2b598e50",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "detects"
+        }
+      ],
+      "uuid": "33dd1c37-1702-4de2-9712-fcc640e4b681",
+      "value": "Detection of Commonly Used Port - DET0736"
+    },
+    {
+      "meta": {
+        "external_id": "DET0763",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0763"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "1e9c5d46-14e2-4efc-8861-e6dc942b3b9c",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "a995ba7c-c2c2-4d74-a3da-74e5a192099b",
+      "value": "Detection of Loss of View - DET0763"
+    },
+    {
+      "meta": {
         "external_id": "DET0683",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0683"
@@ -17535,6 +18155,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0739",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0739"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "322ac45b-d540-4d2a-84a1-cde200238b95",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "detects"
+        }
+      ],
+      "uuid": "ec442b22-3dc8-4b2b-8294-b76b0f01d748",
+      "value": "Detection of Remote System Discovery - DET0739"
+    },
+    {
+      "meta": {
         "external_id": "DET0838",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0838"
@@ -17552,6 +18192,46 @@
       ],
       "uuid": "6e53a352-9654-41fe-bf43-50e6b23a4ac1",
       "value": "Detection of Virtual Private Server - DET0838"
+    },
+    {
+      "meta": {
+        "external_id": "DET0744",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0744"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "35392fb4-a31d-4c6a-b9f2-1c65b7f5e6b9",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "9127dd4e-0994-442f-8d73-b6b2dfb1f9ac",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "8ae936b6-b635-4104-bd11-81c18d90cf97",
+      "value": "Detection of Transient Cyber Asset - DET0744"
+    },
+    {
+      "meta": {
+        "external_id": "DET0745",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0745"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "930aae7c-e8f0-4594-8e3f-f0e71d7e1640",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
+          "type": "detects"
+        }
+      ],
+      "uuid": "62587e44-0623-4b14-bd45-126430eaed4a",
+      "value": "Detection of Lateral Tool Transfer - DET0745"
     },
     {
       "meta": {
@@ -17631,6 +18311,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0746",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0746"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32bfb2ab-2ad1-4c00-8428-96bc626c34f3",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "527106b3-95a2-4ed2-bf89-db7f0e4d0da0",
+          "type": "detects"
+        }
+      ],
+      "uuid": "c0e6c96d-8605-407a-9bce-628e7853b07f",
+      "value": "Detection of Spoof Reporting Message - DET0746"
+    },
+    {
+      "meta": {
         "external_id": "DET0649",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0649"
@@ -17671,6 +18371,66 @@
     },
     {
       "meta": {
+        "external_id": "DET0747",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0747"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "383a1a1c-8ecf-4909-9237-14a1f4fc4179",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "ae24274b-0e20-451e-a883-6eeb0e8e7d00",
+      "value": "Detection of Manipulation of Control - DET0747"
+    },
+    {
+      "meta": {
+        "external_id": "DET0784",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0784"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "11a350cf-1ea0-4065-877b-c3bb410bf3a0",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "detects"
+        }
+      ],
+      "uuid": "2a1619a7-dd27-48e4-b56f-806cb3d2e405",
+      "value": "Detection of Block Command Message - DET0784"
+    },
+    {
+      "meta": {
+        "external_id": "DET0794",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0794"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "23eb2bc3-735d-4425-96e1-f9d3a1453bfa",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "detects"
+        }
+      ],
+      "uuid": "d8cb1dd3-8bf2-48e7-99db-473481b823a8",
+      "value": "Detection of Unauthorized Command Message - DET0794"
+    },
+    {
+      "meta": {
         "external_id": "DET0849",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0849"
@@ -17688,6 +18448,26 @@
       ],
       "uuid": "f5ac003f-2fdc-4ac5-9f2b-3fb2ab00fe95",
       "value": "Detection of Identify Business Tempo - DET0849"
+    },
+    {
+      "meta": {
+        "external_id": "DET0755",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0755"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "78615cd7-6a14-4921-aaa9-2aae0774f0f1",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "fddbd892-faa2-40e1-b40d-2c6e33c00f14",
+      "value": "Detection of Change Operating Mode - DET0755"
     },
     {
       "meta": {
@@ -17811,6 +18591,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0775",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0775"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "29b6e4b8-878c-4139-aa56-7e1513714d34",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "2bb4d762-bf4a-4bc3-9318-15cc6a354163",
+          "type": "detects"
+        }
+      ],
+      "uuid": "c4777f1a-1481-4e8a-a3f4-0da57418c808",
+      "value": "Detection of Loss of Protection - DET0775"
+    },
+    {
+      "meta": {
         "external_id": "DET0875",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0875"
@@ -17828,6 +18628,46 @@
       ],
       "uuid": "1e8c8a62-9546-4323-a561-83e9fad94fa0",
       "value": "Detection of Code Signing Certificates - DET0875"
+    },
+    {
+      "meta": {
+        "external_id": "DET0785",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0785"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "d71e98fa-64d1-4ddb-acb1-bba1e4af6a73",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "47c6f72c-1f2f-4ea8-94d0-08202b7d5bdb",
+      "value": "Detection of Manipulation of View - DET0785"
+    },
+    {
+      "meta": {
+        "external_id": "DET0795",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0795"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "fbd4686e-f637-459b-ad48-c6fd7840acfa",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "97914ffd-b189-415e-9309-e63e3be01b1e",
+      "value": "Detection of Exploitation for Evasion - DET0795"
     },
     {
       "meta": {
@@ -17872,6 +18712,26 @@
       ],
       "uuid": "4809a26b-8527-49dc-81aa-ac2750fd3b75",
       "value": "Detection of GUI Input Capture - DET0676"
+    },
+    {
+      "meta": {
+        "external_id": "DET0766",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0766"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "6e046c4c-6c93-4fdf-a69e-5d81b52d1e9c",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "detects"
+        }
+      ],
+      "uuid": "09754c36-7be2-4536-aad2-a6c3568ba0e5",
+      "value": "Detection of Project File Infection - DET0766"
     },
     {
       "meta": {
@@ -17923,6 +18783,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0786",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0786"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "7ec4b791-7054-442f-8967-6d6fa5e8678b",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+          "type": "detects"
+        }
+      ],
+      "uuid": "1bae319f-03d8-49c9-8bb8-e4f27bb69a11",
+      "value": "Detection of Denial of Control - DET0786"
+    },
+    {
+      "meta": {
+        "external_id": "DET0768",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0768"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "899d41e8-8d02-45f9-ab8a-3a06f4cc4189",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "e6bc5359-4bd4-4688-9136-ac7a6b561f56",
+      "value": "Detection of Detect Operating Mode - DET0768"
+    },
+    {
+      "meta": {
         "external_id": "DET0697",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0697"
@@ -17940,6 +18840,146 @@
       ],
       "uuid": "0c7e55b4-57b2-4a0f-ba0e-f50eab1a95f0",
       "value": "Detection of Abuse Accessibility Features - DET0697"
+    },
+    {
+      "meta": {
+        "external_id": "DET0796",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0796"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "87f5d864-d79b-474a-a3b4-43673dcb9f90",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "f8df6b57-14bc-425f-9a91-6f59f6799307",
+          "type": "detects"
+        }
+      ],
+      "uuid": "c7aea5e8-cd8b-4f79-be41-3a446cdde7b7",
+      "value": "Detection of Internet Accessible Device - DET0796"
+    },
+    {
+      "meta": {
+        "external_id": "DET0769",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0769"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "68073351-4e4f-40e4-9394-a9166bb346d7",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "13412b71-b94e-4aef-912a-44853f8bff05",
+      "value": "Detection of Denial of View - DET0769"
+    },
+    {
+      "meta": {
+        "external_id": "DET0777",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0777"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "330166da-bc80-4aca-bd41-cbd6b1742812",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "detects"
+        }
+      ],
+      "uuid": "825106d1-6f44-47a1-b8dd-c3e3b6cecab7",
+      "value": "Detection of Modify Alarm Settings - DET0777"
+    },
+    {
+      "meta": {
+        "external_id": "DET0778",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0778"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "cbf791b4-5186-4205-ac5a-a56042aaebec",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "37b4971d-2eb8-4f87-899c-19acaf0394bb",
+      "value": "Detection of Loss of Control - DET0778"
+    },
+    {
+      "meta": {
+        "external_id": "DET0797",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0797"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "354b93da-06e9-4634-a5fd-7f9b7b3a9d5a",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "detects"
+        }
+      ],
+      "uuid": "4ea060f9-f6fc-4122-9544-70afd567ea10",
+      "value": "Detection of Block Serial COM - DET0797"
+    },
+    {
+      "meta": {
+        "external_id": "DET0779",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0779"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5fa00fdd-4a55-4191-94a0-564181d7fec2",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "8c77f31f-c6f4-491c-965a-e25c506b0c68",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "fb0931d5-8eb9-4db2-a2a4-447c32b29bd4",
+      "value": "Detection of Loss of Safety - DET0779"
+    },
+    {
+      "meta": {
+        "external_id": "DET0789",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0789"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "393d7e7b-0790-49e7-9bcd-87ab4662b05e",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "detects"
+        }
+      ],
+      "uuid": "05f7d4e4-ae99-4339-b71a-59f1e317dc6d",
+      "value": "Detection of Block Reporting Message - DET0789"
     },
     {
       "meta": {
@@ -18007,6 +19047,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0760",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0760"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "7107739b-92d2-41fa-9fc8-ebe72f6086ee",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "c0abb110-c80e-4d6a-9f27-f2783f8bbfec",
+      "value": "Detection of Command-Line Interface - DET0760"
+    },
+    {
+      "meta": {
         "external_id": "DET0706",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0706"
@@ -18052,6 +19112,26 @@
       ],
       "uuid": "f06f44c7-97ff-4f8d-8c72-650c98e0ebdc",
       "value": "Detection of Wi-Fi Discovery - DET0709"
+    },
+    {
+      "meta": {
+        "external_id": "DET0912",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0912"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0b4e7cfa-9f9d-49b0-b5bf-afdf62058c5a",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "71f2d49e-65dd-4fb6-a4cc-0d2b19d427fa",
+          "type": "detects"
+        }
+      ],
+      "uuid": "527668a3-cc0c-48c2-856a-a45615817366",
+      "value": "Detection of Block Wi-Fi - DET0912"
     },
     {
       "meta": {
@@ -18119,6 +19199,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0782",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0782"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "32db74f9-d46d-4728-891a-113a8b8e2b07",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "detects"
+        }
+      ],
+      "uuid": "89e95503-b02c-43da-90b3-15584b27e6d6",
+      "value": "Detection of Drive-by Compromise - DET0782"
+    },
+    {
+      "meta": {
         "external_id": "DET0898",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0898"
@@ -18144,6 +19244,26 @@
       ],
       "uuid": "ad21a251-e824-4368-a04c-8a480ee653cc",
       "value": "Detection of Spoofed User-Agent - DET0898"
+    },
+    {
+      "meta": {
+        "external_id": "DET0801",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0801"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "fcfe9c48-3a5a-49c8-96c3-be79414a8419",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "194cb4dd-81ca-4e64-94e2-911fab1219f9",
+      "value": "Detection of Device Restart/Shutdown - DET0801"
     },
     {
       "meta": {
@@ -18192,6 +19312,26 @@
       ],
       "uuid": "a5f6a93c-a8f9-4660-a6bc-63761a9ee94b",
       "value": "Detection of Virtualization/Sandbox Evasion - DET0616"
+    },
+    {
+      "meta": {
+        "external_id": "DET0774",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0774"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "53a48c74-0025-45f4-b04a-baa853df8204",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "c40ddd75-f2fc-4899-bda1-bff164c96622",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "c94af5cb-61c3-4180-81e7-30c1669f4252",
+      "value": "Detection of I/O Image - DET0774"
     },
     {
       "meta": {
@@ -18263,6 +19403,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0800",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0800"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "28eb77c1-1834-4b7a-a06f-afebb7f2e756",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "detects"
+        }
+      ],
+      "uuid": "f4f3b9a6-2de0-45a5-8936-2ad9288191b9",
+      "value": "Detection of Network Sniffing - DET0800"
+    },
+    {
+      "meta": {
         "external_id": "DET0900",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0900"
@@ -18331,6 +19491,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0910",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0910"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3f052beb-d384-4ebe-b942-2c4ddeb95833",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "fbb67c2d-37c3-49ee-86e3-bf234cc48ca9",
+          "type": "detects"
+        }
+      ],
+      "uuid": "c779ee07-ee85-42fe-a2c1-14ce25766cdf",
+      "value": "Detection of Block Communications - DET0910"
+    },
+    {
+      "meta": {
         "external_id": "DET0602",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0602"
@@ -18396,6 +19576,26 @@
       ],
       "uuid": "87cb2c80-54e1-4ea1-abd7-81a096eb155e",
       "value": "Detection of Client Configurations - DET0820"
+    },
+    {
+      "meta": {
+        "external_id": "DET0902",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0902"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "613b28ef-88dd-4008-8d7e-206ce55a7cde",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e17cdc00-8b58-4e5f-9d50-4cad1592c4c3",
+          "type": "detects"
+        }
+      ],
+      "uuid": "f487a605-0acb-4b12-b157-33b75ebd9a40",
+      "value": "Detection of Unauthorized Message - DET0902"
     },
     {
       "meta": {
@@ -18476,6 +19676,46 @@
       ],
       "uuid": "11b4d80e-e15b-45b5-81c8-5ebbcdd814f1",
       "value": "Detection of Hide Artifacts - DET0640"
+    },
+    {
+      "meta": {
+        "external_id": "DET0804",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0804"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "058d856a-6356-402f-b3ff-a7c1b6186921",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "detects"
+        }
+      ],
+      "uuid": "74b96bd4-dab9-494e-a540-b7c998581fd5",
+      "value": "Detection of Remote Services - DET0804"
+    },
+    {
+      "meta": {
+        "external_id": "DET0904",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0904"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "7b4c0e19-a9b0-4a74-a196-b38c07b79f20",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "fc6641ac-5748-4498-89e9-d4ada2b6f88a",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "73773bb8-c63b-4d48-9b48-33440f12a514",
+      "value": "Detection of Firmware Modification - DET0904"
     },
     {
       "meta": {
@@ -18567,6 +19807,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0905",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0905"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "1017530e-423d-4857-80b6-99891bf82d28",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "3e9b182e-e493-49e1-9a9b-bd0dfcd34a7c",
+          "type": "detects"
+        }
+      ],
+      "uuid": "ff6456fc-576d-4da5-b561-b58f70961b15",
+      "value": "Detection of Insecure Credentials - DET0905"
+    },
+    {
+      "meta": {
         "external_id": "DET0660",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0660"
@@ -18651,6 +19911,86 @@
     },
     {
       "meta": {
+        "external_id": "DET0790",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0790"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "880a1133-6639-42f0-96a8-3e914426d38b",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "e69d1e15-76e1-434c-bd45-0354a10dde8a",
+      "value": "Detection of Module Firmware - DET0790"
+    },
+    {
+      "meta": {
+        "external_id": "DET0907",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0907"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "51a094bf-b7eb-452a-9b7a-ffac16fce1ac",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "detects"
+        }
+      ],
+      "uuid": "6bdde391-76eb-4bd7-9e19-e805ab98b7ac",
+      "value": "Detection of Port Scan - DET0907"
+    },
+    {
+      "meta": {
+        "external_id": "DET0908",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0908"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "c55f0be5-044e-4577-8095-65b37680d28c",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "f6324642-d17d-49d4-90b2-bab9d229d6fa",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "c4ddc0d7-0296-4d92-9ae1-1a4b7b5d1640",
+      "value": "Detection of Broadcast Discovery - DET0908"
+    },
+    {
+      "meta": {
+        "external_id": "DET0909",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0909"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "64bbc1b2-101f-4322-af1d-0c9cc25cef91",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "67861309-0ba7-4713-843e-3def87e396ec",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "56bf71a3-a28b-4a8f-84ed-3a71449d47c0",
+      "value": "Detection of Multicast Discovery - DET0909"
+    },
+    {
+      "meta": {
         "external_id": "DET0611",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0611"
@@ -18708,6 +20048,26 @@
       ],
       "uuid": "cf1329da-a87c-42bb-8950-58fcf36b9b9b",
       "value": "Detection of Search Engines - DET0811"
+    },
+    {
+      "meta": {
+        "external_id": "DET0911",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0911"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "6008c1f0-1b68-4614-8f5b-a547436b8855",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "df7f8849-56a7-4e83-9fd7-a4f25227d960",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "feb80c7a-96cd-4300-b344-4d75b176c9cb",
+      "value": "Detection of Block Ethernet - DET0911"
     },
     {
       "meta": {
@@ -18795,6 +20155,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0731",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0731"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3f10ffe9-fa73-4aeb-bf98-322831bf757f",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "detects"
+        }
+      ],
+      "uuid": "09f46edf-33f9-4c23-af2f-74864c27f616",
+      "value": "Detection of System Firmware - DET0731"
+    },
+    {
+      "meta": {
         "external_id": "DET0831",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0831"
@@ -18859,6 +20239,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0914",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0914"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3c6aa6f7-29e9-41d9-8500-30b6d0533d64",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "574d5bfb-9a7a-4b28-ab5c-743ac704c135",
+          "type": "detects"
+        }
+      ],
+      "uuid": "e90f1c0c-f2c5-4fe1-942f-411574df043f",
+      "value": "Detection of Program Append - DET0914"
+    },
+    {
+      "meta": {
+        "external_id": "DET0751",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0751"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "66070162-d51e-46e7-8d32-2140fd5e7086",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
+          "type": "detects"
+        }
+      ],
+      "uuid": "3e884c49-75ca-449e-83cb-3517ee88e0f1",
+      "value": "Detection of Screen Capture - DET0751"
+    },
+    {
+      "meta": {
         "external_id": "DET0815",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0815"
@@ -18876,6 +20296,26 @@
       ],
       "uuid": "55ddc6ba-a04a-4e68-bb34-741d38d2c33d",
       "value": "Detection of IP Addresses - DET0815"
+    },
+    {
+      "meta": {
+        "external_id": "DET0915",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0915"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "22b202f2-d4dd-44dd-b5e1-791ff2aef8ed",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "d85a6ee9-820c-4adf-8a64-2392ee70c83c",
+          "type": "detects"
+        }
+      ],
+      "uuid": "c1645705-a26f-45b2-aa68-ff5c93dfc0f4",
+      "value": "Detection of Online Edit - DET0915"
     },
     {
       "meta": {
@@ -18920,6 +20360,26 @@
       ],
       "uuid": "effced27-7981-400b-9f22-e3c28144258f",
       "value": "Detection of Linked Devices - DET0716"
+    },
+    {
+      "meta": {
+        "external_id": "DET0761",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0761"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "3c6a21cb-8643-41bc-94a1-e860b02a1cad",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "6f921aa8-deb3-4286-8101-26a7cbe80c0e",
+      "value": "Detection of Program Upload - DET0761"
     },
     {
       "meta": {
@@ -18983,6 +20443,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0771",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0771"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "d3023733-5874-4746-a947-65925514e382",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "fab8fc7d-f27f-4fbb-9de6-44740aade05f",
+          "type": "detects"
+        }
+      ],
+      "uuid": "336b9423-5543-4354-bd00-13c614ccdc96",
+      "value": "Detection of Change Credential - DET0771"
+    },
+    {
+      "meta": {
+        "external_id": "DET0781",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0781"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5610211c-1458-4333-8640-384189d9318e",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "detects"
+        }
+      ],
+      "uuid": "b817139c-2941-4523-bfb5-10c36d230871",
+      "value": "Detection of Spearphishing Attachment - DET0781"
+    },
+    {
+      "meta": {
         "external_id": "DET0917",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0917"
@@ -19000,6 +20500,26 @@
       ],
       "uuid": "bbda89d6-a007-4ba9-bfd0-cb03344fc540",
       "value": "Detection of Written Content - DET0917"
+    },
+    {
+      "meta": {
+        "external_id": "DET0791",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0791"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "d937e4b8-20f2-44c1-9940-48c74318c715",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "eabde43f-1872-499d-9642-85a6959c4d28",
+      "value": "Detection of User Execution - DET0791"
     },
     {
       "meta": {
@@ -19084,6 +20604,26 @@
       ],
       "uuid": "b76b67bc-d38b-4b63-a0d0-ebfc7f829db6",
       "value": "Detection of Process Injection - DET0632"
+    },
+    {
+      "meta": {
+        "external_id": "DET0724",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0724"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "ddfcd948-3526-4241-a12f-d7bf63468e40",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "ffeac6e1-798f-41b1-8baf-2650d2ebe031",
+      "value": "Detection of Valid Accounts - DET0724"
     },
     {
       "meta": {
@@ -19175,6 +20715,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0752",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0752"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "b74100d1-0085-468a-834a-2bf10924a3b7",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "detects"
+        }
+      ],
+      "uuid": "709e05b2-6400-43a2-9bbf-b64f6017b023",
+      "value": "Detection of Program Download - DET0752"
+    },
+    {
+      "meta": {
         "external_id": "DET0626",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0626"
@@ -19196,6 +20756,26 @@
       ],
       "uuid": "0ec6ab45-a114-4ded-ba5e-a16982ccd64b",
       "value": "Detection of URI Hijacking - DET0626"
+    },
+    {
+      "meta": {
+        "external_id": "DET0726",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0726"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2388dc31-ba9a-4c12-b4b9-28bbc981c73e",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "detects"
+        }
+      ],
+      "uuid": "7f32731d-7800-483c-b077-c4a187a27ae5",
+      "value": "Detection of Wireless Compromise - DET0726"
     },
     {
       "meta": {
@@ -19343,6 +20923,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0728",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0728"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "edd8297d-ec63-4b54-8d28-106f228dd535",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "105c127f-2777-452e-bf61-b0786ee13861",
+      "value": "Detection of Alarm Suppression - DET0728"
+    },
+    {
+      "meta": {
+        "external_id": "DET0792",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0792"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "37d989e6-14cd-49a4-adec-3d8b72c8dc22",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "detects"
+        }
+      ],
+      "uuid": "9ad17e7a-5920-42ac-9bf4-545b99162640",
+      "value": "Detection of Rogue Master - DET0792"
+    },
+    {
+      "meta": {
         "external_id": "DET0882",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0882"
@@ -19387,6 +21007,46 @@
     },
     {
       "meta": {
+        "external_id": "DET0734",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0734"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "e25ef816-bbfd-4656-8ecb-c7eebcba31d4",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "442bf059-f7cf-460b-8200-f35e1e0a0c78",
+      "value": "Detection of Automated Collection - DET0734"
+    },
+    {
+      "meta": {
+        "external_id": "DET0743",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0743"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "0fe075d5-beac-4d02-b93e-0f874997db72",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "c14544a4-5ca1-4523-97eb-4a9840d74c6d",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "bbb288c7-9e40-46bd-b0a1-db4cfef4e1ee",
+      "value": "Detection of Wireless Sniffing - DET0743"
+    },
+    {
+      "meta": {
         "external_id": "DET0834",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0834"
@@ -19428,6 +21088,26 @@
       ],
       "uuid": "80e1ef21-9454-4000-ae75-d7a5ae8e703b",
       "value": "Detection of Execution Guardrails - DET0653"
+    },
+    {
+      "meta": {
+        "external_id": "DET0753",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0753"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "aebd2848-98db-46f1-8e22-627e2ec3c280",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "b52870cc-83f3-473c-b895-72d91751030b",
+          "type": "detects"
+        }
+      ],
+      "uuid": "5ba60cf7-738d-4ed4-827c-8c763ad9f0f0",
+      "value": "Detection of Native API - DET0753"
     },
     {
       "meta": {
@@ -19552,6 +21232,26 @@
       ],
       "uuid": "095e0e71-498f-4403-a69f-5a6e4ff50503",
       "value": "Detection of Establish Accounts - DET0873"
+    },
+    {
+      "meta": {
+        "external_id": "DET0783",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0783"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "882f2365-4c14-4c48-8eef-2a7c293c8569",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+          "type": "detects"
+        }
+      ],
+      "uuid": "7f41ed29-fdc6-4c28-ba10-9de1aa129f7e",
+      "value": "Detection of Modify Program - DET0783"
     },
     {
       "meta": {
@@ -19759,6 +21459,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0748",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0748"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2b751a3d-c680-46c9-b92b-55a9d24bd4f9",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "77d9c726-b53e-481d-8bcc-1068aebfbb9d",
+          "type": "detects"
+        }
+      ],
+      "uuid": "930b268b-abf0-485f-9854-60c1cfdd2d33",
+      "value": "Detection of Autorun Image - DET0748"
+    },
+    {
+      "meta": {
         "external_id": "DET0847",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0847"
@@ -19839,6 +21559,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0756",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0756"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "f12aa823-91cc-40e1-93b7-eaa5f5fa9c4d",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "b04e83cc-8ace-4880-8953-7ce55eb8c427",
+      "value": "Detection of Default Credentials - DET0756"
+    },
+    {
+      "meta": {
         "external_id": "DET0675",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0675"
@@ -19860,6 +21600,26 @@
       ],
       "uuid": "ac9d1b33-cfba-415e-aef2-c4c0b359ed5f",
       "value": "Detection of Location Tracking - DET0675"
+    },
+    {
+      "meta": {
+        "external_id": "DET0765",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0765"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "6b3b3e92-bef7-4977-9895-29036bab29f1",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "b25c4621-5d38-43ee-871e-0e5c02f2f48c",
+      "value": "Detection of Service Stop - DET0765"
     },
     {
       "meta": {
@@ -19907,6 +21667,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0758",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0758"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "f666f516-f8d0-41f6-9a4c-0ac6c1f6086b",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "edf989d8-7e25-4ed2-b289-a55dee68a75e",
+      "value": "Detection of Data Destruction - DET0758"
+    },
+    {
+      "meta": {
         "external_id": "DET0857",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0857"
@@ -19924,6 +21704,26 @@
       ],
       "uuid": "3268135a-a73f-4594-95e6-6ea8813a39d3",
       "value": "Detection of Employee Names - DET0857"
+    },
+    {
+      "meta": {
+        "external_id": "DET0759",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0759"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "ece52da2-ac60-4b0e-863f-ebbc95118a8c",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "887ae691-a519-4b68-af26-bcea1483cef7",
+      "value": "Detection of Connection Proxy - DET0759"
     },
     {
       "meta": {
@@ -20092,6 +21892,26 @@
       ],
       "uuid": "aeb736c8-1c17-4fac-888e-122581ad6e0c",
       "value": "Detection of SMS Messages - DET0686"
+    },
+    {
+      "meta": {
+        "external_id": "DET0776",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0776"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "48d2023b-469d-4f9f-a4e6-010be72436b9",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "442e5dcf-7f41-4ba5-ba89-aefb0d1c63cf",
+      "value": "Detection of Modify Parameter - DET0776"
     },
     {
       "meta": {
@@ -20299,6 +22119,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0798",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0798"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "6b335943-c3af-430e-a135-ab09623bdc20",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "b337bf06-d69b-41e0-8e60-8f24cb718998",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "de675cf4-144e-485c-a761-c72ebcb9e2bc",
+      "value": "Detection of Hardcoded Credentials - DET0798"
+    },
+    {
+      "meta": {
         "external_id": "DET0897",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0897"
@@ -20340,6 +22180,26 @@
       ],
       "uuid": "7a96a921-48bc-4fcf-b6b8-86a96315d4ee",
       "value": "Detection of Adversary-in-the-Middle - DET0623"
+    },
+    {
+      "meta": {
+        "external_id": "DET0764",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0764"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "afc9e394-147e-49db-81df-953d2d3ea93e",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "b6a6d95c-e3b5-438d-a095-3fb0859c8f45",
+      "value": "Detection of Adversary-in-the-Middle - DET0764"
     },
     {
       "meta": {
@@ -20388,6 +22248,26 @@
       ],
       "uuid": "63d80d1b-ca5b-427d-b603-cf65e6e245b9",
       "value": "Detecting Downgrade Attacks - DET0350"
+    },
+    {
+      "meta": {
+        "external_id": "DET0780",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0780"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "ec695157-8c3c-439b-9925-459c9d4172f0",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "04bcf663-e6cd-42bf-8864-f4d1ad345263",
+      "value": "Detection of Rootkit - DET0780"
     },
     {
       "meta": {
@@ -20559,6 +22439,26 @@
     },
     {
       "meta": {
+        "external_id": "DET0722",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0722"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "05ca4f07-df4f-4e88-b216-f40ca6ce39b8",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+          "type": "detects"
+        }
+      ],
+      "uuid": "9f3df5ac-caa0-4189-9b9b-dcf2f6bbdc54",
+      "value": "Detection of Hooking - DET0722"
+    },
+    {
+      "meta": {
         "external_id": "DET0832",
         "refs": [
           "https://attack.mitre.org/detectionstrategies/DET0832"
@@ -20576,6 +22476,26 @@
       ],
       "uuid": "92955a28-74fb-4f60-834a-10dc93377140",
       "value": "Detection of WHOIS - DET0832"
+    },
+    {
+      "meta": {
+        "external_id": "DET0725",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0725"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "791310ad-7db5-41df-9fa5-fa4097d8a51d",
+          "type": "composed-of"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "detects"
+        }
+      ],
+      "uuid": "06443942-ba28-4d13-b4b4-93317d6eafa5",
+      "value": "Detection of Masquerading - DET0725"
     },
     {
       "meta": {
@@ -20720,6 +22640,26 @@
       ],
       "uuid": "98f14414-883e-4da3-930a-19a8faa1be41",
       "value": "Detection of Accounts - DET0635"
+    },
+    {
+      "meta": {
+        "external_id": "DET0735",
+        "refs": [
+          "https://attack.mitre.org/detectionstrategies/DET0735"
+        ]
+      },
+      "related": [
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "detects"
+        },
+        {
+          "dest-uuid": "302a5327-70cf-44b5-b592-ce9a62014dcc",
+          "type": "composed-of"
+        }
+      ],
+      "uuid": "f9ea25e7-6e63-4ef1-a8ad-47a4a261e175",
+      "value": "Detection of Scripting - DET0735"
     },
     {
       "meta": {
@@ -21046,5 +22986,5 @@
       "value": "Detect Social Engineering - DET0899"
     }
   ],
-  "version": 6
+  "version": 7
 }

--- a/clusters/mitre-ics-assets.json
+++ b/clusters/mitre-ics-assets.json
@@ -48,6 +48,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ecb81a8b-022e-4529-a404-55cffca7d3a3",
+          "type": "similar"
+        }
+      ],
       "uuid": "834fab50-be52-4611-95b6-6330d1db65c3",
       "value": "Control Server"
     },
@@ -76,6 +82,12 @@
           "https://ics-cert.us-cert.gov/Secure-Architecture-Design-Definitions"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e2c3336a-dd93-44d6-8246-f93cf132c499",
+          "type": "similar"
+        }
+      ],
       "uuid": "da06d4aa-2471-4582-aadf-e1653dd6575c",
       "value": "Data Historian"
     },
@@ -112,6 +124,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "f1315d02-9118-4e3b-8cdf-4c2d3f77ce41",
+          "type": "similar"
+        }
+      ],
       "uuid": "b34cba3b-4294-4149-b119-214fadef0d01",
       "value": "Engineering Workstation"
     },
@@ -173,6 +191,20 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "1769c499-55e5-462f-bab2-c39b8cd5ae32",
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "986c455b-0f43-42b6-8360-33ac48bd9990",
+          "type": "similar"
+        }
+      ],
       "uuid": "1de9f3b2-07fc-4614-b07f-d5468e51770a",
       "value": "Field Controller/RTU/PLC/IED"
     },
@@ -221,6 +253,12 @@
           "http://isa99.isa.org/ISA99%20Wiki/WP-2-1.aspx"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "3a95f7e4-4877-4967-b2e8-e287976c3e64",
+          "type": "similar"
+        }
+      ],
       "uuid": "3894cc68-79e0-4673-8548-c6e1b57a93e2",
       "value": "Human-Machine Interface"
     },
@@ -242,6 +280,12 @@
           "https://ics-cert.us-cert.gov/Secure-Architecture-Design-Definitions"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "68388d4f-8138-420b-be2b-5a7dfe9ff6b4",
+          "type": "similar"
+        }
+      ],
       "uuid": "c98dda59-afe3-4154-b672-96f18cb5991b",
       "value": "Input/Output Server"
     },
@@ -279,9 +323,19 @@
           "http://www.gegridsolutions.com/multilin/notes/artsci/artsci.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "69d1b1ef-e918-4cfd-9a98-29debd04cb32",
+          "type": "similar"
+        },
+        {
+          "dest-uuid": "75f810ad-b678-4c57-b93b-fdc79bba0c04",
+          "type": "similar"
+        }
+      ],
       "uuid": "01ce6089-11cb-422f-ab05-ffe61ee4b21c",
       "value": "Safety Instrumented System/Protection Relay"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/mitre-ics-software.json
+++ b/clusters/mitre-ics-software.json
@@ -116,7 +116,7 @@
       },
       "related": [
         {
-          "dest-uuid": "89ab0ca5-f7e0-4d16-bf2a-17d68117fa4b",
+          "dest-uuid": "54cc1d4f-5c53-4f0e-9ef5-11b4998e82e4",
           "type": "similar"
         }
       ],
@@ -551,5 +551,5 @@
       "value": "WannaCry"
     }
   ],
-  "version": 3
+  "version": 4
 }

--- a/clusters/mitre-ics-tactics.json
+++ b/clusters/mitre-ics-tactics.json
@@ -32,6 +32,12 @@
           "https://www.us-cert.gov/ncas/alerts/TA17-293A"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "b2a67b1e-913c-46f6-b219-048a90560bb9",
+          "type": "similar"
+        }
+      ],
       "uuid": "834fab50-be52-4611-95b6-6330d1db65c2",
       "value": "Collection"
     },
@@ -47,6 +53,12 @@
           "https://attack.mitre.org/wiki/Technique/T1090"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "97c8ff73-bd14-4b6c-ac32-3d91d2c41e3f",
+          "type": "similar"
+        }
+      ],
       "uuid": "4fd3b7b1-6d05-4cab-8182-6ea52ecbde63",
       "value": "Command and Control"
     },
@@ -68,6 +80,12 @@
           "https://attack.mitre.org/wiki/Technique/T1018"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "696af733-728e-49d7-8261-75fdc590f453",
+          "type": "similar"
+        }
+      ],
       "uuid": "021d9d90-a792-4b84-a9f8-892b11c7db55",
       "value": "Discovery"
     },
@@ -89,6 +107,12 @@
           "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=6142258"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ddf70682-f3ce-479c-a9a4-7eadf9bfead7",
+          "type": "similar"
+        }
+      ],
       "uuid": "099fdd9a-8894-4599-8e7f-59e82e285df6",
       "value": "Evasion"
     },
@@ -121,6 +145,12 @@
           "https://www.f-secure.com/weblog/archives/00002718.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "93bf9a8e-b14c-4587-b6d5-9efc7c12eb45",
+          "type": "similar"
+        }
+      ],
       "uuid": "7779ec85-b841-44b8-9c5e-9c9d670a3938",
       "value": "Execution"
     },
@@ -153,6 +183,12 @@
           "https://www.wsj.com/articles/iranian-hackers-infiltrated-new-york-dam-in-2013-1450662559"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "77542f83-70d0-40c2-8a9d-ad2eb8b00279",
+          "type": "similar"
+        }
+      ],
       "uuid": "40c9594e-ae8b-48f1-8e11-0e08ead4d44b",
       "value": "Impact"
     },
@@ -181,6 +217,12 @@
           "https://ics.sans.org/media/E-ISAC_SANS_Ukraine_DUC_5.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ff048b6c-b872-4218-b68c-3735ebd1f024",
+          "type": "similar"
+        }
+      ],
       "uuid": "aa3913db-52ce-4856-b0db-fce6af13e4d6",
       "value": "Impair Process Control"
     },
@@ -220,6 +262,12 @@
           "http://www.sciencedirect.com/science/article/pii/S1874548213000231"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "298fe907-7931-4fd2-8131-2814dd493134",
+          "type": "similar"
+        }
+      ],
       "uuid": "35bf4454-d73b-43ff-8a38-85342f595009",
       "value": "Inhibit Response Function"
     },
@@ -270,9 +318,15 @@
           "https://www.schneier.com/blog/archives/2008/01/hacking_the_pol.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "69da72d2-f550-41c5-ab9e-e8255707f28a",
+          "type": "similar"
+        }
+      ],
       "uuid": "2366ffb0-91ba-4b8e-bfad-d460c98d43a8",
       "value": "Initial Access"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/mitre-ics-techniques.json
+++ b/clusters/mitre-ics-techniques.json
@@ -27,6 +27,12 @@
           "https://www.welivesecurity.com/wp-content/uploads/2017/06/Win32_Industroyer.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "similar"
+        }
+      ],
       "uuid": "d07be12d-39a2-448c-8e92-f40a46ed9865",
       "value": "Activate Firmware Update Mode"
     },
@@ -44,6 +50,12 @@
           "https://troopers.de/downloads/troopers19/TROOPERS19_NGI_IoT_diet_poisoned_fruit.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2900bbd8-308a-4274-b074-5b8bde8347bc",
+          "type": "similar"
+        }
+      ],
       "uuid": "f35e36fd-1a4a-4fc5-a881-9db30b51b43f",
       "value": "Alarm Suppression"
     },
@@ -65,6 +77,12 @@
           "https://www.welivesecurity.com/wp-content/uploads/2017/06/Win32_Industroyer.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+          "type": "similar"
+        }
+      ],
       "uuid": "cd10178b-3af2-4169-9d19-73194c379fa0",
       "value": "Automated Collection"
     },
@@ -93,6 +111,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "similar"
+        }
+      ],
       "uuid": "bc454d80-054b-48bf-8848-289ec9d8277d",
       "value": "Block Command Message"
     },
@@ -122,6 +146,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "similar"
+        }
+      ],
       "uuid": "c70c3328-e180-4947-badd-8088686aec7f",
       "value": "Block Reporting Message"
     },
@@ -149,6 +179,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "similar"
+        }
+      ],
       "uuid": "6def9c26-dbd6-4410-a363-02bd2e235c22",
       "value": "Block Serial COM"
     },
@@ -168,6 +204,12 @@
           "https://www.welivesecurity.com/wp-content/uploads/2017/06/Win32_Industroyer.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "similar"
+        }
+      ],
       "uuid": "f5b5b616-1b96-485e-8b7b-620e94145bea",
       "value": "Brute Force I/O"
     },
@@ -191,6 +233,12 @@
           "https://github.com/MDudek-ICS/TRISIS-TRITON-HATMAN/tree/master/decompiled_code/library"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "a8cfd474-9358-464f-a169-9c6f099a8e8a",
+          "type": "similar"
+        }
+      ],
       "uuid": "1f846cbc-ed70-429c-b489-eaf1f0f99ca6",
       "value": "Change Program State"
     },
@@ -218,6 +266,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "similar"
+        }
+      ],
       "uuid": "1e6829cd-e6f3-4ff9-b56d-c6f0a2bb88ae",
       "value": "Command-Line Interface"
     },
@@ -250,6 +304,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "similar"
+        }
+      ],
       "uuid": "6f53940b-f5ee-4fcc-8752-2c9bdb16381c",
       "value": "Commonly Used Port"
     },
@@ -274,6 +334,12 @@
           "https://www.cpni.gov.uk/Documents/Publications/2014/2014-04-23-c2-report-birmingham.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "similar"
+        }
+      ],
       "uuid": "2c5bf128-129a-482f-b578-995b389c9e2e",
       "value": "Connection Proxy"
     },
@@ -298,6 +364,12 @@
           "https://www.langner.com/wp-content/uploads/2017/03/to-kill-a-centrifuge.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "83ebd22f-b401-4d59-8219-2294172cf916",
+          "type": "similar"
+        }
+      ],
       "uuid": "0f14bec1-cc6e-4c73-a0de-77b9cf3f525f",
       "value": "Damage to Property"
     },
@@ -333,6 +405,12 @@
           "https://technet.microsoft.com/en-us/library/ee791851.aspx"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "similar"
+        }
+      ],
       "uuid": "cc76d9dc-1e26-48a1-baa1-c42b2aa6d381",
       "value": "Data Destruction"
     },
@@ -352,6 +430,12 @@
           "https://dragos.com/wp-content/uploads/CRASHOVERRIDE2018.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "50d3222f-7550-4a3c-94e1-78cb6c81d064",
+          "type": "similar"
+        }
+      ],
       "uuid": "bb11d289-4661-444b-8923-e77ce630f487",
       "value": "Data Historian Compromise"
     },
@@ -374,6 +458,12 @@
           "https://www.symantec.com/security-center/writeup/2012-052811-0308-99"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "similar"
+        }
+      ],
       "uuid": "ec83fca8-a475-42fd-9ae5-db666ec6dd3d",
       "value": "Data from Information Repositories"
     },
@@ -401,6 +491,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "5658ad88-7510-490e-a351-95d50b1bcd91",
+          "type": "similar"
+        }
+      ],
       "uuid": "c40fbcf3-5baf-4589-8f3a-e544790d2e37",
       "value": "Default Credentials"
     },
@@ -423,6 +519,12 @@
           "https://www.welivesecurity.com/wp-content/uploads/2017/06/Win32_Industroyer.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
+          "type": "similar"
+        }
+      ],
       "uuid": "8d7682dc-e23b-4a53-bac7-ca92ad5d7772",
       "value": "Denial of Control"
     },
@@ -451,6 +553,12 @@
           "https://www.blackhat.com/docs/asia-16/materials/asia-16-Spenneberg-PLC-Blaster-A-Worm-Living-Solely-In-The-PLC-wp.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "similar"
+        }
+      ],
       "uuid": "5dc02bb0-3332-459b-a66e-148e152ee063",
       "value": "Denial of Service"
     },
@@ -472,6 +580,12 @@
           "https://books.google.com/books?id=oXIYBAAAQBAJ&pg=PA249&lpg=PA249&dq=loss+denial+manipulation+of+view&source=bl&ots=dV1uQ8IUff&sig=ACfU3U2NIwGjhg051D_Ytw6npyEk9xcf4w&hl=en&sa=X&ved=2ahUKEwj2wJ7y4tDlAhVmplkKHSTaDnQQ6AEwAHoECAgQAQ#v=onepage&q=loss%20denial%20manipulation%20of%20view&f=false"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "similar"
+        }
+      ],
       "uuid": "3840a392-0074-42ba-9303-d8bf18ce0048",
       "value": "Denial of View"
     },
@@ -491,6 +605,12 @@
           "Triton contains a file named TS_cnames.py which contains default definitions for key state (TS_keystate). Key state is referenced in TsHi.py."
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "similar"
+        }
+      ],
       "uuid": "b12d6ee9-db15-45de-a1d7-594803e53960",
       "value": "Detect Operating Mode"
     },
@@ -510,6 +630,12 @@
           "https://github.com/MDudek-ICS/TRISIS-TRITON-HATMAN/tree/master/decompiled_code/library"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "94f042ae-3033-4a8d-9ec3-26396533a541",
+          "type": "similar"
+        }
+      ],
       "uuid": "2afa4852-71bc-41c9-b524-643cddb3e7fa",
       "value": "Detect Program State"
     },
@@ -540,6 +666,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
+          "type": "similar"
+        }
+      ],
       "uuid": "e3b4487b-d29f-4940-a02d-8c948374964b",
       "value": "Device Restart/Shutdown"
     },
@@ -570,6 +702,12 @@
           "https://securelist.com/bad-rabbit-ransomware/82851/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "similar"
+        }
+      ],
       "uuid": "3eb64b2b-2710-446e-a30d-d49728d17350",
       "value": "Drive-by Compromise"
     },
@@ -591,6 +729,12 @@
           "https://www.fireeye.com/blog/threat-research/2017/12/attackers-deploy-new-ics-attack-framework-triton.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "d614a9cf-18eb-4800-81e4-ab8ddf0baa73",
+          "type": "similar"
+        }
+      ],
       "uuid": "56fc2528-7ad9-4ff4-8a65-b7641822074e",
       "value": "Engineering Workstation Compromise"
     },
@@ -614,6 +758,12 @@
           "https://www.midnightbluelabs.com/blog/2018/1/16/analyzing-the-triton-industrial-malware"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "similar"
+        }
+      ],
       "uuid": "66ff7ce5-3daf-4651-9157-b6df2009e1b6",
       "value": "Execution through API"
     },
@@ -630,6 +780,12 @@
           "https://www.us-cert.gov/ics/alerts/ICS-ALERT-14-281-01B"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
+          "type": "similar"
+        }
+      ],
       "uuid": "fce2a3b6-4bf0-4f98-9287-8849f0ed08d0",
       "value": "Exploit Public-Facing Application"
     },
@@ -654,6 +810,12 @@
           "https://www.nrc.gov/docs/ML1209/ML120900890.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "similar"
+        }
+      ],
       "uuid": "8b5ed78d-5902-4656-99a8-05f8733f56bd",
       "value": "Exploitation for Evasion"
     },
@@ -676,6 +838,12 @@
           "https://dragos.com/blog/industry-news/implications-of-it-ransomware-for-ics-environments/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "similar"
+        }
+      ],
       "uuid": "c9324642-1af8-45d5-8b99-a8227e541f9d",
       "value": "Exploitation of Remote Services"
     },
@@ -713,6 +881,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "similar"
+        }
+      ],
       "uuid": "51aa0e11-3141-4c65-a6bf-2a434ff62e11",
       "value": "External Remote Services"
     },
@@ -742,6 +916,12 @@
           "https://technet.microsoft.com/en-us/library/ee791851.aspx"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "b0628bfc-5376-4a38-9182-f324501cb4cf",
+          "type": "similar"
+        }
+      ],
       "uuid": "fe7af615-363e-4d57-89f3-b513e3d2ea30",
       "value": "Graphical User Interface"
     },
@@ -762,6 +942,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+          "type": "similar"
+        }
+      ],
       "uuid": "eb51ef09-1119-42e5-a54a-bae8da791160",
       "value": "Hooking"
     },
@@ -782,6 +968,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "53a48c74-0025-45f4-b04a-baa853df8204",
+          "type": "similar"
+        }
+      ],
       "uuid": "a721f6e3-0b80-4eca-bbd1-43a6891ac8cd",
       "value": "I/O Image"
     },
@@ -805,6 +997,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e2994b6a-122b-4043-b654-7411c5198ec0",
+          "type": "similar"
+        }
+      ],
       "uuid": "10ea82ba-9f19-476a-8ec5-c653e0add46c",
       "value": "I/O Module Discovery"
     },
@@ -826,6 +1024,12 @@
           "https://www.midnightbluelabs.com/blog/2018/1/16/analyzing-the-triton-industrial-malware"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
+          "type": "similar"
+        }
+      ],
       "uuid": "54e8db05-d233-48f4-9467-702f60bd53c0",
       "value": "Indicator Removal on Host"
     },
@@ -849,6 +1053,12 @@
           "https://www.us-cert.gov/ics/advisories/ICSA-11-094-02B"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "f8df6b57-14bc-425f-9a91-6f59f6799307",
+          "type": "similar"
+        }
+      ],
       "uuid": "a9251e7f-921e-40f3-9ad7-8ab3f38e3136",
       "value": "Internet Accessible Device"
     },
@@ -877,6 +1087,12 @@
           "https://www.f-secure.com/weblog/archives/00002718.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "7374ab87-0782-41f8-b415-678c0950bb2a",
+          "type": "similar"
+        }
+      ],
       "uuid": "48aed709-3fcf-4d51-8316-c4dc6b90114f",
       "value": "Location Identification"
     },
@@ -899,6 +1115,12 @@
           "https://news.softpedia.com/news/on-chernobyl-s-30th-anniversary-malware-shuts-down-german-nuclear-power-plant-503429.shtml"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "similar"
+        }
+      ],
       "uuid": "b997f861-a587-48d5-9070-a358b1b67ac6",
       "value": "Loss of Availability"
     },
@@ -924,6 +1146,12 @@
           "https://www.hydro.com/en/media/on-the-agenda/cyber-attack/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
+          "type": "similar"
+        }
+      ],
       "uuid": "0d1979d5-d62c-4836-b14a-46f5a6d68bca",
       "value": "Loss of Control"
     },
@@ -952,6 +1180,12 @@
           "https://www.darkreading.com/attacks-breaches/how-a-manufacturing-firm-recovered-from-a-devastating-ransomware-attack/d/d-id/1334760"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "similar"
+        }
+      ],
       "uuid": "f2905196-e419-4740-bca9-0fc3af846bc0",
       "value": "Loss of Productivity and Revenue"
     },
@@ -980,6 +1214,12 @@
           "https://www.fireeye.com/blog/threat-research/2017/12/attackers-deploy-new-ics-attack-framework-triton.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "5fa00fdd-4a55-4191-94a0-564181d7fec2",
+          "type": "similar"
+        }
+      ],
       "uuid": "4f46d0e0-91ee-4ab2-a5b7-168ee099b715",
       "value": "Loss of Safety"
     },
@@ -1006,6 +1246,12 @@
           "https://www.hydro.com/en/media/on-the-agenda/cyber-attack/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "similar"
+        }
+      ],
       "uuid": "ceee160f-8d23-41bd-b3f8-cfb87713e1a2",
       "value": "Loss of View"
     },
@@ -1032,6 +1278,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "similar"
+        }
+      ],
       "uuid": "23bcd8f2-4e1e-473b-83fa-8e895e503236",
       "value": "Man in the Middle"
     },
@@ -1054,6 +1306,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "36e9f5bc-ac13-4da4-a2f4-01f4877d9004",
+          "type": "similar"
+        }
+      ],
       "uuid": "08fe1ccd-247f-45a4-b4f0-4d7f8329f510",
       "value": "Manipulate I/O Image"
     },
@@ -1074,6 +1332,12 @@
           "Stuxnet can reprogram a PLC and change critical parameters in such a way that legitimate commands can be overridden or intercepted. In addition, Stuxnet can apply inappropriate command sequences or parameters to cause damage to property."
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "similar"
+        }
+      ],
       "uuid": "9366f29b-dcea-468c-bc47-579747a75978",
       "value": "Manipulation of Control"
     },
@@ -1097,6 +1361,12 @@
           "https://www.fireeye.com/blog/threat-research/2017/12/attackers-deploy-new-ics-attack-framework-triton.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "similar"
+        }
+      ],
       "uuid": "e90b468f-8789-45e2-90fc-6cab1d121283",
       "value": "Masquerading"
     },
@@ -1123,6 +1393,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e5de767e-f513-41cd-aa15-33f6ce5fbf92",
+          "type": "similar"
+        }
+      ],
       "uuid": "d3691a42-3964-4629-bd95-89ddd71e6e38",
       "value": "Modify Alarm Settings"
     },
@@ -1152,6 +1428,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e0d74479-86d2-465d-bf36-903ebecef43e",
+          "type": "similar"
+        }
+      ],
       "uuid": "8f0ff984-424f-4c9e-b446-467f9d6493a0",
       "value": "Modify Control Logic"
     },
@@ -1179,6 +1461,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "similar"
+        }
+      ],
       "uuid": "8da151db-39aa-4424-a236-415dec458799",
       "value": "Modify Parameter"
     },
@@ -1207,6 +1495,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "75587e49-ab7e-44df-9549-faeb1da57f39",
+          "type": "similar"
+        }
+      ],
       "uuid": "08f44b76-8a2f-43d8-b51c-a18ef3e0a999",
       "value": "Module Firmware"
     },
@@ -1233,6 +1527,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "similar"
+        }
+      ],
       "uuid": "48947a94-a769-41a8-bc13-60aecfdcfa90",
       "value": "Monitor Process State"
     },
@@ -1260,6 +1560,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
+          "type": "similar"
+        }
+      ],
       "uuid": "96775fdf-1e64-47d6-b4bc-40d586aff9fd",
       "value": "Network Connection Enumeration"
     },
@@ -1284,6 +1590,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "539d0484-fe95-485a-b654-86991c0d0d00",
+          "type": "similar"
+        }
+      ],
       "uuid": "d9476518-569b-4baa-b01f-09d6ec61b101",
       "value": "Network Service Scanning"
     },
@@ -1327,6 +1639,12 @@
           "https://technet.microsoft.com/en-us/library/ee791851.aspx"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "similar"
+        }
+      ],
       "uuid": "7bccc6c8-43eb-4d26-ba17-98167a068627",
       "value": "Network Sniffing"
     },
@@ -1347,6 +1665,12 @@
           "https://www.fireeye.com/blog/threat-research/2014/07/havex-its-down-with-opc.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "similar"
+        }
+      ],
       "uuid": "6b1da46d-fbe4-4b84-a4e1-1ece7daf6a93",
       "value": "Point & Tag Identification"
     },
@@ -1368,6 +1692,12 @@
           "https://www.midnightbluelabs.com/blog/2018/1/16/analyzing-the-triton-industrial-malware"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "similar"
+        }
+      ],
       "uuid": "53f180f4-9093-4d1e-8372-3e10943b820e",
       "value": "Program Download"
     },
@@ -1391,6 +1721,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ae62fe1a-ea1a-479b-8dc0-65d250bd8bc7",
+          "type": "similar"
+        }
+      ],
       "uuid": "326ade02-552b-4c68-b4e4-f41599b49a32",
       "value": "Program Organization Units"
     },
@@ -1410,6 +1746,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "similar"
+        }
+      ],
       "uuid": "1931da8b-1781-480b-b7db-26b7c432821c",
       "value": "Program Upload"
     },
@@ -1431,6 +1773,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e72425f8-9ae6-41d3-bfdb-e1b865e60722",
+          "type": "similar"
+        }
+      ],
       "uuid": "46034514-6c9c-4afd-8158-246279fcd7d1",
       "value": "Project File Infection"
     },
@@ -1453,6 +1801,12 @@
           "https://dragos.com/blog/industry-news/implications-of-it-ransomware-for-ics-environments/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
+          "type": "similar"
+        }
+      ],
       "uuid": "de0f0771-1772-421c-b2d4-4f913067583d",
       "value": "Remote File Copy"
     },
@@ -1490,6 +1844,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "similar"
+        }
+      ],
       "uuid": "a65e1d32-cbff-40cb-af45-72fd5ad393ff",
       "value": "Remote System Discovery"
     },
@@ -1522,6 +1882,12 @@
           "https://www.langner.com/wp-content/uploads/2017/03/to-kill-a-centrifuge.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
+          "type": "similar"
+        }
+      ],
       "uuid": "00697a1d-aa6d-4a52-91cf-4c0cbb9ff81f",
       "value": "Replication Through Removable Media"
     },
@@ -1552,6 +1918,12 @@
           "https://technet.microsoft.com/en-us/library/ee791851.aspx"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "b14395bd-5419-4ef4-9bd8-696936f509bb",
+          "type": "similar"
+        }
+      ],
       "uuid": "988cb83e-1ecd-4711-8c71-2d461dddd4f7",
       "value": "Rogue Master Device"
     },
@@ -1583,6 +1955,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "23270e54-1d68-4c3b-b763-b25607bcef80",
+          "type": "similar"
+        }
+      ],
       "uuid": "52099a90-ab4f-43a8-8047-89492f5dadc4",
       "value": "Role Identification"
     },
@@ -1619,6 +1997,12 @@
           "https://technet.microsoft.com/en-us/library/ee791851.aspx"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9",
+          "type": "similar"
+        }
+      ],
       "uuid": "753a01c8-60c3-41f4-9241-166d884e1b84",
       "value": "Rootkit"
     },
@@ -1643,6 +2027,12 @@
           "https://www.symantec.com/security-center/writeup/2017-030708-4403-99"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
+          "type": "similar"
+        }
+      ],
       "uuid": "2711392c-7f55-4d48-a505-cfd5de3c3e0e",
       "value": "Screen Capture"
     },
@@ -1679,6 +2069,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "similar"
+        }
+      ],
       "uuid": "38959743-d33f-4e4c-9be2-3c1f773b0c30",
       "value": "Scripting"
     },
@@ -1705,6 +2101,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "5f3da2f3-91c8-4d8b-a02f-bf43a11def55",
+          "type": "similar"
+        }
+      ],
       "uuid": "7bbc25f1-eec4-4ecc-bc98-071dc89d25b2",
       "value": "Serial Connection Enumeration"
     },
@@ -1727,6 +2129,12 @@
           "https://www.welivesecurity.com/2016/01/03/blackenergy-sshbeardoor-details-2015-attacks-ukrainian-news-media-electric-industry/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "similar"
+        }
+      ],
       "uuid": "249f3b38-db72-4941-a36c-59b5db185b87",
       "value": "Service Stop"
     },
@@ -1768,6 +2176,12 @@
           "https://www.boozallen.com/content/dam/boozallen/documents/2016/09/ukraine-report-when-the-lights-went-out.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "similar"
+        }
+      ],
       "uuid": "813ea621-37d0-44dc-aaef-74cacca69f43",
       "value": "Spearphishing Attachment"
     },
@@ -1793,6 +2207,12 @@
           "https://www.wired.com/images_blogs/threatlevel/2010/11/w32_stuxnet_dossier.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "similar"
+        }
+      ],
       "uuid": "6b277198-78b1-4910-bfea-21803c1b8048",
       "value": "Standard Application Layer Protocol"
     },
@@ -1816,6 +2236,12 @@
           "https://www.f-secure.com/weblog/archives/00002718.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "similar"
+        }
+      ],
       "uuid": "eb58509d-92e4-4d43-bfd6-99b26dc62d37",
       "value": "Supply Chain Compromise"
     },
@@ -1849,6 +2275,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "similar"
+        }
+      ],
       "uuid": "1d8e19f2-66f7-4a48-9f9d-26b6d512cdcd",
       "value": "System Firmware"
     },
@@ -1873,6 +2305,12 @@
           "https://www.symantec.com/security-center/writeup/2012-052811-0308-99"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "similar"
+        }
+      ],
       "uuid": "c92ffac5-3979-4209-8f81-9ca45e556a73",
       "value": "Theft of Operational Information"
     },
@@ -1909,6 +2347,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "similar"
+        }
+      ],
       "uuid": "78fb294d-11e9-49d3-9469-40665308a710",
       "value": "Unauthorized Command Message"
     },
@@ -1932,6 +2376,12 @@
           "https://securelist.com/bad-rabbit-ransomware/82851/"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "similar"
+        }
+      ],
       "uuid": "0df00d45-2105-4ab0-ad6d-de0a9b7d898d",
       "value": "User Execution"
     },
@@ -1961,6 +2411,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "similar"
+        }
+      ],
       "uuid": "9e5e5c49-45ec-4dd3-a890-9bcbb7f99a81",
       "value": "Utilize/Change Operating Mode"
     },
@@ -2009,6 +2465,12 @@
           "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r2.pdf"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "similar"
+        }
+      ],
       "uuid": "439051c8-9404-40f1-a4c9-d6bef22ea5fd",
       "value": "Valid Accounts"
     },
@@ -2030,9 +2492,15 @@
           "https://www.schneier.com/blog/archives/2008/01/hacking_the_pol.html"
         ]
       },
+      "related": [
+        {
+          "dest-uuid": "2877063e-1851-48d2-bcc6-bc1d2733157e",
+          "type": "similar"
+        }
+      ],
       "uuid": "6330fa53-0ba5-4be6-bd76-1cb4f9a535d4",
       "value": "Wireless Compromise"
     }
   ],
-  "version": 2
+  "version": 3
 }

--- a/clusters/mitre-intrusion-set.json
+++ b/clusters/mitre-intrusion-set.json
@@ -3094,6 +3094,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "65013dd2-bc61-43e3-afb5-a14c4fa7437a",
           "type": "uses"
         },
@@ -3665,6 +3669,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "26c87906-d750-42c5-946c-d4162c73fc7b",
           "type": "uses"
         },
@@ -3702,6 +3710,10 @@
         },
         {
           "dest-uuid": "3257eb21-f9a7-4430-8de1-d8b6e288f529",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "32632a95-6856-47b9-9ab7-fea5cd7dce00",
           "type": "uses"
         },
         {
@@ -3954,6 +3966,10 @@
         },
         {
           "dest-uuid": "d63a3fb8-9452-4e9d-a60a-54be68d5998c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
           "type": "uses"
         },
         {
@@ -10383,6 +10399,14 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "795c1a92-3a26-453e-b99a-6a566aa94dc6",
           "type": "uses"
         },
@@ -10802,7 +10826,24 @@
           "Palmetto Fusion"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        }
+      ],
       "uuid": "190242d7-73fc-4738-af68-20162f7a5aae",
       "value": "ALLANITE - G1000"
     },
@@ -18095,6 +18136,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "2e34237d-8574-43f6-aace-ae2915de8597",
           "type": "uses"
         },
@@ -18123,6 +18168,10 @@
         },
         {
           "dest-uuid": "58a3e6aa-4453-4cc8-a51f-4befe80b31a8",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
           "type": "uses"
         },
         {
@@ -18195,6 +18244,10 @@
         },
         {
           "dest-uuid": "be2dcee9-a7a7-4e38-afd6-21b31ecc3d63",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c5e3cdbc-0387-4be9-8f83-ff5c0865f377",
           "type": "uses"
         },
         {
@@ -18539,6 +18592,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "635cbe30-392d-4e27-978e-66774357c762",
           "type": "uses"
         },
@@ -18563,6 +18620,10 @@
         },
         {
           "dest-uuid": "75b9a4d2-d4e2-4ca1-9aab-1badd9e05fd0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
           "type": "uses"
         },
         {
@@ -21532,6 +21593,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "2e34237d-8574-43f6-aace-ae2915de8597",
           "type": "uses"
         },
@@ -21647,6 +21712,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "65f2d882-3f41-4d48-8a06-29af77ec9f90",
           "type": "uses"
         },
@@ -21660,6 +21729,10 @@
         },
         {
           "dest-uuid": "7385dfaf-6886-4229-9ecd-6fd678040830",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
           "type": "uses"
         },
         {
@@ -21786,6 +21859,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "cde2d700-9ed1-46cf-9bce-07364fe8b24f",
           "type": "uses"
         },
@@ -21819,6 +21896,10 @@
         },
         {
           "dest-uuid": "dfd7cc1d-e1d8-4394-a198-97c4cab8aa67",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
           "type": "uses"
         },
         {
@@ -28405,5 +28486,5 @@
       "value": "ShinyHunters - G1057"
     }
   ],
-  "version": 43
+  "version": 44
 }

--- a/clusters/mitre-software.json
+++ b/clusters/mitre-software.json
@@ -2802,6 +2802,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "3489cfc5-640f-4bb3-a103-9137b97de79f",
           "type": "uses"
         },
@@ -2810,11 +2814,23 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "65f2d882-3f41-4d48-8a06-29af77ec9f90",
           "type": "uses"
         },
         {
           "dest-uuid": "692074ae-bb62-4a5e-a735-02cb6bde458c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "7830cfcf-b268-4ac0-a69e-73c6affbae9a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
           "type": "uses"
         },
         {
@@ -2831,6 +2847,10 @@
         },
         {
           "dest-uuid": "d742a578-d70e-4d0e-96a6-02a9c30204e6",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
           "type": "uses"
         },
         {
@@ -7561,7 +7581,40 @@
           "PLC-Blaster"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "36e9f5bc-ac13-4da4-a2f4-01f4877d9004",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b52870cc-83f3-473c-b895-72d91751030b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
+          "type": "uses"
+        }
+      ],
       "uuid": "4dcff507-5af8-47ce-964a-8d9569e9ccfe",
       "value": "PLC-Blaster - S1006"
     },
@@ -8454,7 +8507,16 @@
           "ACAD/Medre.A"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "uses"
+        }
+      ],
       "uuid": "a4a98eab-b691-45d9-8c48-869ef8fefd57",
       "value": "ACAD/Medre.A - S1000"
     },
@@ -8730,7 +8792,27 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "354a7f88-63fb-41b5-a801-ce3b377b36f1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
           "type": "uses"
         },
         {
@@ -8750,6 +8832,14 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "5e0f75da-e108-4688-a6de-a4f07cc2cbe3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
           "type": "uses"
         },
@@ -8763,6 +8853,10 @@
         },
         {
           "dest-uuid": "9efb1ea7-c37b-4595-9640-b7680cd84279",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
           "type": "uses"
         },
         {
@@ -10674,6 +10768,14 @@
         ]
       },
       "related": [
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "9a505987-ab05-4f46-a9a6-6441442eec3b",
+          "type": "uses"
+        },
         {
           "dest-uuid": "fb640c43-aa6b-431e-a961-a279010424ac",
           "type": "uses"
@@ -14701,7 +14803,80 @@
           "HatMan"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2aa406ed-81c3-4c1d-ba83-cfbee5a2847a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5a2610f6-9fff-41e1-bc27-575ca20383d4",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5fa00fdd-4a55-4191-94a0-564181d7fec2",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "68a9324d-a524-4766-a899-a026f68a33df",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "9f947a1c-3860-48a8-8af0-a2dfa3efde03",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b52870cc-83f3-473c-b895-72d91751030b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c55f0be5-044e-4577-8095-65b37680d28c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "uses"
+        }
+      ],
       "uuid": "80099a91-4c86-4bea-9ccb-dac55d61960e",
       "value": "Triton - S1009"
     },
@@ -18402,6 +18577,14 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "09a61657-46e1-439e-b3ed-3e4556a78243",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "0a5231ec-41af-4a35-83d0-6bdf11f28c65",
           "type": "uses"
         },
@@ -18418,11 +18601,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "21875073-b0ee-49e3-9077-1e2a885359af",
           "type": "uses"
         },
         {
           "dest-uuid": "246fd3c7-f5e3-466d-8787-4c13d9e3b61c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
           "type": "uses"
         },
         {
@@ -18434,7 +18625,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "2959d63f-73fd-46a1-abd2-109d7dcede32",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
           "type": "uses"
         },
         {
@@ -18454,7 +18657,23 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "354ca909-b54d-4c41-b597-9c296b344a43",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "36e9f5bc-ac13-4da4-a2f4-01f4877d9004",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "391d824f-0ef1-47a0-b0ee-c59a75e27670",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3b6b9246-43f8-4c69-ad7a-2b11cfe0a0d9",
           "type": "uses"
         },
         {
@@ -18470,7 +18689,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "4f9ca633-15c5-463c-9724-bdcd54fde541",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "53a48c74-0025-45f4-b04a-baa853df8204",
           "type": "uses"
         },
         {
@@ -18483,6 +18710,10 @@
         },
         {
           "dest-uuid": "6151cbea-819b-455a-9fa6-99a1cc58797d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "6b335943-c3af-430e-a135-ab09623bdc20",
           "type": "uses"
         },
         {
@@ -18502,6 +18733,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "86850eff-2729-40c3-b85e-c4af26da4a2d",
           "type": "uses"
         },
@@ -18514,7 +18749,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "ab390887-afc0-4715-826d-b1b167d522ae",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "b21c3b2d-02e6-45b1-980b-e69051040839",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "b52870cc-83f3-473c-b895-72d91751030b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
           "type": "uses"
         },
         {
@@ -18522,7 +18769,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "bf90d72c-c00b-45e3-b3aa-68560560d4c5",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
           "type": "uses"
         },
         {
@@ -18546,6 +18801,22 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "f24faf46-3b26-4dbb-98f2-63460498e433",
           "type": "uses"
         },
@@ -18563,6 +18834,10 @@
         },
         {
           "dest-uuid": "f9e9365a-9ca2-4d9c-8e7c-050d73d1101a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "fc5fda7e-6b2c-4457-b036-759896a2efa2",
           "type": "uses"
         }
       ],
@@ -18816,6 +19091,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "3405891b-16aa-4bd7-bd7c-733501f9b20f",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "355be19c-ffc9-46d5-8d50-d6a036c675b6",
           "type": "uses"
         },
@@ -18863,6 +19142,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "dcaa092b-7de9-4a21-977f-7fcb77e89c48",
           "type": "uses"
         },
@@ -18876,6 +19159,10 @@
         },
         {
           "dest-uuid": "f6dacc85-b37d-458e-b58d-74fc4bbf5755",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
           "type": "uses"
         }
       ],
@@ -20186,7 +20473,39 @@
       },
       "related": [
         {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "15ca2a99-2d3e-457f-b1d7-c52a1d5849c9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "19a71d1e-6334-4233-8260-b749cae37953",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1af9e3fd-2bcc-414d-adbd-fe3b95c02ca1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "20fb2507-d71c-455d-9b6d-6104461cf26b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "25dfc8ad-bd73-4dfd-84a9-3c3d383f76e9",
           "type": "uses"
         },
         {
@@ -20194,7 +20513,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "2bb4d762-bf4a-4bc3-9318-15cc6a354163",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "2bee5ffb-7a7a-4119-b1f2-158151b19ac0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
           "type": "uses"
         },
         {
@@ -20206,7 +20537,35 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4c2e1408-9d68-4187-8e6b-a77bc52700ec",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "4fe28b27-b13c-453e-a386-c2ef362a573b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "55e7e5c1-3760-4451-bae0-e79b29f452c5",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "56ddc820-6cfb-407f-850b-52c035d123ac",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
           "type": "uses"
         },
         {
@@ -20214,7 +20573,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "7866bb5f-98ee-45c2-984c-8a328c5176b2",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "7bc57495-ea59-4380-be31-a64af124ef18",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
           "type": "uses"
         },
         {
@@ -20227,6 +20594,10 @@
         },
         {
           "dest-uuid": "a782ebe2-daba-42c7-bc82-e8e9d923162d",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
           "type": "uses"
         },
         {
@@ -20246,7 +20617,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "df8b2a25-8bdf-4856-953c-a04372b1c161",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e33c7ecc-5a38-497f-beb2-a9a2049a4c20",
           "type": "uses"
         },
         {
@@ -20259,6 +20642,10 @@
         },
         {
           "dest-uuid": "e6919abc-99f9-4c6c-95a5-14761e7b2add",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
           "type": "uses"
         }
       ],
@@ -21301,11 +21688,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "1c4e5d32-1fe9-4116-9d9d-59e3925bd6a2",
           "type": "uses"
         },
         {
           "dest-uuid": "20fb2507-d71c-455d-9b6d-6104461cf26b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
           "type": "uses"
         },
         {
@@ -21325,7 +21720,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "bbde9781-60aa-4b8a-a911-895b0c1b3872",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ea0c980c-5cf0-43a7-a049-59c4c207566e",
           "type": "uses"
         },
         {
@@ -22708,6 +23111,10 @@
       },
       "related": [
         {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "0a5231ec-41af-4a35-83d0-6bdf11f28c65",
           "type": "uses"
         },
@@ -22716,11 +23123,23 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "20fb2507-d71c-455d-9b6d-6104461cf26b",
           "type": "uses"
         },
         {
           "dest-uuid": "391d824f-0ef1-47a0-b0ee-c59a75e27670",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "53a26eee-1080-4d17-9762-2027d5a1b805",
           "type": "uses"
         },
         {
@@ -22886,6 +23305,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "9db0cf3a-a3c9-4012-8268-123b9db6fd82",
           "type": "uses"
         },
@@ -22898,7 +23321,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "b5b9bacb-97f2-4249-b804-47fd44de1f95",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "bbde9781-60aa-4b8a-a911-895b0c1b3872",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "c267bbee-bb59-47fe-85e0-3ed210337c21",
           "type": "uses"
         },
         {
@@ -23641,6 +24072,10 @@
           "type": "similar"
         },
         {
+          "dest-uuid": "648f995e-9c3a-41e4-aeee-98bb41037426",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "707399d6-ab3e-4963-9315-d9d3818cd6a0",
           "type": "uses"
         },
@@ -23684,11 +24119,19 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c",
           "type": "uses"
         },
         {
           "dest-uuid": "df8b2a25-8bdf-4856-953c-a04372b1c161",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
           "type": "uses"
         },
         {
@@ -27726,6 +28169,34 @@
         ]
       },
       "related": [
+        {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3de230d4-3e42-4041-b089-17e1128feded",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "uses"
+        },
         {
           "dest-uuid": "8f4a33ec-8b1f-4b80-a2f6-642b2e479580",
           "type": "uses"
@@ -31812,6 +32283,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "b8cfed42-6a8a-4989-ad72-541af74475ec",
           "type": "uses"
         },
@@ -31829,6 +32304,10 @@
             "estimative-language:likelihood-probability=\"likely\""
           ],
           "type": "similar"
+        },
+        {
+          "dest-uuid": "fa3aa267-da22-4bdd-961f-03223322a8d5",
+          "type": "uses"
         }
       ],
       "uuid": "ff6840c9-4c87-4d07-bbb6-9f50aa33d498",
@@ -34866,7 +35345,88 @@
           "PIPEDREAM"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "25852363-5968-4673-b81d-341d5ed90bd1",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2883c520-7957-46ca-89bd-dab1ad53b601",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2fedbe69-581f-447d-8a78-32ee7db939a9",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "3067b85e-271e-4bc5-81ad-ab1a81d411e3",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "38213338-1aab-479d-949b-c81b66ccca5c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "4344d1b8-968b-4697-9ab9-f9abe5f52265",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "5d24bb1d-4487-4923-ae3a-8e679092ac7a",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "64bbc1b2-101f-4322-af1d-0c9cc25cef91",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "6b335943-c3af-430e-a135-ab09623bdc20",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "77015a55-eef8-4f71-a071-b152f82ec1ef",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "be69c571-d746-4b1f-bdd0-c0c9817e9068",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cd2c76a4-5e23-4ca5-9c40-d5e0604f7101",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "cfe68e93-ce94-4c0f-a57d-3aa72cedd618",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d5a69cfb-fc2a-46cb-99eb-74b236db5061",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "d67adac8-e3b9-44f9-9e6d-6c2a7d69dbe4",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
+          "type": "uses"
+        }
+      ],
       "uuid": "d3aa1058-b1b3-4c29-a3ba-9a9b90ccd93b",
       "value": "INCONTROLLER - S1045"
     },
@@ -44522,7 +45082,27 @@
       },
       "related": [
         {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "32901740-b42c-4fdd-bc02-345b5dc57082",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "6008c1f0-1b68-4614-8f5b-a547436b8855",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "71f2d49e-65dd-4fb6-a4cc-0d2b19d427fa",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "a81696ef-c106-482c-8f80-59c30f2569fb",
           "type": "uses"
         },
         {
@@ -55526,6 +56106,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "9db0cf3a-a3c9-4012-8268-123b9db6fd82",
           "type": "uses"
         },
@@ -55551,6 +56135,10 @@
         },
         {
           "dest-uuid": "e358d692-23c0-4a31-9eb6-ecc13a8d7735",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
           "type": "uses"
         },
         {
@@ -56402,6 +56990,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "65f2d882-3f41-4d48-8a06-29af77ec9f90",
           "type": "uses"
         },
@@ -56414,6 +57006,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "85a45294-08f1-4539-bf00-7da08aa7b0ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "9db0cf3a-a3c9-4012-8268-123b9db6fd82",
           "type": "uses"
         },
@@ -56423,6 +57019,10 @@
         },
         {
           "dest-uuid": "cba37adb-d6fb-4610-b069-dd04c0643384",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ead7bd34-186e-4c79-9a4d-b65bcce6ed9d",
           "type": "uses"
         },
         {
@@ -58045,6 +58645,10 @@
         },
         {
           "dest-uuid": "4f9ca633-15c5-463c-9724-bdcd54fde541",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
           "type": "uses"
         },
         {
@@ -61237,6 +61841,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "063b5b92-5361-481a-9c3f-95492ed9a2d8",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "0d91b3c0-5e50-47c3-949a-2a796f04d144",
           "type": "uses"
         },
@@ -61253,7 +61861,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "2736b752-4ec5-4421-a230-8977dea7649c",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "2aed01ad-3df3-4410-a8cb-11ea4ded587c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2dc2b567-8821-49f9-9045-8740f3d0b958",
           "type": "uses"
         },
         {
@@ -61289,6 +61905,10 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "63b6942d-8359-4506-bfb3-cf87aa8120ee",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "677569f9-a8b0-459e-ab24-7f18091fa7bf",
           "type": "uses"
         },
@@ -61309,7 +61929,15 @@
           "type": "uses"
         },
         {
+          "dest-uuid": "b7e13ee8-182c-4f19-92a4-a88d7d855d54",
+          "type": "uses"
+        },
+        {
           "dest-uuid": "b80d107d-fa0d-4b60-9684-b0433e8bdba0",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "ba203963-3182-41ac-af14-7e7ebc83cd61",
           "type": "uses"
         },
         {
@@ -61354,6 +61982,14 @@
         },
         {
           "dest-uuid": "dfd7cc1d-e1d8-4394-a198-97c4cab8aa67",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e1f9cdd2-9511-4fca-90d7-f3e92cfdd0bf",
           "type": "uses"
         },
         {
@@ -69592,7 +70228,28 @@
           "BUSTLEBERM"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "097924ce-a9a9-4039-8591-e0deedfb8722",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "24a9253e-8948-4c98-b751-8e2aee53127c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "2d0d40ad-22fa-4cc8-b264-072557e1364b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e076cca8-2f08-45c9-aff7-ea5ac798b387",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "e6c31185-8040-4267-83d3-b217b8a92f07",
+          "type": "uses"
+        }
+      ],
       "uuid": "b34df04a-9d30-4d84-a03f-0d536ee19a05",
       "value": "FrostyGoop - S1165"
     },
@@ -69673,7 +70330,32 @@
           "Fuxnet"
         ]
       },
-      "related": [],
+      "related": [
+        {
+          "dest-uuid": "138979ba-0430-4de6-a128-2fc0b056ba36",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "1b22b676-9347-4c55-9a35-ef0dc653db5b",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "493832d9-cea6-4b63-abe7-9a65a6473675",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8d2f3bab-507c-4424-b58b-edc977bd215c",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "8e7089d3-fba2-44f8-94a8-9a79c53920c4",
+          "type": "uses"
+        },
+        {
+          "dest-uuid": "f8df6b57-14bc-425f-9a91-6f59f6799307",
+          "type": "uses"
+        }
+      ],
       "uuid": "931e2489-8078-4f9f-85b2-a9211950e75b",
       "value": "Fuxnet - S1157"
     },
@@ -72534,5 +73216,5 @@
       "value": "Embargo - S1247"
     }
   ],
-  "version": 1
+  "version": 2
 }

--- a/galaxies/mitre-asset.json
+++ b/galaxies/mitre-asset.json
@@ -1,0 +1,9 @@
+{
+  "description": "Assets from MITRE ATT&CK, representing the devices and systems that adversaries target.",
+  "icon": "server",
+  "name": "MITRE ATT&CK Assets",
+  "namespace": "mitre",
+  "type": "mitre-asset",
+  "uuid": "a70f0c3d-126f-4e8f-beb6-98901f8990d8",
+  "version": 1
+}

--- a/galaxies/mitre-attack-pattern.json
+++ b/galaxies/mitre-attack-pattern.json
@@ -1,5 +1,5 @@
 {
-  "description": "Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise and Mobile).",
+  "description": "Techniques, sub-techniques and tactics from MITRE ATT&CK (Enterprise, Mobile, PRE and ICS).",
   "icon": "map",
   "kill_chain_order": {
     "attack-Containers": [
@@ -151,6 +151,56 @@
       "exfiltration",
       "impact"
     ],
+    "ics-attack": [
+      "initial-access",
+      "execution",
+      "persistence",
+      "privilege-escalation",
+      "evasion",
+      "discovery",
+      "lateral-movement",
+      "collection",
+      "command-and-control",
+      "inhibit-response-function",
+      "impair-process-control",
+      "impact"
+    ],
+    "ics-attack-Control-Server": [
+      "collection"
+    ],
+    "ics-attack-Data-Historian": [
+      "collection"
+    ],
+    "ics-attack-Engineering-Workstation": [
+      "initial-access"
+    ],
+    "ics-attack-Field-Controller/RTU/PLC/IED": [
+      "execution",
+      "discovery",
+      "lateral-movement",
+      "collection",
+      "inhibit-response-function",
+      "impair-process-control"
+    ],
+    "ics-attack-Human-Machine-Interface": [
+      "collection"
+    ],
+    "ics-attack-Input/Output-Server": [
+      "discovery"
+    ],
+    "ics-attack-Safety-Instrumented-System/Protection-Relay": [
+      "execution",
+      "lateral-movement",
+      "inhibit-response-function",
+      "impair-process-control"
+    ],
+    "ics-attack-Windows": [
+      "initial-access",
+      "execution",
+      "discovery",
+      "lateral-movement",
+      "collection"
+    ],
     "mobile-attack-Android": [
       "initial-access",
       "execution",
@@ -207,5 +257,5 @@
   "namespace": "mitre",
   "type": "mitre-attack-pattern",
   "uuid": "c4e851fa-775f-11e7-8163-b774922098cd",
-  "version": 18
+  "version": 20
 }

--- a/galaxies/mitre-ics-assets.json
+++ b/galaxies/mitre-ics-assets.json
@@ -2,8 +2,8 @@
   "description": "Assets from MITRE ATT&CK for ICS.",
   "icon": "certificate",
   "name": "MITRE ATT&CK ICS Assets",
-  "namespace": "mitre",
+  "namespace": "deprecated",
   "type": "mitre-ics-assets",
   "uuid": "86b19468-784e-4ec9-9af9-f069aa4cf70d",
-  "version": 2
+  "version": 3
 }

--- a/galaxies/mitre-ics-levels.json
+++ b/galaxies/mitre-ics-levels.json
@@ -2,8 +2,8 @@
   "description": "Purdue model levels used by MITRE ATT&CK for ICS.",
   "icon": "layer-group",
   "name": "MITRE ATT&CK ICS Levels",
-  "namespace": "mitre",
+  "namespace": "deprecated",
   "type": "mitre-ics-levels",
   "uuid": "34d60262-0e7d-4c91-859b-de1fa9c54ae7",
-  "version": 2
+  "version": 3
 }

--- a/galaxies/mitre-ics-tactics.json
+++ b/galaxies/mitre-ics-tactics.json
@@ -2,8 +2,8 @@
   "description": "Tactics from MITRE ATT&CK for ICS.",
   "icon": "chess-pawn",
   "name": "MITRE ATT&CK ICS Tactics",
-  "namespace": "mitre",
+  "namespace": "deprecated",
   "type": "mitre-ics-tactics",
   "uuid": "e521606c-3c66-4621-9040-6f0f792fc999",
-  "version": 2
+  "version": 3
 }

--- a/galaxies/mitre-ics-techniques.json
+++ b/galaxies/mitre-ics-techniques.json
@@ -2,8 +2,8 @@
   "description": "Techniques from MITRE ATT&CK for ICS.",
   "icon": "user-ninja",
   "name": "MITRE ATT&CK ICS Techniques",
-  "namespace": "mitre",
+  "namespace": "deprecated",
   "type": "mitre-ics-techniques",
   "uuid": "99261a7e-2270-40eb-823f-834cc1ad3159",
-  "version": 2
+  "version": 3
 }

--- a/tools/gen_mitre.py
+++ b/tools/gen_mitre.py
@@ -16,6 +16,7 @@ misp_dir = '../'
 
 domains = ['enterprise-attack', 'mobile-attack', 'pre-attack', 'ics-attack']
 types = {'data-source': 'x-mitre-data-source',
+         'asset': 'x-mitre-asset',
          'attack-pattern': ['attack-pattern', 'x-mitre-tactic'],
          'course-of-action': 'course-of-action',
          'intrusion-set': 'intrusion-set',
@@ -27,12 +28,11 @@ types = {'data-source': 'x-mitre-data-source',
          }
 mitre_sources = ['mitre-attack', 'mitre-ics-attack', 'mitre-pre-attack', 'mitre-mobile-attack']
 
-# ATT&CK publishes Groups, Software and Campaigns as a single listing spanning every
-# domain, but keeps a separate matrix per domain for techniques, tactics and mitigations.
-# So only these galaxies take data from the ics-attack bundle; the ICS matrix itself
-# stays in the mitre-ics-* galaxies.
-cross_domain_types = ['intrusion-set', 'software', 'campaign']
-cross_domain_only_domains = ['ics-attack']
+# Every domain contributes every object type. ATT&CK does keep a separate matrix per
+# domain, but a matrix is a per-domain *view*, not an object type: an ICS technique is
+# an attack-pattern with a T-prefixed ID exactly like an Enterprise one, so it belongs
+# in mitre-attack-pattern next to the Enterprise, Mobile and PRE ones. The mitre-ics-*
+# matrix galaxies are deprecated in favour of that.
 
 
 def matches_type(item_type, meta_type):
@@ -55,7 +55,6 @@ def build_allowed_item_types(keys):
 
 
 allowed_item_types = build_allowed_item_types(types)
-allowed_item_types_cross_domain = build_allowed_item_types(cross_domain_types)
 
 
 kill_chain_order_sort_order = {
@@ -110,6 +109,20 @@ kill_chain_order_sort_order = {
         "stage-capabilities",
         "launch",     # added manually
         "compromise"  # added manually
+    ],
+    "ics-attack": [
+        "initial-access",
+        "execution",
+        "persistence",
+        "privilege-escalation",
+        "evasion",
+        "discovery",
+        "lateral-movement",
+        "collection",
+        "command-and-control",
+        "inhibit-response-function",
+        "impair-process-control",
+        "impact"
     ]
 }
 
@@ -175,13 +188,8 @@ for domain in domains:
     with open(os.path.join(attack_dir, domain + '.json')) as f:
         attack_data = json.load(f)
 
-    if domain in cross_domain_only_domains:
-        domain_item_types = allowed_item_types_cross_domain
-    else:
-        domain_item_types = allowed_item_types
-
     for item in attack_data['objects']:
-        if item['type'] not in domain_item_types:
+        if item['type'] not in allowed_item_types:
             continue
 
         # print(json.dumps(item, indent=2, sort_keys=True, ensure_ascii=False))
@@ -231,21 +239,25 @@ for domain in domains:
                         json.dumps(item['external_references'])
                     ))
 
+            # most ICS objects carry the literal string "None" as their only platform,
+            # which means the same as having no platform at all
+            platforms = [platform for platform in item.get('x_mitre_platforms', []) if platform != 'None']
+
             if 'kill_chain_phases' in item:   # many (but not all) attack-patterns have this
                 value['meta']['kill_chain'] = []
                 for killchain in item['kill_chain_phases']:
                     kill_chain_name = killchain['kill_chain_name'][6:]
                     phase_name = killchain['phase_name']
-                    if 'x_mitre_platforms' in item:
-                        for platform in item['x_mitre_platforms']:
+                    if platforms:
+                        for platform in platforms:
                             platform = platform.replace(' ', '-')
                             value['meta']['kill_chain'].append(f"{kill_chain_name}-{platform}:{phase_name}")
                     else:
                         value['meta']['kill_chain'].append(f"{kill_chain_name}:{phase_name}")
             if 'x_mitre_data_sources' in item:
                 value['meta']['mitre_data_sources'] = item['x_mitre_data_sources']
-            if 'x_mitre_platforms' in item:
-                value['meta']['mitre_platforms'] = item['x_mitre_platforms']
+            if platforms:
+                value['meta']['mitre_platforms'] = platforms
             if 'x_mitre_analytic_refs' in item:
                 for ref in item['x_mitre_analytic_refs']:
                     ref_data = {
@@ -340,9 +352,8 @@ for domain in domains:
             pass  # ignore relations from which we do not know the source
 
 
-# drop relations whose target ended up in no galaxy at all.
-# the ics-attack bundle links its groups and software to the ICS techniques, which we
-# deliberately do not load here, so those targets would otherwise dangle.
+# drop relations whose target ended up in no galaxy at all,
+# so that no cluster ends up with a dangling dest-uuid.
 known_uuids = set(all_data_uuid) | non_mitre_uuids
 for value in all_data_uuid.values():
     if 'related' in value:


### PR DESCRIPTION
Closes #1288 

`tools/gen_mitre.py` now loads every object type from every domain, so the ICS matrix is generated like Enterprise, Mobile and PRE instead of living in hand-maintained galaxies.

## Before → after

| | before | after |
|---|---|---|
| ICS techniques + tactics | `mitre-ics-techniques` (78) / `-tactics` (9), 2020 wiki import | in `mitre-attack-pattern`, 1266 → **1396** (+130) |
| ICS mitigations | nowhere | in `mitre-course-of-action`, 282 → **334** (+52) |
| ICS detection strategies | nowhere | in `mitre-detection-strategy`, 823 → **920** (+97) |
| ICS analytics | nowhere | in `mitre-analytic`, 1969 → **2066** (+97) |
| ICS data components / sources | nowhere | +5 / +2 (`mitre-data-component` 123, `mitre-data-source` 42) |
| ICS assets | `mitre-ics-assets` (7) | new **`mitre-asset`** galaxy, 18 values from `x-mitre-asset` |
| `mitre-ics-*` matrix galaxies | `namespace: mitre` | `namespace: deprecated`, frozen, with `similar` links |

Groups / Software / Campaigns gain no values (already merged in #1259) but their `related` arrays grow — +20 / +169 / +82 — because ICS relationships that used to dangle now resolve. All six regenerated clusters take **additions only**: no existing value is modified or removed. 

Generated from `mitre/cti` at ATT&CK **v19.2**.

## Generator changes (`tools/gen_mitre.py`)

- dropped `cross_domain_types` / `cross_domain_only_domains`: a matrix is a per-domain view, not
  an object type, so every domain now contributes every type
- added `'asset': 'x-mitre-asset'` to `types`
- added an `ics-attack` key to `kill_chain_order_sort_order`, in **matrix column order**
  (`initial-access` → `impact`), matching how the `attack` key follows the Enterprise matrix
- `x_mitre_platforms: ["None"]` is stripped — upstream's way of saying "no platform". Only ICS
  objects carry it, so no other domain changes.

## Deprecations

`mitre-ics-techniques`, `-tactics`, `-assets` and `-levels` follow what `51896f05` did for `-groups` and `-software`: the clusters are frozen and the galaxies move to `namespace: deprecated`. Tags cannot migrate on their own (0 shared UUIDs, and the `value`strings change), so every value gets a `similar` link to its successor — 78/78 techniques, 9/9 tactics, 7/7 assets. `-levels` has no successor: the Purdue model is not an ATT&CK concept. The 9 inbound `related` links from `threat-actor` and `veris-framework` stay resolvable.

Three IDs recorded in `mitre-ics-techniques` were wrong and would have resolved to a different technique if zero-padded blindly: `Internet Accessible Device` → `T0883`, `Scripting` → `T0853`,`Default Credentials` → `T0812`.

### Assets: the 7 frozen values and their successors

| `mitre-ics-assets` value | successor in `mitre-asset` |
|---|---|
| Control Server | `A0007` Control Server |
| Data Historian | `A0006` Data Historian |
| Human-Machine Interface | `A0002` Human-Machine Interface (HMI) |
| Engineering Workstation | `A0001` Workstation |
| Input/Output Server | `A0009` Data Gateway |
| Safety Instrumented System/Protection Relay | `A0010` Safety Controller, `A0005` Intelligent Electronic Device (IED) |
| Field Controller/RTU/PLC/IED | `A0003` PLC, `A0004` RTU, `A0005` IED |

The remaining nine assets (`A0008`, `A0011`–`A0018`) are new to misp-galaxy.

## Also fixed

`mitre-ics-software`'s `BlackEnergy 3` pointed at `S1002`, deprecated upstream — now `S0089`. And `mitre-attack-pattern`'s description said *"(Enterprise and Mobile)"* while already holding PRE; it now reads *"(Enterprise, Mobile, PRE and ICS)"*.

## Validation

`tools/chk_mitre_naming.py` (0 blocking problems), `tools/update_README_with_index.py`,
`./jq_all_the_things.sh`, `./validate_all.sh`. No duplicate `value`, no duplicate UUID and no dangling `dest-uuid` across the changed clusters.